### PR TITLE
feat(export): add delimiter/listSeparator override to use with GraphQL

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { TranslateModule, TranslateLoader, TranslateService } from '@ngx-transla
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { AppComponent } from './app.component';
+import { CustomActionFormatterComponent } from './examples/custom-actionFormatter.component';
 import { CustomTitleFormatterComponent } from './examples/custom-titleFormatter.component';
 import { EditorNgSelectComponent } from './examples/editor-ng-select.component';
 import { FilterNgSelectComponent } from './examples/filter-ng-select.component';
@@ -77,6 +78,7 @@ export function appInitializerFactory(translate: TranslateService, injector: Inj
 @NgModule({
   declarations: [
     AppComponent,
+    CustomActionFormatterComponent,
     CustomTitleFormatterComponent,
     EditorNgSelectComponent,
     FilterNgSelectComponent,
@@ -137,6 +139,7 @@ export function appInitializerFactory(translate: TranslateService, injector: Inj
   ],
   entryComponents: [
     // dynamically created components
+    CustomActionFormatterComponent,
     CustomTitleFormatterComponent,
     EditorNgSelectComponent,
     FilterNgSelectComponent,

--- a/src/app/examples/custom-actionFormatter.component.ts
+++ b/src/app/examples/custom-actionFormatter.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+@Component({
+  template: `<div id="myDrop" class="dropdown" style="position:absolute; z-index:12000;">
+  <button class="btn btn-default btn-xs dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+    Action
+    <span class="caret"></span>
+  </button>
+  <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+      <li><a class="pointer" (click)="parent.deleteCell(row)">Delete Row</a></li>
+    </ul></div>`
+})
+export class CustomActionFormatterComponent {
+  parent: any;
+}

--- a/src/app/examples/grid-angular.component.html
+++ b/src/app/examples/grid-angular.component.html
@@ -48,6 +48,7 @@
                        (sgOnCellChange)="onCellChanged($event.detail.eventData, $event.detail.args)"
                        (sgOnClick)="onCellClicked($event.detail.eventData, $event.detail.args)"
                        (sgOnValidationError)="onCellValidation($event.detail.eventData, $event.detail.args)"
+                       (sgOnActiveCellChanged)="onActiveCellChanged($event.detail.eventData, $event.detail.args)"
                        [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions" [dataset]="dataset">
     </angular-slickgrid>
   </div>

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -398,10 +398,17 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
     if (backendApi) {
       // internalPostProcess only works (for now) with a GraphQL Service, so make sure it is that type
       if (backendApi && backendApi.service instanceof GraphqlService) {
-        backendApi.internalPostProcess = (processResult: any) => {
+        backendApi.internalPostProcess = (processResult: GraphqlResult) => {
           const datasetName = (backendApi && backendApi.service && typeof backendApi.service.getDatasetName === 'function') ? backendApi.service.getDatasetName() : '';
           if (processResult && processResult.data && processResult.data[datasetName]) {
             this._dataset = processResult.data[datasetName].nodes;
+            if (processResult.data[datasetName].listSeparator) {
+              // if the "listSeparator" is available in the GraphQL result, we'll override the ExportOptions Delimiter with this new info
+              if (!this.gridOptions.exportOptions) {
+                this.gridOptions.exportOptions = {};
+              }
+              this.gridOptions.exportOptions.delimiterOverride = processResult.data[datasetName].listSeparator.toString();
+            }
             this.refreshGridData(this._dataset, processResult.data[datasetName].totalCount);
           } else {
             this._dataset = [];

--- a/src/app/modules/angular-slickgrid/models/exportOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/exportOption.interface.ts
@@ -4,6 +4,9 @@ export interface ExportOption {
   /** export delimiter, can be (comma, tab, ... or even custom string). */
   delimiter?: DelimiterType | string;
 
+  /** Allows you to override for the export delimiter, useful when adding the "listSeparator" to the GraphQL query */
+  delimiterOverride?: DelimiterType | string;
+
   /** Defaults to false, which leads to all Formatters of the grid being evaluated on export. You can also override a column by changing the propery on the column itself */
   exportWithFormatter?: boolean;
 

--- a/src/app/modules/angular-slickgrid/models/graphqlResult.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/graphqlResult.interface.ts
@@ -1,14 +1,16 @@
+import { DelimiterType } from './delimiterType.enum';
 import { Metrics } from './metrics.interface';
 import { Statistic } from './statistic.interface';
 
 export interface GraphqlResult {
   data: {
     [datasetName: string]: {
-      nodes: any[],
+      nodes: any[];
       pageInfo: {
         hasNextPage: boolean;
-      },
-      totalCount: number
+      };
+      listSeparator?: DelimiterType;
+      totalCount: number;
     }
   };
 

--- a/src/app/modules/angular-slickgrid/models/graphqlServiceOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/graphqlServiceOption.interface.ts
@@ -7,10 +7,16 @@ import { GraphqlPaginationOption } from './graphqlPaginationOption.interface';
 
 export interface GraphqlServiceOption extends BackendServiceOption {
   /**
-   * When using Translation, we probably want to add locale in the query for the filterBy/orderBy to work
-   * ex.: users(first: 10, offset: 0, locale: "en-CA", filterBy: [{field: name, operator: EQ, value:"John"}]) {
+   * When using Translation, we probably want to add locale as a query parameter for the filterBy/orderBy to work
+   * ex.: users(first: 10, offset: 0, locale: "en-CA", filterBy: [{field: name, operator: EQ, value:"John"}]) { }
    */
   addLocaleIntoQuery?: boolean;
+
+  /**
+   * Add the Current User List Separator to the result query (in English the separator is comma ",").
+   * This is useful to set the "delimiter" property when using Export CSV, for example French uses semicolon ";" as a delimiter/separator
+   */
+  addListSeparator?: boolean;
 
   /** What is the dataset, this is required for the GraphQL query to be built */
   datasetName?: string;

--- a/src/app/modules/angular-slickgrid/services/__tests__/graphql.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/graphql.service.spec.ts
@@ -243,6 +243,16 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
+    it('should include "listSeparator" in the query string when option "addListSeparator" is enabled', () => {
+      const expectation = `query{ users(first:10, offset:0){ listSeparator, totalCount, nodes{ id, field1, field2 }}}`;
+      const columns = [{ id: 'field1', field: 'field1', width: 100 }, { id: 'field2', field: 'field2', width: 100 }];
+
+      service.init({ datasetName: 'users', columnDefinitions: columns, addListSeparator: true }, paginationOptions, gridStub);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
+
     it('should include default locale "en" in the query string when option "addLocaleIntoQuery" is enabled and i18n is not defined', () => {
       const expectation = `query{ users(first:10, offset:0, locale: "en"){ totalCount, nodes{ id, field1, field2 }}}`;
       const columns = [{ id: 'field1', field: 'field1', width: 100 }, { id: 'field2', field: 'field2', width: 100 }];
@@ -415,6 +425,7 @@ describe('GraphqlService', () => {
     });
 
     it('should return a query with the new filter', () => {
+      serviceOptions.addListSeparator = false;
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"female"}]) { totalCount,nodes{ id,field1,field2 } }}`;
       const querySpy = jest.spyOn(service, 'buildQuery');
       const resetSpy = jest.spyOn(service, 'resetPaginationOptions');
@@ -441,9 +452,10 @@ describe('GraphqlService', () => {
     });
 
     it('should return a query with a new filter when previous filters exists', () => {
+      serviceOptions.addListSeparator = true;
       const expectation = `query{users(first:10, offset:0,
                           filterBy:[{field:gender, operator:EQ, value:"female"}, {field:firstName, operator:StartsWith, value:"John"}])
-                          { totalCount,nodes{ id,field1,field2 } }}`;
+                          { listSeparator, totalCount,nodes{ id,field1,field2 } }}`;
       const querySpy = jest.spyOn(service, 'buildQuery');
       const resetSpy = jest.spyOn(service, 'resetPaginationOptions');
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
@@ -476,6 +488,7 @@ describe('GraphqlService', () => {
 
   describe('processOnPaginationChanged method', () => {
     it('should return a query with the new pagination', () => {
+      serviceOptions.addListSeparator = false;
       const expectation = `query{users(first:20, offset:40) { totalCount,nodes { id, field1, field2 }}}`;
       const querySpy = jest.spyOn(service, 'buildQuery');
 
@@ -489,7 +502,8 @@ describe('GraphqlService', () => {
     });
 
     it('should return a query with the new pagination and use pagination size options that was passed to service options when it is not provided as argument to "processOnPaginationChanged"', () => {
-      const expectation = `query{users(first:10, offset:20) { totalCount,nodes { id, field1, field2 }}}`;
+      serviceOptions.addListSeparator = true;
+      const expectation = `query{users(first:10, offset:20) { listSeparator, totalCount,nodes { id, field1, field2 }}}`;
       const querySpy = jest.spyOn(service, 'buildQuery');
 
       service.init(serviceOptions, paginationOptions, gridStub);
@@ -519,6 +533,7 @@ describe('GraphqlService', () => {
 
   describe('processOnSortChanged method', () => {
     it('should return a query with the new sorting when using single sort', () => {
+      serviceOptions.addListSeparator = false;
       const expectation = `query{ users(first:10, offset:0, orderBy:[{field:gender, direction: DESC}]) { totalCount,nodes{ id,field1,field2 } }}`;
       const querySpy = jest.spyOn(service, 'buildQuery');
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
@@ -532,9 +547,10 @@ describe('GraphqlService', () => {
     });
 
     it('should return a query with the multiple new sorting when using multiColumnSort', () => {
+      serviceOptions.addListSeparator = true;
       const expectation = `query{ users(first:10, offset:0,
                             orderBy:[{field:gender, direction: DESC}, {field:firstName, direction: ASC}]) {
-                            totalCount,nodes{ id,field1,field2 } }}`;
+                            listSeparator, totalCount,nodes{ id,field1,field2 } }}`;
       const querySpy = jest.spyOn(service, 'buildQuery');
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnName = { id: 'firstName', field: 'firstName' } as Column;
@@ -553,6 +569,7 @@ describe('GraphqlService', () => {
   describe('updateFilters method', () => {
     beforeEach(() => {
       serviceOptions.columnDefinitions = [{ id: 'company', field: 'company' }, { id: 'gender', field: 'gender' }, { id: 'name', field: 'name' }];
+      serviceOptions.addListSeparator = false;
     });
 
     it('should throw an error when filter columnId is not found to be part of the column definitions', () => {
@@ -569,7 +586,9 @@ describe('GraphqlService', () => {
     });
 
     it('should return a query with the new filter when filters are passed as a filter trigger by a filter event and is of type ColumnFilters', () => {
-      const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}`;
+      serviceOptions.addListSeparator = true;
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EQ, value:"female"}]) {
+        listSeparator, totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['female'], operator: 'EQ' },
@@ -913,7 +932,8 @@ describe('GraphqlService', () => {
     });
 
     it('should return a query without any sorting after clearFilters was called', () => {
-      const expectation = `query{ users(first:10,offset:0) { totalCount,nodes{id, company, gender,name} }}`;
+      serviceOptions.addListSeparator = true;
+      const expectation = `query{ users(first:10,offset:0) { listSeparator, totalCount, nodes {id, company, gender,name} }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['female'], operator: 'EQ' },
@@ -933,10 +953,13 @@ describe('GraphqlService', () => {
   describe('presets', () => {
     beforeEach(() => {
       serviceOptions.columnDefinitions = [{ id: 'company', field: 'company' }, { id: 'gender', field: 'gender' }, { id: 'duration', field: 'duration' }, { id: 'startDate', field: 'startDate' }];
+      serviceOptions.addListSeparator = false;
     });
 
     it('should return a query with search having a range of exclusive numbers when the search value contains 2 (..) to represent a range of numbers', () => {
-      const expectation = `query{users(first:10, offset:0, filterBy:[{field:duration, operator:GT, value:"2"}, {field:duration, operator:LT, value:"33"}]) { totalCount,nodes{ id,company,gender,duration,startDate } }}`;
+      serviceOptions.addListSeparator = true;
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:duration, operator:GT, value:"2"}, {field:duration, operator:LT, value:"33"}]) {
+        listSeparator, totalCount,nodes{ id,company,gender,duration,startDate } }}`;
       const presetFilters = [
         { columnId: 'duration', searchTerms: ['2..33'] },
       ] as CurrentFilter[];
@@ -1044,12 +1067,14 @@ describe('GraphqlService', () => {
   describe('updateSorters method', () => {
     beforeEach(() => {
       serviceOptions.columnDefinitions = [{ id: 'company', field: 'company' }, { id: 'gender', field: 'gender' }, { id: 'name', field: 'name' }];
+      serviceOptions.addListSeparator = false;
     });
 
     it('should return a query with the multiple new sorting when using multiColumnSort', () => {
+      serviceOptions.addListSeparator = true;
       const expectation = `query{ users(first:10, offset:0,
                             orderBy:[{field:gender, direction: DESC}, {field:firstName, direction: ASC}]) {
-                            totalCount,nodes{ id, company, gender, name } }}`;
+                            listSeparator, totalCount,nodes{ id, company, gender, name } }}`;
       const mockColumnSort = [
         { columnId: 'gender', sortCol: { id: 'gender', field: 'gender' }, sortAsc: false },
         { columnId: 'firstName', sortCol: { id: 'firstName', field: 'firstName' }, sortAsc: true }
@@ -1136,8 +1161,9 @@ describe('GraphqlService', () => {
     });
 
     it('should return a query without any sorting after clearSorters was called', () => {
+      serviceOptions.addListSeparator = true;
       const expectation = `query { users(first:10, offset:0) {
-        totalCount, nodes { id,company,gender,name }}}`;
+        listSeparator, totalCount, nodes { id,company,gender,name }}}`;
       const mockColumnSort = [
         { columnId: 'gender', sortCol: { id: 'gender', field: 'gender' }, sortAsc: false },
         { columnId: 'firstName', sortCol: { id: 'firstName', field: 'firstName' }, sortAsc: true }


### PR DESCRIPTION
- a new flag "addListSeparator" was added to the GraphQL Backend Service, this flag when set will ask the GraphQL on the backend side to return the current user list separator (in English it's a comma but in French it's a semicolon). For example, with .Net Core, we can get this list separator by the `CultureInfo.TextInfo.ListSeparator`