### PR TITLE
refactor(export): should throw error when grid/dataview objects are null

### DIFF
--- a/src/app/modules/angular-slickgrid/services/__tests__/excelExport.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/excelExport.service.spec.ts
@@ -142,6 +142,15 @@ describe('ExcelExportService', () => {
         jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
       });
 
+      it('should throw an error when trying call exportToExcel" without a grid and/or dataview object initialized', async () => {
+        try {
+          service.init(null, null);
+          await service.exportToExcel(mockExportExcelOptions);
+        } catch (e) {
+          expect(e.toString()).toContain('[Angular-Slickgrid] it seems that the SlickGrid & DataView objects are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
+        }
+      });
+
       it('should trigger an event before exporting the file', () => {
         const spyOnBefore = jest.spyOn(service.onGridBeforeExportToExcel, 'next');
 

--- a/src/app/modules/angular-slickgrid/services/__tests__/export.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/export.service.spec.ts
@@ -155,6 +155,16 @@ describe('ExportService', () => {
         jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
       });
 
+      it('should throw an error when trying call exportToExcel" without a grid and/or dataview object initialized', (done) => {
+        try {
+          service.init(null, null);
+          service.exportToFile(mockExportTxtOptions);
+        } catch (e) {
+          expect(e.toString()).toContain('[Angular-Slickgrid] it seems that the SlickGrid & DataView objects are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
+          done();
+        }
+      });
+
       it('should trigger an event before exporting the file', () => {
         const spyOnBefore = jest.spyOn(service.onGridBeforeExportToFile, 'next');
 

--- a/src/app/modules/angular-slickgrid/services/excelExport.service.ts
+++ b/src/app/modules/angular-slickgrid/services/excelExport.service.ts
@@ -83,6 +83,10 @@ export class ExcelExportService {
    * Example: exportToExcel({ format: FileType.csv, delimiter: DelimiterType.comma })
    */
   exportToExcel(options: ExcelExportOption): Promise<boolean> {
+    if (!this._grid || !this._dataView) {
+      throw new Error('[Angular-Slickgrid] it seems that the SlickGrid & DataView objects are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
+    }
+
     return new Promise((resolve, reject) => {
       this.onGridBeforeExportToExcel.next(true);
       this._excelExportOptions = $.extend(true, {}, this._gridOptions.excelExportOptions, options);

--- a/src/app/modules/angular-slickgrid/services/export.service.ts
+++ b/src/app/modules/angular-slickgrid/services/export.service.ts
@@ -73,6 +73,10 @@ export class ExportService {
    * Example: exportToFile({ format: FileType.csv, delimiter: DelimiterType.comma })
    */
   exportToFile(options: ExportOption): Promise<boolean> {
+    if (!this._grid || !this._dataView) {
+      throw new Error('[Angular-Slickgrid] it seems that the SlickGrid & DataView objects are not initialized did you forget to enable the grid option flag "enableExcelExport"?');
+    }
+
     return new Promise((resolve, reject) => {
       this.onGridBeforeExportToFile.next(true);
       this._exportOptions = $.extend(true, {}, this._gridOptions.exportOptions, options);


### PR DESCRIPTION
- this happen when user try to use the export method without enabling the service in the grid option