### PR TITLE
extend GridOption with editCommandHandler option

### DIFF
--- a/src/app/modules/angular-slickgrid/models/editCommand.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/editCommand.interface.ts
@@ -1,0 +1,15 @@
+import { Editor } from ".";
+
+export interface EditCommand {
+    row: number;
+    cell: number;
+    editor: Editor | any;
+    serializedValue: any;
+    prevSerializedValue: any;
+
+    /** Call to commit changes*/
+    execute: () => void;
+
+    /** Call to rollback changes*/
+    undo: () => void;
+}

--- a/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
@@ -49,6 +49,9 @@ export interface GridOption {
   /** Defaults to false, when enabled will give the possibility to edit cell values with inline editors. */
   editable?: boolean;
 
+  /** option to intercept edit commands and implement undo support. Call command.execute() to finish edit operation*/
+  editCommandHandler?: (row: any, column: any, command: any) => void;
+
   /** Do we want to enable asynchronous (delayed) post rendering */
   enableAsyncPostRender?: boolean;
 

--- a/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
@@ -8,6 +8,8 @@ import { GridMenu } from './gridMenu.interface';
 import { HeaderButton } from './headerButton.interface';
 import { HeaderMenu } from './headerMenu.interface';
 import { Pagination } from './pagination.interface';
+import { Column } from './column.interface';
+import { EditCommand } from './editCommand.interface';
 
 export interface GridOption {
   /** Defaults to false, which leads to load editor asynchronously (delayed) */
@@ -49,8 +51,8 @@ export interface GridOption {
   /** Defaults to false, when enabled will give the possibility to edit cell values with inline editors. */
   editable?: boolean;
 
-  /** option to intercept edit commands and implement undo support. Call command.execute() to finish edit operation*/
-  editCommandHandler?: (row: any, column: any, command: any) => void;
+  /** option to intercept edit commands and implement undo support.*/
+  editCommandHandler?: (item: any, column: Column, command: EditCommand) => void;
 
   /** Do we want to enable asynchronous (delayed) post rendering */
   enableAsyncPostRender?: boolean;


### PR DESCRIPTION
editCommandHandler works in base slickgrid (6pac/SlickGrid) but was lost in Angular-Slickgrid. Very usefull option I think.