### PR TITLE
fix(editor): allow all Editors to work with complex objects

### DIFF
--- a/src/app/examples/custom-inputEditor.ts
+++ b/src/app/examples/custom-inputEditor.ts
@@ -8,7 +8,7 @@ declare var $: any;
  * KeyDown events are also handled to provide handling for Tab, Shift-Tab, Esc and Ctrl-Enter.
  */
 export class CustomInputEditor implements Editor {
-  private _lastInputEvent: KeyboardEvent;
+  private _lastInputEvent: JQueryEventObject;
   $input: any;
   defaultValue: any;
 
@@ -40,7 +40,7 @@ export class CustomInputEditor implements Editor {
 
     this.$input = $(`<input type="text" class="editor-text" placeholder="${placeholder}" />`)
       .appendTo(this.args.container)
-      .on('keydown.nav', (event: KeyboardEvent) => {
+      .on('keydown.nav', (event: JQueryEventObject) => {
         this._lastInputEvent = event;
         if (event.keyCode === KeyCode.LEFT || event.keyCode === KeyCode.RIGHT) {
           event.stopImmediatePropagation();

--- a/src/app/examples/grid-editor.component.ts
+++ b/src/app/examples/grid-editor.component.ts
@@ -94,7 +94,7 @@ export class GridEditorComponent implements OnInit {
   updatedObject: any;
   selectedLanguage = 'en';
 
-  constructor(private http: HttpClient, private translate: TranslateService) {}
+  constructor(private http: HttpClient, private translate: TranslateService) { }
 
   ngOnInit(): void {
     this.prepareGrid();
@@ -178,14 +178,13 @@ export class GridEditorComponent implements OnInit {
         sortable: true,
         type: FieldType.number,
         filter: { model: Filters.slider, params: { hideSliderNumber: false } },
-        /*
         editor: {
           model: Editors.slider,
           minValue: 0,
           maxValue: 100,
           // params: { hideSliderNumber: true },
         },
-        */
+        /*
         editor: {
           // default is 0 decimals, if no decimals is passed it will accept 0 or more decimals
           // however if you pass the "decimalPlaces", it will validate with that maximum
@@ -197,7 +196,7 @@ export class GridEditorComponent implements OnInit {
           // errorMessage: this.i18n.tr('INVALID_FLOAT', { maxDecimal: 2 }),
           params: { decimalPlaces: 2 },
         },
-
+        */
       }, {
         id: 'complete',
         name: '% Complete',

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -1,3 +1,4 @@
+/// <reference types="jquery" />
 // import 3rd party vendor libs
 // only import the necessary core lib, each will be imported on demand when enabled (via require)
 import 'jquery-ui-dist/jquery-ui';
@@ -170,7 +171,7 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
     private sortService: SortService,
     private translate: TranslateService,
     @Inject('config') private forRootConfig: GridOption
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.onBeforeGridCreate.emit(true);
@@ -238,7 +239,7 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
       if (column.editor && column.editor.collectionAsync) {
         this.loadEditorCollectionAsync(column);
       }
-      return { ...column, editor: column.editor && column.editor.model, internalColumnEditor: { ...column.editor }};
+      return { ...column, editor: column.editor && column.editor.model, internalColumnEditor: { ...column.editor } };
     });
 
     // save reference for all columns before they optionally become hidden/visible
@@ -338,6 +339,28 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
       /** @deprecated please use "extensionService" instead */
       pluginService: this.extensionService,
     });
+  }
+
+  /**
+   * Commits the current edit to the grid
+   */
+  commitEdit(target: Element) {
+    if (this.grid.getOptions().autoCommitEdit) {
+      const activeNode = this.grid.getActiveCellNode();
+
+      // a timeout must be set or this could come into conflict when slickgrid
+      // tries to commit the edit when going from one editor to another on the grid
+      // through the click event. If the timeout was not here it would
+      // try to commit/destroy the editor twice, which would throw a jquery
+      // error about the element not being in the DOM
+      setTimeout(() => {
+        // make sure the target is the active editor so we do not
+        // commit prematurely
+        if (activeNode && activeNode.contains(target) && this.grid.getEditorLock().isActive()) {
+          this.grid.getEditorLock().commitCurrentEdit();
+        }
+      });
+    }
   }
 
   /**
@@ -486,8 +509,8 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
 
       // if user entered some any "presets", we need to reflect them all in the grid
       if (gridOptions && gridOptions.presets) {
-         // Filters "presets"
-         if (backendService && backendService.updateFilters && Array.isArray(gridOptions.presets.filters) && gridOptions.presets.filters.length > 0) {
+        // Filters "presets"
+        if (backendService && backendService.updateFilters && Array.isArray(gridOptions.presets.filters) && gridOptions.presets.filters.length > 0) {
           backendService.updateFilters(gridOptions.presets.filters, true);
         }
         // Sorters "presets"

--- a/src/app/modules/angular-slickgrid/editors/checkboxEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/checkboxEditor.ts
@@ -60,11 +60,18 @@ export class CheckboxEditor implements Editor {
   }
 
   loadValue(item: any) {
-    this.defaultValue = !!item[this.columnDef.field];
-    if (this.defaultValue) {
-      this.$input.prop('checked', true);
-    } else {
-      this.$input.prop('checked', false);
+    const fieldName = this.columnDef && this.columnDef.field;
+
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+
+    if (item && this.columnDef && (item.hasOwnProperty(fieldName) || item.hasOwnProperty(fieldNameFromComplexObject))) {
+      this.defaultValue = !!item[fieldNameFromComplexObject || fieldName];
+      if (this.defaultValue) {
+        this.$input.prop('checked', true);
+      } else {
+        this.$input.prop('checked', false);
+      }
     }
   }
 
@@ -77,7 +84,10 @@ export class CheckboxEditor implements Editor {
   }
 
   applyValue(item: any, state: any) {
-    item[this.columnDef.field] = state;
+    const fieldName = this.columnDef && this.columnDef.field;
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+    item[fieldNameFromComplexObject || fieldName] = state;
   }
 
   isValueChanged() {

--- a/src/app/modules/angular-slickgrid/editors/dateEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/dateEditor.ts
@@ -131,8 +131,15 @@ export class DateEditor implements Editor {
   }
 
   loadValue(item: any) {
-    this.defaultDate = item[this.args.column.field];
-    this.flatInstance.setDate(item[this.args.column.field]);
+    const fieldName = this.columnDef && this.columnDef.field;
+
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+
+    if (item && this.columnDef && (item.hasOwnProperty(fieldName) || item.hasOwnProperty(fieldNameFromComplexObject))) {
+      this.defaultDate = item[fieldNameFromComplexObject || fieldName];
+      this.flatInstance.setDate(item[this.args.column.field]);
+    }
   }
 
   serializeValue() {
@@ -152,9 +159,12 @@ export class DateEditor implements Editor {
     if (!state) {
       return;
     }
-
+    const fieldName = this.columnDef && this.columnDef.field;
     const outputFormat = mapMomentDateFormatWithFieldType(this.args.column.type || FieldType.dateIso);
-    item[this.args.column.field] = moment(state, outputFormat).toDate();
+
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+    item[fieldNameFromComplexObject || fieldName] = moment(state, outputFormat).toDate();
   }
 
   isValueChanged() {

--- a/src/app/modules/angular-slickgrid/editors/integerEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/integerEditor.ts
@@ -9,7 +9,7 @@ declare var $: any;
  * KeyDown events are also handled to provide handling for Tab, Shift-Tab, Esc and Ctrl-Enter.
  */
 export class IntegerEditor implements Editor {
-  private _lastInputEvent: KeyboardEvent;
+  private _lastInputEvent: JQueryEventObject;
   $input: any;
   defaultValue: any;
 
@@ -42,7 +42,7 @@ export class IntegerEditor implements Editor {
 
     this.$input = $(`<input type="number" class="editor-text editor-${columnId}" placeholder="${placeholder}" />`)
       .appendTo(this.args.container)
-      .on('keydown.nav', (event: KeyboardEvent) => {
+      .on('keydown.nav', (event: JQueryEventObject) => {
         this._lastInputEvent = event;
         if (event.keyCode === KeyCode.LEFT || event.keyCode === KeyCode.RIGHT) {
           event.stopImmediatePropagation();
@@ -73,10 +73,17 @@ export class IntegerEditor implements Editor {
   }
 
   loadValue(item: any) {
-    this.defaultValue = parseInt(item[this.args.column.field], 10);
-    this.$input.val(this.defaultValue);
-    this.$input[0].defaultValue = this.defaultValue;
-    this.$input.select();
+    const fieldName = this.columnDef && this.columnDef.field;
+
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+
+    if (item && this.columnDef && (item.hasOwnProperty(fieldName) || item.hasOwnProperty(fieldNameFromComplexObject))) {
+      this.defaultValue = parseInt(item[fieldNameFromComplexObject || fieldName], 10);
+      this.$input.val(this.defaultValue);
+      this.$input[0].defaultValue = this.defaultValue;
+      this.$input.select();
+    }
   }
 
   serializeValue() {
@@ -88,7 +95,10 @@ export class IntegerEditor implements Editor {
   }
 
   applyValue(item: any, state: any) {
-    item[this.args.column.field] = state;
+    const fieldName = this.columnDef && this.columnDef.field;
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+    item[fieldNameFromComplexObject || fieldName] = state;
   }
 
   isValueChanged() {

--- a/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
@@ -86,7 +86,7 @@ export class LongTextEditor implements Editor {
     this.$textarea.focus().select();
   }
 
-  handleKeyDown(event: KeyboardEvent) {
+  handleKeyDown(event: JQueryEventObject) {
     if (event.which === KeyCode.ENTER && event.ctrlKey) {
       this.save();
     } else if (event.which === KeyCode.ESCAPE) {
@@ -147,8 +147,16 @@ export class LongTextEditor implements Editor {
   }
 
   loadValue(item: any) {
-    this.$textarea.val(this.defaultValue = item[this.columnDef.field]);
-    this.$textarea.select();
+    const fieldName = this.columnDef && this.columnDef.field;
+
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+
+    if (item && this.columnDef && (item.hasOwnProperty(fieldName) || item.hasOwnProperty(fieldNameFromComplexObject))) {
+      this.defaultValue = item[fieldNameFromComplexObject || fieldName];
+      this.$textarea.val(this.defaultValue);
+      this.$textarea.select();
+    }
   }
 
   serializeValue() {
@@ -156,7 +164,10 @@ export class LongTextEditor implements Editor {
   }
 
   applyValue(item: any, state: any) {
-    item[this.columnDef.field] = state;
+    const fieldName = this.columnDef && this.columnDef.field;
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+    item[fieldNameFromComplexObject || fieldName] = state;
   }
 
 

--- a/src/app/modules/angular-slickgrid/editors/sliderEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/sliderEditor.ts
@@ -9,7 +9,7 @@ const DEFAULT_MAX_VALUE = 100;
 const DEFAULT_STEP = 1;
 
 export class SliderEditor implements Editor {
-  private _lastInputEvent: KeyboardEvent;
+  private _lastInputEvent: JQueryEventObject;
   private _elementRangeInputId: string;
   private _elementRangeOutputId: string;
   $editorElm: any;
@@ -63,7 +63,7 @@ export class SliderEditor implements Editor {
     // if user chose to display the slider number on the right side, then update it every time it changes
     // we need to use both "input" and "change" event to be all cross-browser
     if (!this.editorParams.hideSliderNumber) {
-      this.$editorElm.on('input change', (event: KeyboardEvent & { target: HTMLInputElement }) => {
+      this.$editorElm.on('input change', (event: JQueryEventObject & { target: HTMLInputElement }) => {
         this._lastInputEvent = event;
         const value = event && event.target && event.target.value || '';
         if (value) {
@@ -98,11 +98,17 @@ export class SliderEditor implements Editor {
   }
 
   loadValue(item: any) {
-    // this.$input.val(this.defaultValue = item[this.columnDef.field]);
-    this.defaultValue = item[this.columnDef.field];
-    this.$input.val(this.defaultValue);
-    this.$input[0].defaultValue = this.defaultValue;
-    this.$sliderNumber.html(this.defaultValue);
+    const fieldName = this.columnDef && this.columnDef.field;
+
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+
+    if (item && this.columnDef && (item.hasOwnProperty(fieldName) || item.hasOwnProperty(fieldNameFromComplexObject))) {
+      this.defaultValue = item[fieldNameFromComplexObject || fieldName];
+      this.$input.val(this.defaultValue);
+      this.$input[0].defaultValue = this.defaultValue;
+      this.$sliderNumber.html(this.defaultValue);
+    }
   }
 
   serializeValue() {
@@ -110,7 +116,10 @@ export class SliderEditor implements Editor {
   }
 
   applyValue(item: any, state: any) {
-    item[this.columnDef.field] = state;
+    const fieldName = this.columnDef && this.columnDef.field;
+    // when it's a complex object, then pull the object name only, e.g.: "user.firstName" => "user"
+    const fieldNameFromComplexObject = fieldName.indexOf('.') ? fieldName.substring(0, fieldName.indexOf('.')) : '';
+    item[fieldNameFromComplexObject || fieldName] = state;
   }
 
   isValueChanged() {

--- a/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
@@ -51,7 +51,7 @@ export class AutoCompleteFilter implements Filter {
   /**
    * Initialize the Filter
    */
-  constructor(protected translate: TranslateService, protected collectionService: CollectionService) {}
+  constructor(protected translate: TranslateService, protected collectionService: CollectionService) { }
 
   /** Getter for the Collection Options */
   protected get collectionOptions(): CollectionOption {
@@ -276,7 +276,7 @@ export class AutoCompleteFilter implements Filter {
     if (this.columnFilter && this.columnFilter.placeholder) {
       placeholder = this.columnFilter.placeholder;
     }
-    return `<input type="text" class="form-control autocomplete search-filter filter-${columnId}" placeholder="${placeholder}">`;
+    return `<input type="text" autocomplete="off" class="form-control autocomplete search-filter filter-${columnId}" placeholder="${placeholder}">`;
   }
 
   /**
@@ -301,7 +301,7 @@ export class AutoCompleteFilter implements Filter {
     }
 
     // user might pass his own autocomplete options
-    const autoCompleteOptions = this.columnDef && this.columnDef.filter && this.columnDef.filter.filterOptions;
+    const autoCompleteOptions = this.columnFilter.filterOptions;
 
     // when user passes it's own autocomplete options
     // we still need to provide our own "select" callback implementation

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -123,7 +123,7 @@ export class SelectFilter implements Filter {
     if (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) {
       return this.columnDef && this.columnDef.filter && this.columnDef.filter.operator;
     }
-    return  this.isMultipleSelect ? OperatorType.in : OperatorType.equal;
+    return this.isMultipleSelect ? OperatorType.in : OperatorType.equal;
   }
 
   /**

--- a/src/app/modules/angular-slickgrid/models/collectionCustomStructure.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/collectionCustomStructure.interface.ts
@@ -7,7 +7,7 @@ export interface CollectionCustomStructure {
 
   /**
    * defaults to "value", optional text that can be added to each <option label=""> attribute, which can then be used when showing selected text
-   * Can be used with `filterOptions: { useSelectOptionTitle: true }` when user want to show different text as selected values
+   * Can be used with `filterOptions: { useSelectOptionTitle: true }` (or with "editorOptions") when user want to show different text as selected values
    */
   optionLabel?: string;
 

--- a/src/app/modules/angular-slickgrid/services/filter.service.ts
+++ b/src/app/modules/angular-slickgrid/services/filter.service.ts
@@ -77,7 +77,7 @@ export class FilterService {
     this._slickSubscriber.subscribe(this.onBackendFilterChange.bind(this));
 
     // subscribe to SlickGrid onHeaderRowCellRendered event to create filter template
-    this._eventHandler.subscribe(grid.onHeaderRowCellRendered, (e: KeyboardEvent, args: any) => {
+    this._eventHandler.subscribe(grid.onHeaderRowCellRendered, (e: JQueryEventObject, args: any) => {
       // firstColumnIdRendered is null at first, so if it changes to being filled and equal then we know it was already rendered
       if (args.column.id === this._firstColumnIdRendered) {
         this._isFilterFirstRender = false;
@@ -89,7 +89,7 @@ export class FilterService {
     });
   }
 
-  onBackendFilterChange(event: KeyboardEvent, args: any) {
+  onBackendFilterChange(event: JQueryEventObject, args: any) {
     if (!args || !args.grid) {
       throw new Error('Something went wrong when trying to attach the "attachBackendOnFilterSubscribe(event, args)" function, it seems that "args" is not populated correctly');
     }
@@ -127,7 +127,7 @@ export class FilterService {
     }
   }
 
-  async executeBackendCallback(event: KeyboardEvent, args: any, startTime: Date, backendApi: BackendServiceApi) {
+  async executeBackendCallback(event: JQueryEventObject, args: any, startTime: Date, backendApi: BackendServiceApi) {
     const query = await backendApi.service.processOnFilterChanged(event, args);
 
     // emit an onFilterChanged event when it's not called by a clear filter
@@ -160,7 +160,7 @@ export class FilterService {
     dataView.setFilterArgs({ columnFilters: this._columnFilters, grid: this._grid });
     dataView.setFilter(this.customLocalFilter.bind(this, dataView));
 
-    this._slickSubscriber.subscribe((e: KeyboardEvent, args: any) => {
+    this._slickSubscriber.subscribe((e: JQueryEventObject, args: any) => {
       const columnId = args.columnId;
       if (columnId != null) {
         dataView.refresh();
@@ -172,7 +172,7 @@ export class FilterService {
     });
 
     // subscribe to SlickGrid onHeaderRowCellRendered event to create filter template
-    this._eventHandler.subscribe(grid.onHeaderRowCellRendered, (e: KeyboardEvent, args: any) => {
+    this._eventHandler.subscribe(grid.onHeaderRowCellRendered, (e: JQueryEventObject, args: any) => {
       this.addFilterTemplateToHeaderRow(args);
     });
   }
@@ -197,7 +197,7 @@ export class FilterService {
     // when using a backend service, we need to manually trigger a filter change
     if (isBackendApi) {
       emitter = EmitterType.remote;
-      this.onBackendFilterChange(event as KeyboardEvent, { grid: this._grid, columnFilters: this._columnFilters });
+      this.onBackendFilterChange(event as JQueryEventObject, { grid: this._grid, columnFilters: this._columnFilters });
     }
 
     // emit an event when filter is cleared
@@ -397,7 +397,7 @@ export class FilterService {
     return currentFilters;
   }
 
-  callbackSearchEvent(e: KeyboardEvent | undefined, args: FilterCallbackArg) {
+  callbackSearchEvent(e: JQueryEventObject | undefined, args: FilterCallbackArg) {
     if (args) {
       const searchTerm = ((e && e.target) ? (e.target as HTMLInputElement).value : undefined);
       const searchTerms = (args.searchTerms && Array.isArray(args.searchTerms)) ? args.searchTerms : (searchTerm ? [searchTerm] : undefined);
@@ -517,7 +517,7 @@ export class FilterService {
   populateColumnFilterSearchTerms() {
     if (this._gridOptions.presets && Array.isArray(this._gridOptions.presets.filters) && this._gridOptions.presets.filters.length > 0) {
       const filters = this._gridOptions.presets.filters;
-      this._columnDefinitions.forEach((columnDef: Column) =>  {
+      this._columnDefinitions.forEach((columnDef: Column) => {
         // clear any columnDef searchTerms before applying Presets
         if (columnDef.filter && columnDef.filter.searchTerms) {
           delete columnDef.filter.searchTerms;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "experimentalDecorators": true,
     "target": "es5",
     "typeRoots": [
-      "node_modules/@types"
+      "node_modules/@types",
+      "typings"
     ],
     "lib": [
       "es2017",


### PR DESCRIPTION
- as soon as the column definition property "field" includes a dot "." we consider it as a complex object and the lib deals with a complex object differently. On each Editor, we have to return the object but if the "field" contains the "." then we need to pull the object name before the dot. For example, if our "field" is "user.firstName" then our complex object is "user" and we should return in most cases the "user" object