### PR TITLE
added option for user to select the length of autocomplete

### DIFF
--- a/src/app/modules/angular-slickgrid/editors/autoCompleteEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/autoCompleteEditor.ts
@@ -160,7 +160,7 @@ export class AutoCompleteEditor implements Editor {
 
   serializeValue() {
     // if user provided a custom structure, we will serialize the value returned from the object with custom structure
-    const minLength = this.editorOptions.minLength || this.editorOptions.minLength === 0 ? this.editorOptions.minLength : 3;
+    const minLength = typeof this.editorOptions.minLength !== 'undefined' ? this.editorOptions.minLength : 3;
     if (this.editorOptions.forceUserInput) {
       this._currentValue = this.$input.val().length >= minLength ? this.$input.val() : this._currentValue;
     }

--- a/src/app/modules/angular-slickgrid/editors/autoCompleteEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/autoCompleteEditor.ts
@@ -160,8 +160,9 @@ export class AutoCompleteEditor implements Editor {
 
   serializeValue() {
     // if user provided a custom structure, we will serialize the value returned from the object with custom structure
+    const minLength = this.editorOptions.minLength || this.editorOptions.minLength === 0 ? this.editorOptions.minLength : 3;
     if (this.editorOptions.forceUserInput) {
-      this._currentValue = this.$input.val().length > 3 ? this.$input.val() : this._currentValue;
+      this._currentValue = this.$input.val().length >= minLength ? this.$input.val() : this._currentValue;
     }
     if (this.customStructure && this._currentValue.hasOwnProperty(this.labelName)) {
       return this._currentValue[this.labelName];


### PR DESCRIPTION
Hi there,

Just noticed that I missed something on this feature. It is a small change but it detects if the user has used the `minLength` and applies it to the field. For example if you want the user to be able to clear the input or be able to add a text with less than 3 characters.

![image](https://user-images.githubusercontent.com/3384277/57631003-8fd29e80-7596-11e9-9ee0-1649261e8686.png)
