### PR TITLE
fix(styling): styling issue in Firefox after col reordering, fixes #297

### DIFF
--- a/src/app/modules/angular-slickgrid/styles/slick-default-theme.scss
+++ b/src/app/modules/angular-slickgrid/styles/slick-default-theme.scss
@@ -14,6 +14,7 @@
    .slick-header-column {
      background: $grid-header-background;
      // background-color: #EBECEE;
+     box-sizing: content-box !important; /* this here only for Firefox! */
    }
 
    .slick-header-columns {

--- a/src/app/modules/angular-slickgrid/styles/slick-grid.scss
+++ b/src/app/modules/angular-slickgrid/styles/slick-grid.scss
@@ -28,6 +28,7 @@
   .slick-group-header-column.ui-state-default {
     position: relative;
     display: inline-block;
+    box-sizing: content-box !important; /* this here only for Firefox! */
     overflow: hidden;
     -o-text-overflow: ellipsis;
     text-overflow: ellipsis;


### PR DESCRIPTION
- found a commit in SlickGrid to address Firefox styling issue https://github.com/6pac/SlickGrid/commit/a8d4452b625270b7671eb0e2a0d84aa6cc556656

### BEFORE 

![2019-10-02_19-07-07](https://user-images.githubusercontent.com/643976/66088112-efcae100-e547-11e9-9bcd-204fb31ca1b0.gif)

### AFTER

![2019-10-02_19-06-32](https://user-images.githubusercontent.com/643976/66088118-f48f9500-e547-11e9-9e87-ec773f410fad.gif)
