### PR TITLE
feat(select):  add option to use label as selected text

### DIFF
--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -78,6 +78,7 @@ export class GridClientSideComponent implements OnInit {
           customStructure: {
             value: 'value',
             label: 'label',
+            optionLabel: 'value', // if selected text is too long, we can use option labels instead
             labelSuffix: 'text',
           },
           collectionOptions: {
@@ -89,7 +90,11 @@ export class GridClientSideComponent implements OnInit {
           // we could add certain option(s) to the "multiple-select" plugin
           filterOptions: {
             maxHeight: 250,
-            width: 175
+            width: 175,
+
+            // if we want to display shorter text as the selected text (on the select filter itself, parent element)
+            // we can use "useSelectOptionLabel" or "useSelectOptionLabelToHtml" the latter will parse html
+            useSelectOptionLabelToHtml: true
           }
         }
       },

--- a/src/app/modules/angular-slickgrid/editors/selectEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/selectEditor.ts
@@ -380,7 +380,7 @@ export class SelectEditor implements Editor {
       const prefixText = option[this.labelPrefixName] || '';
       const suffixText = option[this.labelSuffixName] || '';
       let optionLabel = option[this.optionLabel] || '';
-      optionLabel = optionLabel.toString().replace(/""/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+      optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
       let optionText = (prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
 
       // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default

--- a/src/app/modules/angular-slickgrid/editors/selectEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/selectEditor.ts
@@ -50,6 +50,9 @@ export class SelectEditor implements Editor {
   /** The property name for a suffix that can be added to the labels in the collection */
   labelSuffixName: string;
 
+  /** A label that can be added to each option and can be used as an alternative to display selected options */
+  optionLabel: string;
+
   /** Grid options */
   gridOptions: GridOption;
 
@@ -213,6 +216,7 @@ export class SelectEditor implements Editor {
     this.labelName = (this.customStructure) ? this.customStructure.label : 'label';
     this.labelPrefixName = (this.customStructure) ? this.customStructure.labelPrefix : 'labelPrefix';
     this.labelSuffixName = (this.customStructure) ? this.customStructure.labelSuffix : 'labelSuffix';
+    this.optionLabel = (this.customStructure) ? this.customStructure.optionLabel : 'value';
     this.valueName = (this.customStructure) ? this.customStructure.value : 'value';
 
     // always render the Select (dropdown) DOM element, even if user passed a "collectionAsync",
@@ -375,6 +379,8 @@ export class SelectEditor implements Editor {
       const labelText = ((option.labelKey || this.enableTranslateLabel) && this._translate && typeof this._translate.instant === 'function') ? this._translate.instant(labelKey || ' ') : labelKey;
       const prefixText = option[this.labelPrefixName] || '';
       const suffixText = option[this.labelSuffixName] || '';
+      let optionLabel = option[this.optionLabel] || '';
+      optionLabel = optionLabel.toString().replace(/""/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
       let optionText = (prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
 
       // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
@@ -386,7 +392,7 @@ export class SelectEditor implements Editor {
         optionText = htmlEncode(sanitizedText);
       }
 
-      options += `<option value="${option[this.valueName]}">${optionText}</option>`;
+      options += `<option value="${option[this.valueName]}" label="${optionLabel}">${optionText}</option>`;
     });
 
     return `<select id="${this.elementName}" class="ms-filter search-filter" ${this.isMultipleSelect ? 'multiple="multiple"' : ''}>${options}</select>`;

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -322,7 +322,7 @@ export class SelectFilter implements Filter {
       const prefixText = option[this.labelPrefixName] || '';
       const suffixText = option[this.labelSuffixName] || '';
       let optionLabel = option[this.optionLabel] || '';
-      optionLabel = optionLabel.toString().replace(/""/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+      optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
       let optionText = (prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
 
       // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -44,6 +44,7 @@ export class SelectFilter implements Filter {
   labelName: string;
   labelPrefixName: string;
   labelSuffixName: string;
+  optionLabel: string;
   valueName: string;
   enableTranslateLabel = false;
   subscriptions: Subscription[] = [];
@@ -138,6 +139,7 @@ export class SelectFilter implements Filter {
     this.labelName = (this.customStructure) ? this.customStructure.label : 'label';
     this.labelPrefixName = (this.customStructure) ? this.customStructure.labelPrefix : 'labelPrefix';
     this.labelSuffixName = (this.customStructure) ? this.customStructure.labelSuffix : 'labelSuffix';
+    this.optionLabel = (this.customStructure) ? this.customStructure.optionLabel : 'value';
     this.valueName = (this.customStructure) ? this.customStructure.value : 'value';
 
     // always render the Select (dropdown) DOM element, even if user passed a "collectionAsync",
@@ -319,6 +321,8 @@ export class SelectFilter implements Filter {
       const labelText = ((option.labelKey || this.enableTranslateLabel) && this.translate && typeof this.translate.instant === 'function') ? this.translate.instant(labelKey || ' ') : labelKey;
       const prefixText = option[this.labelPrefixName] || '';
       const suffixText = option[this.labelSuffixName] || '';
+      let optionLabel = option[this.optionLabel] || '';
+      optionLabel = optionLabel.toString().replace(/""/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
       let optionText = (prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
 
       // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
@@ -331,7 +335,7 @@ export class SelectFilter implements Filter {
       }
 
       // html text of each select option
-      options += `<option value="${option[this.valueName]}" ${selected}>${optionText}</option>`;
+      options += `<option value="${option[this.valueName]}" label="${optionLabel}" ${selected}>${optionText}</option>`;
 
       // if there's a search term, we will add the "filled" class for styling purposes
       if (selected) {

--- a/src/app/modules/angular-slickgrid/models/collectionCustomStructure.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/collectionCustomStructure.interface.ts
@@ -5,6 +5,12 @@ export interface CollectionCustomStructure {
   /** your custom property name to use for the "value" (equals of the "option" in a select dropdown) */
   value: string;
 
+  /**
+   * defaults to "value", optional text that can be added to each <option label=""> attribute, which can then be used when showing selected text
+   * Can be used with `filterOptions: { useSelectOptionTitle: true }` when user want to show different text as selected values
+   */
+  optionLabel?: string;
+
   /** an optional prefix that will be prepended before the label text */
   labelPrefix?: string;
 

--- a/src/app/modules/angular-slickgrid/models/multipleSelectOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/multipleSelectOption.interface.ts
@@ -107,6 +107,9 @@ export interface MultipleSelectOption {
   /** Whether or not Multiple Select allows you to select only one option.By default this option is set to false. */
   single?: boolean;
 
+  /** Defaults to false, when set to True it will use the "title" that were defined in each select option */
+  useSelectOptionTitle?: boolean;
+
   /** Define the width property of the dropdown list, support a percentage setting.By default this option is set to undefined. Which is the same as the select input field. */
   width?: number | string;
 


### PR DESCRIPTION
- in some cases the selected text (option text) might be too wide to show as selected text, this PR adds possibility to use a different property with shorter text

```typescript
{ 
  id: 'duration', name: 'Duration (days)', field: 'duration', 
  filter: {
    collectionAsync: this.http.get<{ option: string; value: string; }[]>(URL_SAMPLE_COLLECTION_DATA),
   customStructure: {
    value: 'value',
    label: 'label',
    optionLabel: 'value', // if selected text is too long, we can use option labels instead
    labelSuffix: 'text',
  },
  model: Filters.multipleSelect,

  // we could add certain option(s) to the "multiple-select" plugin
  filterOptions: {
    // if we want to display shorter text as the selected text (on the select filter itself, parent element)
    useSelectOptionLabel: true // or "useSelectOptionLabelToHtml" the latter will parse html
  }
}
```

For example below we are showing just the value "(220, 10)" instead of the longer text "(220 days, 10 days)" (which would show by default). 

![shorter-label](https://user-images.githubusercontent.com/643976/46503497-fb7ead00-c7f8-11e8-9a5c-27f456f4e22d.png)
