### PR TITLE
fix(editor): dynamically adding editor column throws error, fixes #195

### DIFF
--- a/src/app/examples/grid-editor.component.html
+++ b/src/app/examples/grid-editor.component.html
@@ -29,6 +29,10 @@
             <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
             <button class="btn btn-default btn-sm btn-info" (click)="addItem()" title="Clear Filters &amp; Sorting to see it better">Add item</button>
             <button class="btn btn-default btn-sm btn-danger" (click)="deleteItem()">Delete item</button>
+            <button class="btn btn-default btn-sm" (click)="dynamicallyAddTitleHeader()">
+              <i class="fa fa-plus"></i>
+              Dynamically Duplicate Title Column
+            </button>
         </div>
     </div>
 

--- a/src/app/examples/grid-editor.component.ts
+++ b/src/app/examples/grid-editor.component.ts
@@ -94,6 +94,7 @@ export class GridEditorComponent implements OnInit {
   alertWarning: any;
   updatedObject: any;
   selectedLanguage = 'en';
+  duplicateTitleHeaderCount = 1;
 
   constructor(private http: HttpClient, private translate: TranslateService) { }
 
@@ -573,6 +574,22 @@ export class GridEditorComponent implements OnInit {
       autoCommitEdit: this.gridOptions.autoCommitEdit
     });
     return true;
+  }
+
+  dynamicallyAddTitleHeader() {
+    const newCol = {
+      id: `title${this.duplicateTitleHeaderCount++}`,
+      name: 'Title',
+      field: 'title',
+      editor: {
+        model: Editors.text,
+        required: true,
+        validator: myCustomTitleValidator, // use a custom validator
+      },
+      sortable: true, minWidth: 100, filterable: true, params: { useFormatterOuputToFilter: true }
+    };
+    this.columnDefinitions.push(newCol);
+    this.columnDefinitions = this.columnDefinitions.slice();
   }
 
   setAutoEdit(isAutoEdit) {


### PR DESCRIPTION
- Column with Editors are special because we need to swap them internally in the library to a property named "internalColumnEditor", we do this because SlickGrid has "editor" reserved to a factory but that is completely different than the implementation in Angular-Slickgrid, so if user add a column dynamically, it should also be analyzed as well at that time.