### PR TITLE
feat(collection): support multiple filterBy/sortBy in CollectionService

### DIFF
--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -63,12 +63,12 @@ export class GridClientSideComponent implements OnInit {
           // remove value 365 & 360 from the dropdown filter
           collectionFilterBy: [{
             property: 'value',
-            operator: OperatorType.notEqual,
-            value: 365
+            operator: OperatorType.contains,
+            value: 10
           }, {
             property: 'value',
-            operator: OperatorType.notEqual,
-            value: 360
+            operator: OperatorType.contains,
+            value: 20
           }],
           collectionSortBy: {
             property: 'value',
@@ -81,7 +81,8 @@ export class GridClientSideComponent implements OnInit {
             labelSuffix: 'text',
           },
           collectionOptions: {
-            separatorBetweenTextLabels: ' '
+            separatorBetweenTextLabels: ' ',
+            filterAfterEachPass: 'merge'
           },
           model: Filters.multipleSelect,
 
@@ -147,7 +148,7 @@ export class GridClientSideComponent implements OnInit {
       // use columnDef searchTerms OR use presets as shown below
       presets: {
         filters: [
-          { columnId: 'duration', searchTerms: [2, 22, 44] },
+          { columnId: 'duration', searchTerms: [10, 220] },
           // { columnId: 'complete', searchTerms: ['5'], operator: '>' },
           { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },
           // { columnId: 'effort-driven', searchTerms: [true] }

--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -59,11 +59,17 @@ export class GridClientSideComponent implements OnInit {
         filterable: true,
         filter: {
           collectionAsync: this.http.get<{ option: string; value: string; }[]>(URL_SAMPLE_COLLECTION_DATA),
-          collectionFilterBy: {
+          // collectionFilterBy & collectionSortBy accept a single option and/or array of options
+          // remove value 365 & 360 from the dropdown filter
+          collectionFilterBy: [{
             property: 'value',
             operator: OperatorType.notEqual,
             value: 365
-          },
+          }, {
+            property: 'value',
+            operator: OperatorType.notEqual,
+            value: 360
+          }],
           collectionSortBy: {
             property: 'value',
             sortDesc: true,

--- a/src/app/modules/angular-slickgrid/editors/selectEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/selectEditor.ts
@@ -296,9 +296,10 @@ export class SelectEditor implements Editor {
     let outputCollection = inputCollection;
 
     // user might want to filter certain items of the collection
-    if (this.columnDef.internalColumnEditor && this.columnDef.internalColumnEditor.collectionFilterBy) {
+    if (this.columnDef && this.columnDef.internalColumnEditor && this.columnDef.internalColumnEditor.collectionFilterBy) {
       const filterBy = this.columnDef.internalColumnEditor.collectionFilterBy;
-      outputCollection = this._collectionService.filterCollection(outputCollection, filterBy);
+      const filterCollectionBy = this.columnDef.internalColumnEditor.collectionOptions && this.columnDef.internalColumnEditor.collectionOptions.filterAfterEachPass || null;
+      outputCollection = this._collectionService.filterCollection(outputCollection, filterBy, filterCollectionBy);
     }
 
     return outputCollection;

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -207,7 +207,8 @@ export class SelectFilter implements Filter {
     // user might want to filter certain items of the collection
     if (this.columnDef && this.columnFilter && this.columnFilter.collectionFilterBy) {
       const filterBy = this.columnFilter.collectionFilterBy;
-      outputCollection = this.collectionService.filterCollection(outputCollection, filterBy);
+      const filterCollectionBy = this.columnFilter.collectionOptions && this.columnFilter.collectionOptions.filterAfterEachPass || null;
+      outputCollection = this.collectionService.filterCollection(outputCollection, filterBy, filterCollectionBy);
     }
 
     return outputCollection;

--- a/src/app/modules/angular-slickgrid/models/collectionOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/collectionOption.interface.ts
@@ -1,3 +1,6 @@
+import { FilterMultiplePassType } from './filterMultiplePassType.enum';
+import { FilterMultiplePassTypeString } from './filterMultiplePassTypeString';
+
 export interface CollectionOption {
   /**
    * Optionally add a blank entry to the beginning of the collection.
@@ -14,6 +17,14 @@ export interface CollectionOption {
    * collectionInObjectProperty: 'someProperty.myCollection'
    */
   collectionInObjectProperty?: string;
+
+  /**
+   * When using multiple "collectionFilterBy", do we want to "merge" or "extract" the result after each pass?
+   * For example if we have 2 filters to pass by, and we start with pass 1 returning 7 items and last pass returning 5 items
+   * "merge" would return the merge of the 7 items & 5 items, since some item might be the same the result is anywhere between 5 to 13 items
+   * "extract" is the default and will return 5 items, since the result of each pass is sent used by the next pass
+   */
+  filterAfterEachPass?: FilterMultiplePassType | FilterMultiplePassTypeString;
 
   /** defaults to empty, when using label with prefix/suffix, do we want to add a separator between each text (like a white space) */
   separatorBetweenTextLabels?: string;

--- a/src/app/modules/angular-slickgrid/models/columnEditor.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/columnEditor.interface.ts
@@ -16,13 +16,13 @@ export interface ColumnEditor {
   collection?: any[];
 
   /** We could filter some items from the collection */
-  collectionFilterBy?: CollectionFilterBy;
+  collectionFilterBy?: CollectionFilterBy | CollectionFilterBy[];
 
   /** Options to change the behavior of the "collection" */
   collectionOptions?: CollectionOption;
 
   /** We could sort the collection by their value, or by translated value when enableTranslateLabel is True */
-  collectionSortBy?: CollectionSortBy;
+  collectionSortBy?: CollectionSortBy | CollectionSortBy[];
 
   /** A custom structure can be used instead of the default label/value pair. Commonly used with Select/Multi-Select Editor */
   customStructure?: CollectionCustomStructure;

--- a/src/app/modules/angular-slickgrid/models/columnEditor.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/columnEditor.interface.ts
@@ -15,13 +15,13 @@ export interface ColumnEditor {
   /** A collection of items/options (commonly used with a Select/Multi-Select Editor) */
   collection?: any[];
 
-  /** We could filter some items from the collection */
+  /** We could filter some 1 or more items from the collection */
   collectionFilterBy?: CollectionFilterBy | CollectionFilterBy[];
 
   /** Options to change the behavior of the "collection" */
   collectionOptions?: CollectionOption;
 
-  /** We could sort the collection by their value, or by translated value when enableTranslateLabel is True */
+  /** We could sort the collection by 1 or more properties, or by translated value(s) when enableTranslateLabel is True */
   collectionSortBy?: CollectionSortBy | CollectionSortBy[];
 
   /** A custom structure can be used instead of the default label/value pair. Commonly used with Select/Multi-Select Editor */

--- a/src/app/modules/angular-slickgrid/models/columnFilter.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/columnFilter.interface.ts
@@ -51,10 +51,10 @@ export interface ColumnFilter {
   collectionOptions?: CollectionOption;
 
   /** We could filter some items from the collection */
-  collectionFilterBy?: CollectionFilterBy;
+  collectionFilterBy?: CollectionFilterBy | CollectionFilterBy[];
 
   /** We could sort the collection by their value, or by translated value when enableTranslateLabel is True */
-  collectionSortBy?: CollectionSortBy;
+  collectionSortBy?: CollectionSortBy | CollectionSortBy[];
 
   /** A custom structure can be used instead of the default label/value pair. Commonly used with Select/Multi-Select Filter */
   customStructure?: CollectionCustomStructure;

--- a/src/app/modules/angular-slickgrid/models/columnFilter.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/columnFilter.interface.ts
@@ -50,10 +50,10 @@ export interface ColumnFilter {
   /** Options to change the behavior of the "collection" */
   collectionOptions?: CollectionOption;
 
-  /** We could filter some items from the collection */
+  /** We could filter some 1 or more items from the collection */
   collectionFilterBy?: CollectionFilterBy | CollectionFilterBy[];
 
-  /** We could sort the collection by their value, or by translated value when enableTranslateLabel is True */
+  /** We could sort the collection by 1 or more properties, or by translated value(s) when enableTranslateLabel is True */
   collectionSortBy?: CollectionSortBy | CollectionSortBy[];
 
   /** A custom structure can be used instead of the default label/value pair. Commonly used with Select/Multi-Select Filter */

--- a/src/app/modules/angular-slickgrid/models/filterMultiplePassType.enum.ts
+++ b/src/app/modules/angular-slickgrid/models/filterMultiplePassType.enum.ts
@@ -1,0 +1,4 @@
+export enum FilterMultiplePassType {
+  merge = 'merge',
+  extract = 'extract'
+}

--- a/src/app/modules/angular-slickgrid/models/filterMultiplePassTypeString.ts
+++ b/src/app/modules/angular-slickgrid/models/filterMultiplePassTypeString.ts
@@ -1,0 +1,1 @@
+export type FilterMultiplePassTypeString = 'merge' | 'extract';

--- a/src/app/modules/angular-slickgrid/models/index.ts
+++ b/src/app/modules/angular-slickgrid/models/index.ts
@@ -39,6 +39,8 @@ export * from './filterCallback.interface';
 export * from './filterChangedArgs.interface';
 export * from './filterCondition.interface';
 export * from './filterConditionOption.interface';
+export * from './filterMultiplePassType.enum';
+export * from './filterMultiplePassTypeString';
 export * from './formatter.interface';
 export * from './graphqlDatasetFilter.interface';
 export * from './graphqlCursorPaginationOption.interface';

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -238,7 +238,7 @@ export class SortService {
           }
         }
       }
-      return 0;
+      return SortDirectionNumber.neutral;
     });
     grid.invalidate();
     grid.render();

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -463,6 +463,17 @@ export function toKebabCase(str: string): string {
 }
 
 /**
+ * Takes an input array and makes sure the array has unique values by removing duplicates
+ * @param array input with possible duplicates
+ * @return array output without duplicates
+ */
+export function uniqueArray(arr): any[] {
+  return arr.filter((item, index) => {
+    return arr.indexOf(item) >= index;
+  });
+}
+
+/**
  * Unsubscribe all Observables Subscriptions
  * It will return an empty array if it all went well
  * @param subscriptions


### PR DESCRIPTION
- this allows to pass an array or a simple object to both `collectionFilterBy` and `collectionSortBy`

Tested with the following column definition
```typescript
{ 
  id: 'duration', name: 'Duration (days)', field: 'duration', sortable: true, 
  filterable: true,
  filter: {
    collectionAsync: this.http.get<{ option: string; value: string; }[]>(URL_SAMPLE_COLLECTION_DATA),

    // you can pass single/multiple filterBy option(s)
    collectionFilterBy: [{
      property: 'value',
      operator: OperatorType.notEqual,
      value: 365
    }, {
      property: 'value',
      operator: OperatorType.notEqual,
      value: 360
    }],

   // when using multiple filters, it will by default chain the results after each pass
   // this mean that each pass affect all the next passes (less and less results after each passes)
   // but you have the option to change that and use "merged" instead
   collectionOptions: {
     // options are "merged" or "chained" (defaults to "chained")
     filterResultAfterEachPass: 'merged' 
   },

    // you can pass single/multiple sortBy option(s)
    collectionSortBy: [{
      property: 'suffix',
      sortDesc: true,
      fieldType: FieldType.string
    }, {
      property: 'value',
      sortDesc: true,
      fieldType: FieldType.number
    }],
    customStructure: {
      value: 'value',
      label: 'label',
      labelSuffix: 'suffix',
    },
    model: Filters.multipleSelect,
  }
},
```

The collection tested with has multiple items of the following structure. It was modified with only the 1st character of each "suffix" property to add a different char (like "fays", "eays", ...) and our sort is by "suffix", then by "value". 
```typescript
[
  { "value": 0, "label": 0, "prefix": "Task", "suffix": "day" }, 
  { "value": 1, "label": 1, "prefix": "Task", "suffix": "ay" }, 
  { "value": 2, "label": 2, "prefix": "Task", "suffix": "days" }, 
  { "value": 3, "label": 3, "prefix": "Task", "suffix": "fays" }
  // ...
]
```
If we look at the animated GIF below, we see that it works as expected.
![2018-10-02_19-10-23](https://user-images.githubusercontent.com/643976/46382124-71f3a180-c677-11e8-87d1-6866888c18e2.gif)
