### PR TITLE
feat(editors): add optional placeholder to all Editors

### DIFF
--- a/src/app/examples/custom-inputEditor.ts
+++ b/src/app/examples/custom-inputEditor.ts
@@ -35,7 +35,9 @@ export class CustomInputEditor implements Editor {
   }
 
   init(): void {
-    this.$input = $(`<input type="text" class="editor-text" placeholder="custom" />`)
+    const placeholder = this.columnEditor && this.columnEditor.placeholder || '';
+
+    this.$input = $(`<input type="text" class="editor-text" placeholder="${placeholder}" />`)
       .appendTo(this.args.container)
       .on('keydown.nav', (e) => {
         if (e.keyCode === KeyCode.LEFT || e.keyCode === KeyCode.RIGHT) {

--- a/src/app/examples/grid-editor.component.ts
+++ b/src/app/examples/grid-editor.component.ts
@@ -157,6 +157,7 @@ export class GridEditorComponent implements OnInit {
         type: FieldType.string,
         editor: {
           model: CustomInputEditor,
+          placeholder: 'custom',
           validator: myCustomTitleValidator, // use a custom validator
         },
         filter: {

--- a/src/app/modules/angular-slickgrid/editors/dateEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/dateEditor.ts
@@ -40,7 +40,8 @@ export class DateEditor implements Editor {
 
   init(): void {
     if (this.args && this.args.column) {
-      const fieldId = this.columnDef && this.columnDef.id;
+      const columnId = this.columnDef && this.columnDef.id;
+      const placeholder = this.columnEditor && this.columnEditor.placeholder || '';
       const gridOptions = this.args.grid.getOptions() as GridOption;
       this.defaultDate = (this.args.item) ? this.args.item[this.args.column.field] : null;
       const inputFormat = mapFlatpickrDateFormatWithFieldType(this.columnDef.type || FieldType.dateIso);
@@ -62,7 +63,7 @@ export class DateEditor implements Editor {
         },
       };
 
-      this.$input = $(`<input type="text" data-defaultDate="${this.defaultDate}" class="editor-text flatpickr editor-${fieldId}" />`);
+      this.$input = $(`<input type="text" data-defaultDate="${this.defaultDate}" class="editor-text editor-${columnId} flatpickr" placeholder="${placeholder}" />`);
       this.$input.appendTo(this.args.container);
       this.flatInstance = (this.$input[0] && typeof this.$input[0].flatpickr === 'function') ? this.$input[0].flatpickr(pickerOptions) : null;
       this.show();

--- a/src/app/modules/angular-slickgrid/editors/floatEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/floatEditor.ts
@@ -38,8 +38,10 @@ export class FloatEditor implements Editor {
   }
 
   init(): void {
-    const fieldId = this.columnDef && this.columnDef.id;
-    this.$input = $(`<input type="number" class="editor-text editor-${fieldId}" step="${this.getInputDecimalSteps()}" />`)
+    const columnId = this.columnDef && this.columnDef.id;
+    const placeholder = this.columnEditor && this.columnEditor.placeholder || '';
+
+    this.$input = $(`<input type="number" class="editor-text editor-${columnId}" placeholder="${placeholder}" step="${this.getInputDecimalSteps()}" />`)
       .appendTo(this.args.container)
       .on('keydown.nav', (e) => {
         if (e.keyCode === KeyCode.LEFT || e.keyCode === KeyCode.RIGHT) {

--- a/src/app/modules/angular-slickgrid/editors/integerEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/integerEditor.ts
@@ -36,8 +36,10 @@ export class IntegerEditor implements Editor {
   }
 
   init(): void {
-    const fieldId = this.columnDef && this.columnDef.id;
-    this.$input = $(`<input type="number" class="editor-text editor-${fieldId}" />`)
+    const columnId = this.columnDef && this.columnDef.id;
+    const placeholder = this.columnEditor && this.columnEditor.placeholder || '';
+
+    this.$input = $(`<input type="number" class="editor-text editor-${columnId}" placeholder="${placeholder}" />`)
       .appendTo(this.args.container)
       .on('keydown.nav', (e) => {
         if (e.keyCode === KeyCode.LEFT || e.keyCode === KeyCode.RIGHT) {

--- a/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
@@ -57,12 +57,13 @@ export class LongTextEditor implements Editor {
   }
 
   init(): void {
-    const fieldId = this.columnDef && this.columnDef.id;
+    const columnId = this.columnDef && this.columnDef.id;
+    const placeholder = this.columnEditor && this.columnEditor.placeholder || '';
     const cancelText = this._translate && this._translate.instant('CANCEL') || Constants.TEXT_CANCEL;
     const saveText = this._translate && this._translate.instant('SAVE') || Constants.TEXT_SAVE;
     const $container = $('body');
 
-    this.$wrapper = $(`<div class="slick-large-editor-text editor-${fieldId}" />`).appendTo($container);
+    this.$wrapper = $(`<div class="slick-large-editor-text editor-${columnId}" placeholder="${placeholder}" />`).appendTo($container);
     this.$input = $(`<textarea hidefocus rows="5">`).appendTo(this.$wrapper);
 
     // the lib does not get the focus out event for some reason

--- a/src/app/modules/angular-slickgrid/editors/textEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/textEditor.ts
@@ -35,8 +35,10 @@ export class TextEditor implements Editor {
   }
 
   init(): void {
-    const fieldId = this.columnDef && this.columnDef.id;
-    this.$input = $(`<input type="text" class="editor-text editor-${fieldId}" />`)
+    const columnId = this.columnDef && this.columnDef.id;
+    const placeholder = this.columnEditor && this.columnEditor.placeholder || '';
+
+    this.$input = $(`<input type="text" class="editor-text editor-${columnId}" placeholder="${placeholder}" />`)
       .appendTo(this.args.container)
       .on('keydown.nav', (e) => {
         if (e.keyCode === KeyCode.LEFT || e.keyCode === KeyCode.RIGHT) {

--- a/src/app/modules/angular-slickgrid/models/columnEditor.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/columnEditor.interface.ts
@@ -54,6 +54,12 @@ export interface ColumnEditor {
   /** Any inline editor function that implements Editor for the cell */
   model?: any;
 
+  /**
+   * Placeholder text that can be used by some Editors.
+   * Note that this will override the default placeholder configured in the global config
+   */
+  placeholder?: string;
+
   /** Editor Validator */
   validator?: EditorValidator;
 


### PR DESCRIPTION
- you can pass "collection", "collectionAsync" or your own datasource implementation
- uses jQuery UI which is a SlickGrid dependency, so no lib added for this feature

List of things TODO
- [x] get a working demo with remote API
- [x] get a working demo with JSON files (objects or string types)
- [x] add SASS styling for the autocomplete 
- [x] add way to provide an optional `placeholder` to tell user what to do 
- [x] run a Build and fix any TSlint issue found

animated GIF of the Feature
![w7eyr7qkvp](https://user-images.githubusercontent.com/643976/50624023-d5e16c80-0ee9-11e9-809c-f98967953ba4.gif)
