### PR TITLE
refactor(services): remove gridOptions and columnDefinitions references

### DIFF
--- a/src/app/examples/grid-editor.component.html
+++ b/src/app/examples/grid-editor.component.html
@@ -27,10 +27,10 @@
 
     <div class="col-sm-8">
         <div class="alert alert-info" *ngIf="updatedObject">
-            <strong>Update Object:</strong> {{updatedObject | json}}
+            <strong>Updated Item:</strong> {{updatedObject | json}}
         </div>
         <div class="alert alert-warning" *ngIf="alertWarning">
-            <strong>Update Object:</strong> {{alertWarning}}
+            <strong>Updated Item:</strong> {{alertWarning}}
         </div>
     </div>
 

--- a/src/app/examples/grid-editor.component.ts
+++ b/src/app/examples/grid-editor.component.ts
@@ -92,7 +92,11 @@ export class GridEditorComponent implements OnInit, OnDestroy {
       sortable: true,
       type: FieldType.string,
       editor: Editors.longText,
-      minWidth: 100
+      minWidth: 100,
+      onCellChange: (args: OnEventArgs) => {
+        console.log(args);
+        this.alertWarning = `Updated Title: ${args.dataContext.title}`;
+      }
     }, {
       id: 'duration',
       name: 'Duration (days)',

--- a/src/app/examples/grid-headermenu.component.ts
+++ b/src/app/examples/grid-headermenu.component.ts
@@ -89,7 +89,7 @@ export class GridHeaderMenuComponent implements OnInit {
 
             // add to the column array, the column sorted by the header menu
             cols.push({ sortCol: args.column, sortAsc: (args.command === 'sort-asc') });
-            this.sortService.onLocalSortChanged(this.gridObj, this.gridOptions, this.dataviewObj, cols);
+            this.sortService.onLocalSortChanged(this.gridObj, this.dataviewObj, cols);
 
             // update the this.gridObj sortColumns array which will at the same add the visual sort icon(s) on the UI
             const newSortColumns: ColumnSort[] = cols.map((col) => {

--- a/src/app/modules/angular-slickgrid/services/controlAndPlugin.service.ts
+++ b/src/app/modules/angular-slickgrid/services/controlAndPlugin.service.ts
@@ -19,7 +19,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { castToPromise, sanitizeHtmlToText } from './../services/utilities';
 import { FilterService } from './filter.service';
 import { ExportService } from './export.service';
-import { SharedService } from './shared.service';
 import { SortService } from './sort.service';
 
 // using external non-typed js libraries
@@ -48,7 +47,6 @@ export class ControlAndPluginService {
   constructor(
     private exportService: ExportService,
     private filterService: FilterService,
-    private sharedService: SharedService,
     private sortService: SortService,
     private translate: TranslateService
   ) {}
@@ -65,12 +63,12 @@ export class ControlAndPluginService {
    * @param options
    * @param dataView
    */
-  attachDifferentControlOrPlugins() {
-    this._grid = this.sharedService.grid;
-    this._gridOptions = this.sharedService.gridOptions;
-    this._dataView = this.sharedService.dataView;
-    this._columnDefinitions = this.sharedService.columnDefinitions;
-    this.visibleColumns = this.sharedService.columnDefinitions;
+  attachDifferentControlOrPlugins(grid: any, dataView: any, groupItemMetadataProvider: any) {
+    this._grid = grid;
+    this._dataView = dataView;
+    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
+    this._columnDefinitions = (grid && grid.getColumns) ? grid.getColumns() : [];
+    this.visibleColumns = this._columnDefinitions;
 
     // Column Picker Plugin
     if (this._gridOptions.enableColumnPicker) {
@@ -91,7 +89,7 @@ export class ControlAndPluginService {
     // Grouping Plugin
     // register the group item metadata provider to add expand/collapse group handlers
     if (this._gridOptions.enableGrouping) {
-      const groupItemMetaProvider = this.sharedService.groupItemMetadataProvider || {};
+      const groupItemMetaProvider = groupItemMetadataProvider || {};
       this._grid.registerPlugin(groupItemMetaProvider);
     }
 
@@ -617,7 +615,7 @@ export class ControlAndPluginService {
                 if (options.backendServiceApi) {
                   this.sortService.onBackendSortChanged(e, { multiColumnSort: true, sortCols: cols, grid });
                 } else {
-                  this.sortService.onLocalSortChanged(grid, options, dataView, cols);
+                  this.sortService.onLocalSortChanged(grid, dataView, cols);
                 }
 
                 // update the this.gridObj sortColumns array which will at the same add the visual sort icon(s) on the UI

--- a/src/app/modules/angular-slickgrid/services/export.service.ts
+++ b/src/app/modules/angular-slickgrid/services/export.service.ts
@@ -36,7 +36,6 @@ export class ExportService {
   private _exportQuoteWrapper: string;
   private _columnHeaders: ExportColumnHeader[];
   private _groupedHeaders: ExportColumnHeader[];
-  private _gridOptions: GridOption;
   private _hasGroupedItems = false;
   private _exportOptions: ExportOption;
   onGridBeforeExportToFile = new Subject<boolean>();
@@ -44,15 +43,18 @@ export class ExportService {
 
   constructor(private translate: TranslateService) { }
 
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
   /**
    * Initialize the Export Service
    * @param grid
    * @param gridOptions
    * @param dataView
    */
-  init(grid: any, gridOptions: GridOption, dataView: any): void {
+  init(grid: any, dataView: any): void {
     this._grid = grid;
-    this._gridOptions = gridOptions;
     this._dataView = dataView;
   }
 

--- a/src/app/modules/angular-slickgrid/services/filter.service.ts
+++ b/src/app/modules/angular-slickgrid/services/filter.service.ts
@@ -34,24 +34,25 @@ export class FilterService {
   private _columnFilters: ColumnFilters = {};
   private _dataView: any;
   private _grid: any;
-  private _gridOptions: GridOption;
   private _onFilterChangedOptions: any;
   private _isFirstQuery = true;
   onFilterChanged = new Subject<CurrentFilter[]>();
 
   constructor(private collectionService: CollectionService, private translate: TranslateService) { }
 
-  init(grid: any, gridOptions: GridOption, columnDefinitions: Column[]): void {
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
+  init(grid: any): void {
     this._grid = grid;
-    this._gridOptions = gridOptions;
   }
 
   /**
    * Attach a backend filter hook to the grid
    * @param grid SlickGrid Grid object
-   * @param gridOptions Grid Options object
    */
-  attachBackendOnFilter(grid: any, options: GridOption) {
+  attachBackendOnFilter(grid: any) {
     this._filters = [];
     this._slickSubscriber = new Slick.Event();
 
@@ -105,10 +106,9 @@ export class FilterService {
   /**
    * Attach a local filter hook to the grid
    * @param grid SlickGrid Grid object
-   * @param gridOptions Grid Options object
    * @param dataView
    */
-  attachLocalOnFilter(grid: any, options: GridOption, dataView: any) {
+  attachLocalOnFilter(grid: any, dataView: any) {
     this._filters = [];
     this._dataView = dataView;
     this._slickSubscriber = new Slick.Event();
@@ -453,14 +453,16 @@ export class FilterService {
   }
 
   /**
-   * When user passes an array of preset filters, we need to pre-polulate each column filter searchTerm(s)
+   * When user passes an array of preset filters, we need to pre-populate each column filter searchTerm(s)
    * The process is to loop through the preset filters array, find the associated column from columnDefinitions and fill in the filter object searchTerm(s)
    * This is basically the same as if we would manually add searchTerm(s) to a column filter object in the column definition, but we do it programmatically.
    * At the end of the day, when creating the Filter (DOM Element), it will use these searchTerm(s) so we can take advantage of that without recoding each Filter type (DOM element)
-   * @param gridOptions
-   * @param columnDefinitions
+   * @param grid
    */
-  populateColumnFilterSearchTerms(gridOptions: GridOption, columnDefinitions: Column[]) {
+  populateColumnFilterSearchTerms(grid: any) {
+    const gridOptions: GridOption = (grid && grid.getOptions) ? grid.getOptions() : {};
+    const columnDefinitions: Column[] = (grid && grid.getColumns) ? grid.getColumns() : [];
+
     if (gridOptions.presets && gridOptions.presets.filters) {
       const filters = gridOptions.presets.filters;
       columnDefinitions.forEach((columnDef: Column) =>  {

--- a/src/app/modules/angular-slickgrid/services/graphql.service.ts
+++ b/src/app/modules/angular-slickgrid/services/graphql.service.ts
@@ -39,7 +39,6 @@ export class GraphqlService implements BackendService {
   private _currentPagination: CurrentPagination;
   private _currentSorters: CurrentSorter[];
   private _columnDefinitions: Column[];
-  private _gridOptions: GridOption;
   private _grid: any;
   options: GraphqlServiceOption;
   pagination: Pagination | undefined;
@@ -50,6 +49,10 @@ export class GraphqlService implements BackendService {
   };
 
   constructor(private translate: TranslateService) {}
+
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
 
   /**
    * Build the GraphQL query, since the service include/exclude cursor, the output query will be different.
@@ -175,7 +178,6 @@ export class GraphqlService implements BackendService {
 
     if (grid && grid.getColumns && grid.getOptions) {
       this._columnDefinitions = grid.getColumns();
-      this._gridOptions = grid.getOptions();
     }
   }
 

--- a/src/app/modules/angular-slickgrid/services/grid-odata.service.ts
+++ b/src/app/modules/angular-slickgrid/services/grid-odata.service.ts
@@ -35,7 +35,6 @@ export class GridOdataService implements BackendService {
   private _currentPagination: CurrentPagination;
   private _currentSorters: CurrentSorter[];
   private _columnDefinitions: Column[];
-  private _gridOptions: GridOption;
   private _grid: any;
   options: OdataOption;
   pagination: Pagination | undefined;
@@ -46,6 +45,10 @@ export class GridOdataService implements BackendService {
   };
 
   constructor(private odataService: OdataService) { }
+
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
 
   buildQuery(): string {
     return this.odataService.buildQuery();
@@ -70,8 +73,6 @@ export class GridOdataService implements BackendService {
     if (grid && grid.getColumns && grid.getOptions) {
       this._columnDefinitions = grid.getColumns() || options.columnDefinitions;
       this._columnDefinitions = this._columnDefinitions.filter((column: Column) => !column.excludeFromQuery);
-
-      this._gridOptions = grid.getOptions();
     }
   }
 

--- a/src/app/modules/angular-slickgrid/services/gridEvent.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridEvent.service.ts
@@ -7,13 +7,13 @@ export class GridEventService {
   private _eventHandler: any = new Slick.EventHandler();
 
   /* OnCellChange Event */
-  attachOnCellChange(grid: any, gridOptions: GridOption, dataView: any) {
+  attachOnCellChange(grid: any, dataView: any) {
     // subscribe to this Slickgrid event of onCellChange
     this._eventHandler.subscribe(grid.onCellChange, (e: Event, args: CellArgs) => {
-      if (!e || !args || !args.grid || args.cell === undefined || !args.grid.getColumns || !args.grid.getDataItem) {
+      if (!e || !args || !grid || args.cell === undefined || !grid.getColumns || !grid.getDataItem) {
         return;
       }
-      const column = args.grid.getColumns()[args.cell];
+      const column = grid.getColumns()[args.cell];
 
       // if the column definition has a onCellChange property (a callback function), then run it
       if (typeof column.onCellChange === 'function') {
@@ -25,7 +25,7 @@ export class GridEventService {
           gridDefinition: grid.getOptions(),
           grid,
           columnDef: column,
-          dataContext: args.grid.getDataItem(args.row)
+          dataContext: grid.getDataItem(args.row)
         };
 
         // finally call up the Slick.column.onCellChanges.... function
@@ -35,12 +35,12 @@ export class GridEventService {
     });
   }
   /* OnClick Event */
-  attachOnClick(grid: any, gridOptions: GridOption, dataView: any) {
+  attachOnClick(grid: any, dataView: any) {
     this._eventHandler.subscribe(grid.onClick, (e: Event, args: CellArgs) => {
-      if (!e || !args || !args.grid || args.cell === undefined || !args.grid.getColumns || !args.grid.getDataItem) {
+      if (!e || !args || !grid || args.cell === undefined || !grid.getColumns || !grid.getDataItem) {
         return;
       }
-      const column = args.grid.getColumns()[args.cell];
+      const column = grid.getColumns()[args.cell];
 
       // if the column definition has a onCellClick property (a callback function), then run it
       if (typeof column.onCellClick === 'function') {
@@ -52,7 +52,7 @@ export class GridEventService {
           gridDefinition: grid.getOptions(),
           grid,
           columnDef: column,
-          dataContext: args.grid.getDataItem(args.row)
+          dataContext: grid.getDataItem(args.row)
         };
 
         // finally call up the Slick.column.onCellClick.... function

--- a/src/app/modules/angular-slickgrid/services/gridExtra.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridExtra.service.ts
@@ -1,4 +1,4 @@
-import { GridOption } from './../models/index';
+import { Column, GridOption } from './../models/index';
 
 // using external non-typed js libraries
 declare var $: any;
@@ -7,11 +7,17 @@ declare var Slick: any;
 export class GridExtraService {
   private _grid: any;
   private _dataView: any;
-  private _gridOptions: GridOption;
 
-  init(grid, columnDefinition, gridOptions, dataView) {
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
+  private get _columnDefinition(): Column[] {
+    return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
+  }
+
+  init(grid: any, dataView: any): void {
     this._grid = grid;
-    this._gridOptions = gridOptions;
     this._dataView = dataView;
   }
 

--- a/src/app/modules/angular-slickgrid/services/gridState.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridState.service.ts
@@ -16,7 +16,6 @@ declare var $: any;
 
 export class GridStateService {
   private _grid: any;
-  private _gridOptions: GridOption;
   private _preset: GridState;
   private filterService: FilterService;
   private _filterSubcription: Subscription;
@@ -24,17 +23,21 @@ export class GridStateService {
   private sortService: SortService;
   onGridStateChanged = new Subject<GridStateChange>();
 
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
   /**
    * Initialize the Export Service
    * @param grid
-   * @param gridOptions
+   * @param filterService
+   * @param sortService
    * @param dataView
    */
   init(grid: any, filterService: FilterService, sortService: SortService): void {
     this._grid = grid;
     this.filterService = filterService;
     this.sortService = sortService;
-    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
 
     // Subscribe to Event Emitter of Filter & Sort changed, go back to page 1 when that happen
     this._filterSubcription = this.filterService.onFilterChanged.subscribe((currentFilters: CurrentFilter[]) => {

--- a/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
+++ b/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
@@ -14,14 +14,16 @@ export class GroupingAndColspanService {
   private _eventHandler = new Slick.EventHandler();
   private _dataView: any;
   private _grid: any;
-  private _gridOptions: GridOption;
   private _columnDefinitions: Column[];
+
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
 
   init(grid: any, dataView: any) {
     this._grid = grid;
     this._dataView = dataView;
     if (grid) {
-      this._gridOptions = grid.getOptions();
       this._columnDefinitions = grid.getColumns();
     }
 

--- a/src/app/modules/angular-slickgrid/services/resizer.service.ts
+++ b/src/app/modules/angular-slickgrid/services/resizer.service.ts
@@ -19,15 +19,15 @@ export interface GridDimension {
 
 export class ResizerService {
   private _grid: any;
-  private _gridOptions: GridOption;
   private _lastDimensions: GridDimension;
   onGridBeforeResize = new Subject<boolean>();
 
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
   init(grid: any): void {
     this._grid = grid;
-    if (grid) {
-      this._gridOptions = grid.getOptions();
-    }
   }
 
   /** Attach an auto resize trigger on the datagrid, if that is enable then it will resize itself to the available space

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -23,23 +23,23 @@ export class SortService {
   private _eventHandler: any = new Slick.EventHandler();
   private _dataView: any;
   private _grid: any;
-  private _gridOptions: GridOption;
   private _slickSubscriber: SlickEvent;
   private _isBackendGrid = false;
   onSortChanged = new Subject<CurrentSorter[]>();
 
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
   /**
    * Attach a backend sort (single/multi) hook to the grid
    * @param grid SlickGrid Grid object
-   * @param gridOptions Grid Options object
+   * @param dataView SlickGrid DataView object
    */
   attachBackendOnSort(grid: any, dataView: any) {
     this._isBackendGrid = true;
     this._grid = grid;
     this._dataView = dataView;
-    if (grid) {
-      this._gridOptions = grid.getOptions();
-    }
     this._slickSubscriber = grid.onSort;
 
     // subscribe to the SlickGrid event and call the backend execution
@@ -91,7 +91,6 @@ export class SortService {
     let columnDefinitions = [];
 
     if (grid) {
-      this._gridOptions = grid.getOptions();
       columnDefinitions = grid.getColumns();
     }
     this._slickSubscriber = grid.onSort;
@@ -114,7 +113,7 @@ export class SortService {
         });
       }
 
-      this.onLocalSortChanged(grid, this._gridOptions, dataView, sortColumns);
+      this.onLocalSortChanged(grid, dataView, sortColumns);
       this.emitSortChanged('local');
     });
 
@@ -141,7 +140,7 @@ export class SortService {
       } else {
         const columnDefinitions = this._grid.getColumns() as Column[];
         if (columnDefinitions && Array.isArray(columnDefinitions)) {
-          this.onLocalSortChanged(this._grid, this._gridOptions, this._dataView, new Array({sortAsc: true, sortCol: columnDefinitions[0] }));
+          this.onLocalSortChanged(this._grid, this._dataView, new Array({sortAsc: true, sortCol: columnDefinitions[0] }));
         }
       }
     }
@@ -204,13 +203,13 @@ export class SortService {
       });
 
       if (sortCols.length > 0) {
-        this.onLocalSortChanged(grid, gridOptions, dataView, sortCols);
+        this.onLocalSortChanged(grid, dataView, sortCols);
         grid.setSortColumns(sortCols); // add sort icon in UI
       }
     }
   }
 
-  onLocalSortChanged(grid: any, gridOptions: GridOption, dataView: any, sortColumns: ColumnSort[]) {
+  onLocalSortChanged(grid: any, dataView: any, sortColumns: ColumnSort[]) {
     dataView.sort((dataRow1: any, dataRow2: any) => {
       for (let i = 0, l = sortColumns.length; i < l; i++) {
         const columnSortObj = sortColumns[i];


### PR DESCRIPTION
Remove all `gridOptions` and `columnDefinitions` references from all Services. 
The reasons of doing so
- we have access to the Grid Options and Column Definitions from the Grid object
- simplify all `init` and creation of Services
- we can be more dynamic, user can change some Grid Options dynamically and they will be available in all Services since we are getting them from the Grid object when the time comes, so if options changed, we will see the latest.

Related to issue #20
