### PR TITLE
refactor(backend): remove all castToPromise and keep Observables as is

### DIFF
--- a/src/app/modules/angular-slickgrid/services/backend-utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/backend-utilities.ts
@@ -1,0 +1,37 @@
+import { GraphqlResult } from '../models/graphqlResult.interface';
+import { BackendServiceApi } from '../models/backendServiceApi.interface';
+import { GridOption } from '../models';
+
+/** Execute the Backend Processes Callback, that could come from an Observable or a Promise callback */
+export function executeBackendProcessesCallback(startTime: Date, processResult: GraphqlResult | any, backendApi: BackendServiceApi, gridOptions: GridOption): GraphqlResult | any {
+  const endTime = new Date();
+
+  // define what our internal Post Process callback, only available for GraphQL Service for now
+  // it will basically refresh the Dataset & Pagination without having the user to create his own PostProcess every time
+  if (processResult && backendApi && backendApi.internalPostProcess) {
+    backendApi.internalPostProcess(processResult);
+  }
+
+  // send the response process to the postProcess callback
+  if (backendApi.postProcess) {
+    if (processResult instanceof Object) {
+      processResult.statistics = {
+        startTime,
+        endTime,
+        executionTime: endTime.valueOf() - startTime.valueOf(),
+        itemCount: gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems,
+        totalItemCount: gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems
+      };
+    }
+    backendApi.postProcess(processResult);
+  }
+}
+
+/** On a backend service api error, we will run the "onError" if there is 1 provided or just throw back the error when nothing is provided */
+export function  onBackendError(e: any, backendApi: BackendServiceApi) {
+  if (backendApi && backendApi.onError) {
+    backendApi.onError(e);
+  } else {
+    throw e;
+  }
+}

--- a/src/app/modules/angular-slickgrid/services/index.ts
+++ b/src/app/modules/angular-slickgrid/services/index.ts
@@ -1,3 +1,4 @@
+export * from './backend-utilities';
 export * from './collection.service';
 export * from './export.service';
 export * from './extension.service';


### PR DESCRIPTION
- the refactoring is mostly because of Spinner with Http Interceptor not always stopping, it might not be related at all but perhaps keeping Observable as Observable (instead of casting them to Promise) might help with this spinner issue.
- also the refactoring moves all the backend service processes into 1 method which deals with all of these processes. So instead of troubleshooting in multiple area, it will all be in the same method (DRY)
- also worth to know that the Backend Service API still support Promise, we won't remove that feature, so both Promise & Observable are supported and we won't cast any of them anymore