### PR TITLE
fix(rowDetail): update to latest SlickGrid version, fixes #180

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.22.1",
     "rxjs": "^6.3.3",
-    "slickgrid": "^2.4.7",
+    "slickgrid": "^2.4.8",
     "text-encoding-utf-8": "^1.0.2",
     "tslib": "^1.9.3",
     "vinyl-paths": "^2.1.0"

--- a/src/app/examples/grid-rowdetail.component.html
+++ b/src/app/examples/grid-rowdetail.component.html
@@ -10,6 +10,8 @@
         </button>
     </span>
 
+    <hr/>
+
     <angular-slickgrid gridId="grid21"
               [columnDefinitions]="columnDefinitions"
               [gridOptions]="gridOptions"

--- a/src/app/examples/grid-rowdetail.component.ts
+++ b/src/app/examples/grid-rowdetail.component.ts
@@ -32,7 +32,7 @@ export class GridRowDetailComponent implements OnInit {
   columnDefinitions: Column[];
   gridOptions: GridOption;
   dataset: any[];
-  detailViewRowCount = 7;
+  detailViewRowCount = 9;
   selectedLanguage: string;
 
   constructor(private translate: TranslateService) {


### PR DESCRIPTION
- prior to this version, a scrolling always appeared in the row detail panel
- closes #180