### PR TITLE
feat(editor): Add auto commit edit flag to grid options

### DIFF
--- a/src/app/examples/grid-editor.component.html
+++ b/src/app/examples/grid-editor.component.html
@@ -19,6 +19,10 @@
                     <i class="fa fa-undo"></i>
                     Undo last edit(s)
                 </button>
+                <label class="checkbox-inline control-label" for="autoCommitEdit">
+                    <input type="checkbox" id="autoCommitEdit" [value]="gridOptions.autoCommitEdit" (click)="changeAutoCommit()">
+                    Auto Commit Edit
+                  </label>
             </span>
         </div>
         <div class="row" style="margin-top: 5px">

--- a/src/app/examples/grid-editor.component.ts
+++ b/src/app/examples/grid-editor.component.ts
@@ -315,6 +315,7 @@ export class GridEditorComponent implements OnInit {
     this.gridOptions = {
       asyncEditorLoading: false,
       autoEdit: this.isAutoEdit,
+      autoCommitEdit: false,
       autoResize: {
         containerId: 'demo-container',
         sidePadding: 15
@@ -453,6 +454,14 @@ export class GridEditorComponent implements OnInit {
 
   onCellValidation(e, args) {
     alert(args.validationResults.msg);
+  }
+
+  changeAutoCommit() {
+    this.gridOptions.autoCommitEdit = !this.gridOptions.autoCommitEdit;
+    this.gridObj.setOptions({
+      autoCommitEdit: this.gridOptions.autoCommitEdit
+    });
+    return true;
   }
 
   setAutoEdit(isAutoEdit) {

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -280,6 +280,28 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
   }
 
   /**
+   * Commits the current edit to the grid
+   */
+  commitEdit(target: Element) {
+    if (this.grid.getOptions().autoCommitEdit) {
+      const activeNode = this.grid.getActiveCellNode();
+
+      // a timeout must be set or this could come into conflict when slickgrid
+      // tries to commit the edit when going from one editor to another on the grid
+      // through the click event. If the timeout was not here it would
+      // try to commit/destroy the twice, which would throw a jquery
+      // error about the element not being in the DOM
+      setTimeout(() => {
+        // make sure the target is the active editor so we do not
+        // commit prematurely
+        if (activeNode && activeNode.contains(target) && this.grid.getEditorLock().isActive()) {
+          this.grid.getEditorLock().commitCurrentEdit();
+        }
+      });
+    }
+  }
+
+  /**
    * Define what our internal Post Process callback, it will execute internally after we get back result from the Process backend call
    * For now, this is GraphQL Service only feature and it will basically refresh the Dataset & Pagination without having the user to create his own PostProcess every time
    */

--- a/src/app/modules/angular-slickgrid/editors/checkboxEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/checkboxEditor.ts
@@ -34,6 +34,11 @@ export class CheckboxEditor implements Editor {
     this.$input = $(`<input type="checkbox" value="true" class="editor-checkbox" />`);
     this.$input.appendTo(this.args.container);
     this.$input.focus();
+
+    // make the checkbox editor act like a regular checkbox that commit the value on click
+    if (this.args.grid.getOptions().autoCommitEdit) {
+      this.$input.click(() => this.args.grid.getEditorLock().commitCurrentEdit());
+    }
   }
 
   destroy(): void {

--- a/src/app/modules/angular-slickgrid/editors/dateEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/dateEditor.ts
@@ -110,7 +110,12 @@ export class DateEditor implements Editor {
   }
 
   save() {
-    this.args.commitChanges();
+    // autocommit will not focus the next editor
+    if (this.args.grid.getOptions().autoCommitEdit) {
+      this.args.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
+    }
   }
 
   getColumnEditor() {

--- a/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
@@ -52,6 +52,10 @@ export class LongTextEditor implements Editor {
     return this.columnEditor.validator || this.columnDef.validator;
   }
 
+  get hasAutoCommitEdit() {
+    return this.args.grid.getOptions().autoCommitEdit;
+  }
+
   init(): void {
     const cancelText = this._translate && this._translate.instant('CANCEL') || Constants.TEXT_CANCEL;
     const saveText = this._translate && this._translate.instant('SAVE') || Constants.TEXT_SAVE;
@@ -59,6 +63,12 @@ export class LongTextEditor implements Editor {
 
     this.$wrapper = $(`<div class="slick-large-editor-text" />`).appendTo($container);
     this.$input = $(`<textarea hidefocus rows="5">`).appendTo(this.$wrapper);
+
+    // aurelia-slickgrid does not get the focus out event for some reason
+    // so register it here
+    if (this.hasAutoCommitEdit) {
+      this.$input.on('focusout', () => this.save());
+    }
 
     $(`<div class="editor-footer">
           <button class="btn btn-primary btn-xs">${saveText}</button>
@@ -93,7 +103,9 @@ export class LongTextEditor implements Editor {
   }
 
   save() {
-    if (this.args && this.args.commitChanges) {
+    if (this.hasAutoCommitEdit) {
+      this.args.grid.getEditorLock().commitCurrentEdit();
+    } else {
       this.args.commitChanges();
     }
   }

--- a/src/app/modules/angular-slickgrid/editors/sliderEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/sliderEditor.ts
@@ -80,7 +80,11 @@ export class SliderEditor implements Editor {
   }
 
   save() {
-    this.args.commitChanges();
+    if (this.args.grid.getOptions().autoCommitEdit) {
+      this.args.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
+    }
   }
 
   cancel() {

--- a/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
@@ -33,6 +33,9 @@ export interface GridOption {
   /** Defaults to 40, which is the delay before the asynchronous post renderer start cleanup execution */
   asyncPostRenderCleanupDelay?: number;
 
+  /** Defaults to false, when enabled will try to commit the current edit without focusing on the next row. If a custom editor is implemented and the grid cannot auto commit, you must use this option to implement it yourself */
+  autoCommitEdit?: boolean;
+
   /** Defaults to false, when enabled will automatically open the inlined editor as soon as there is a focus on the cell (can be combined with "enableCellNavigation: true"). */
   autoEdit?: boolean;
 


### PR DESCRIPTION
The auto commit flag will attempt to commit the current editor when the
editor is focused out. However, not all editors behave the same so extra
logic had to be included in some editors. This means that the grid may not
be able to auto commit custom editors and it will be the
responsibility of the user building the editor.

**checkboxEditor**: Can be handled by the focusout event, but a click event
was added in the editor to make it behave more like a checkbox
**dateEditor**, **sliderEditor**: Prevent focus to the next editor
**longTextEditor**: Add focusout event to textarea, grid does not capture event
**selectEditor**: No focusout event so commit on close
**others**: handled by aurelia-slickgrid subscription to focusout
