### PR TITLE
feat(formatterOptions): add decimal,thousand separator to all Formatters

### DIFF
--- a/src/app/examples/grid-formatter.component.ts
+++ b/src/app/examples/grid-formatter.component.ts
@@ -70,10 +70,16 @@ export class GridFormatterComponent implements OnInit {
       enableAutoResize: true,
       enableCellNavigation: true,
 
-      // you customize the date separator through "formatterOptions"
+      // you customize all formatter at once certain options through "formatterOptions" in the Grid Options
+      // or independently through the column definition "params", the option names are the same
       /*
       formatterOptions: {
-        dateSeparator: '.'
+        dateSeparator: '.',
+        decimalSeparator: ',',
+        displayNegativeNumberWithParentheses: true,
+        minDecimal: 0,
+        maxDecimal: 2,
+        thousandSeparator: '_'
       },
       */
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/decimalFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/decimalFormatter.spec.ts
@@ -47,11 +47,17 @@ describe('the Decimal Formatter', () => {
   });
 
   it('should display a number with dollar sign and use "minDecimalPlaces" (or the deprecated "decimalPlaces") params', () => {
-    const input = 99.1;
+    const input = 12345678.1;
+
     const output1 = decimalFormatter(1, 1, input, { params: { minDecimalPlaces: 2 } } as Column, {});
     const output2 = decimalFormatter(1, 1, input, { params: { decimalPlaces: 2 } } as Column, {});
-    expect(output1).toBe('99.10');
-    expect(output2).toBe('99.10');
+    const output3 = decimalFormatter(1, 1, input, { params: { decimalPlaces: 2, thousandSeparator: ',' } } as Column, {});
+    const output4 = decimalFormatter(1, 1, input, { params: { decimalPlaces: 2, decimalSeparator: ',', thousandSeparator: ' ' } } as Column, {});
+
+    expect(output1).toBe('12345678.10');
+    expect(output2).toBe('12345678.10');
+    expect(output3).toBe('12,345,678.10');
+    expect(output4).toBe('12 345 678,10');
   });
 
   it('should display a number with dollar sign and use "maxDecimal" params', () => {
@@ -72,10 +78,23 @@ describe('the Decimal Formatter', () => {
     expect(output).toBe(`(2.40)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = decimalFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`(12,345,678.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -2.4;
     const output = decimalFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`(2.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = decimalFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`(12 345 678,40)`);
   });
 });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dollarColoredBoldFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dollarColoredBoldFormatter.spec.ts
@@ -28,6 +28,12 @@ describe('the DollarColoredBold Formatter', () => {
     expect(output).toBe(`<span style="color:red; font-weight:bold;">-$15.00</span>`);
   });
 
+  it('should display a red number with dollar symbol and thousand separator when value is a negative number', () => {
+    const input = -12345678;
+    const output = dollarColoredBoldFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red; font-weight:bold;">-$12,345,678.00</span>`);
+  });
+
   it('should display a green number with dollar symbol when value greater or equal to 70 and is a type string', () => {
     const input = '70';
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {});
@@ -58,10 +64,23 @@ describe('the DollarColoredBold Formatter', () => {
     expect(output).toBe(`<span style="color:red; font-weight:bold;">($2.40)</span>`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = dollarColoredBoldFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red; font-weight:bold;">($12,345,678.40)</span>`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`<span style="color:red; font-weight:bold;">($2.40)</span>`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`<span style="color:red; font-weight:bold;">($12 345 678,40)</span>`);
   });
 });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dollarColoredFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dollarColoredFormatter.spec.ts
@@ -28,6 +28,12 @@ describe('the DollarColored Formatter', () => {
     expect(output).toBe(`<span style="color:red">-$15.00</span>`);
   });
 
+  it('should display a red number with dollar symbol and thousand separator when value is a negative number', () => {
+    const input = -12345678;
+    const output = dollarColoredFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red">-$12,345,678.00</span>`);
+  });
+
   it('should display a green number with dollar symbol when value greater or equal to 70 and is a type string', () => {
     const input = '70';
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {});
@@ -58,10 +64,22 @@ describe('the DollarColored Formatter', () => {
     expect(output).toBe(`<span style="color:red">($2.40)</span>`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = dollarColoredFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red">($12,345,678.40)</span>`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`<span style="color:red">($2.40)</span>`);
+  });
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`<span style="color:red">($12 345 678,40)</span>`);
   });
 });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dollarFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dollarFormatter.spec.ts
@@ -28,6 +28,12 @@ describe('the Dollar Formatter', () => {
     expect(output).toBe(`-$15.00`);
   });
 
+  it('should display a number with negative dollar sign when a negative number and thousand separator is provided', () => {
+    const input = -12345678;
+    const output = dollarFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`-$12,345,678.00`);
+  });
+
   it('should display a number with dollar sign when a number is provided', () => {
     const input = 99;
     const output = dollarFormatter(1, 1, input, {} as Column, {});
@@ -58,10 +64,23 @@ describe('the Dollar Formatter', () => {
     expect(output).toBe(`($2.40)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = dollarFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`($12,345,678.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`($2.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = dollarFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`($12 345 678,40)`);
   });
 });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/formatterUtilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/formatterUtilities.spec.ts
@@ -1,4 +1,4 @@
-import { getAssociatedDateFormatter, getValueFromParamsOrGridOptions } from '../formatterUtilities';
+import { getAssociatedDateFormatter, getValueFromParamsOrFormatterOptions } from '../formatterUtilities';
 import { FieldType, Column, GridOption } from '../../models';
 
 describe('formatterUtilities', () => {
@@ -11,7 +11,7 @@ describe('formatterUtilities', () => {
       const gridOptions = { formatterOptions: { minDecimal: 2 } } as GridOption;
       const gridSpy = gridStub.getOptions.mockReturnValue(gridOptions);
 
-      const output = getValueFromParamsOrGridOptions('minDecimal', {} as Column, gridStub, -1);
+      const output = getValueFromParamsOrFormatterOptions('minDecimal', {} as Column, gridStub, -1);
 
       expect(gridSpy).toHaveBeenCalled();
       expect(output).toBe(2);
@@ -21,7 +21,7 @@ describe('formatterUtilities', () => {
       const gridOptions = { formatterOptions: { minDecimal: 2 } } as GridOption;
       const gridSpy = gridStub.getOptions.mockReturnValue(gridOptions);
 
-      const output = getValueFromParamsOrGridOptions('minDecimal', { params: { minDecimal: 3 } } as Column, gridStub, -1);
+      const output = getValueFromParamsOrFormatterOptions('minDecimal', { params: { minDecimal: 3 } } as Column, gridStub, -1);
 
       expect(gridSpy).toHaveBeenCalled();
       expect(output).toBe(3);
@@ -29,7 +29,7 @@ describe('formatterUtilities', () => {
 
     it('should return default value when not found in "params" (columnDef) neither the "formatterOptions" (gridOption)', () => {
       const defaultValue = 5;
-      const output = getValueFromParamsOrGridOptions('minDecimal', { field: 'column1' } as Column, {}, defaultValue);
+      const output = getValueFromParamsOrFormatterOptions('minDecimal', { field: 'column1' } as Column, {}, defaultValue);
       expect(output).toBe(defaultValue);
     });
   });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/percentCompleteFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/percentCompleteFormatter.spec.ts
@@ -52,10 +52,23 @@ describe('the Percent Complete Formatter', () => {
     expect(output).toBe(`<span style='color:red'>(2.4%)</span>`);
   });
 
-  it('should display a negative percentage with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with thousand separator and parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
+    const input = -345678.024;
+    const output = percentCompleteFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style='color:red'>(345,678.024%)</span>`);
+  });
+
+  it('should display a negative percentage with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -2.4;
     const output = percentCompleteFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`<span style='color:red'>(2.40%)</span>`);
+  });
+
+  it('should display a negative average with thousand separator and parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as GridOption);
+    const input = -345678.024;
+    const output = percentCompleteFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`<span style='color:red'>(345_678,02%)</span>`);
   });
 });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/percentFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/percentFormatter.spec.ts
@@ -40,16 +40,35 @@ describe('the Percent Symbol Formatter', () => {
     expect(output).toBe('88%');
   });
 
+  it('should display thousand separated percentage when the thousand separator is provided', () => {
+    const input = '345678';
+    const output = percentFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe('34,567,800%');
+  });
+
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
     const input = -0.024;
     const output = percentFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true } } as Column, {});
     expect(output).toBe(`(2.4%)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with thousand separator and parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
+    const input = -345678.024;
+    const output = percentFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`(34,567,802.4%)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -0.024;
     const output = percentFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`(2.40%)`);
+  });
+
+  it('should display a negative average with thousand separator and parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as GridOption);
+    const input = -345678.024;
+    const output = percentFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`(34_567_802,40%)`);
   });
 });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/percentSymbolFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/percentSymbolFormatter.spec.ts
@@ -28,10 +28,22 @@ describe('the Percent Symbol Formatter', () => {
     expect(output).toBe(`-15%`);
   });
 
+  it('should display a number with thousand separator and negative percentage sign when a negative number is provided', () => {
+    const input = -15;
+    const output = percentSymbolFormatter(1, 1, input, {} as Column, {});
+    expect(output).toBe(`-15%`);
+  });
+
   it('should display a number with percentage sign when a number is provided', () => {
     const input = 99;
     const output = percentSymbolFormatter(1, 1, input, {} as Column, {});
     expect(output).toBe(`99%`);
+  });
+
+  it('should display a number with thousand separator and  percentage sign when a number is provided', () => {
+    const input = 2345678;
+    const output = percentSymbolFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`2,345,678%`);
   });
 
   it('should display a number with percentage sign when a string number is provided', () => {
@@ -40,16 +52,35 @@ describe('the Percent Symbol Formatter', () => {
     expect(output).toBe(`99%`);
   });
 
+  it('should display a number with thousand separator and  percentage sign when a string number is provided', () => {
+    const input = '2345678';
+    const output = percentSymbolFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`2,345,678%`);
+  });
+
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
     const input = -2.4;
     const output = percentSymbolFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true } } as Column, {});
     expect(output).toBe(`(2.4%)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with thousand separator and parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
+    const input = -2345678.4;
+    const output = percentSymbolFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`(2,345,678.4%)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -2.4;
     const output = percentSymbolFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`(2.40%)`);
+  });
+
+  it('should display a negative average with thousand separator and parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as GridOption);
+    const input = -2345678.4;
+    const output = percentSymbolFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`(2_345_678,40%)`);
   });
 });

--- a/src/app/modules/angular-slickgrid/formatters/decimalFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/decimalFormatter.ts
@@ -1,13 +1,15 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const decimalFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
   const params = columnDef.params || {};
-  let minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  let maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 2);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  let minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  let maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 2);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   // @deprecated: decimalPlaces, minDecimalPlaces, maxDecimalPlaces
   // add these extra checks to support previous way of passing the decimal count
@@ -19,7 +21,7 @@ export const decimalFormatter: Formatter = (row: number, cell: number, value: an
   }
 
   if (isNumber) {
-    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/app/modules/angular-slickgrid/formatters/dollarColoredBoldFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/dollarColoredBoldFormatter.ts
@@ -1,16 +1,18 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const dollarColoredBoldFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const colorStyle = (value >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}; font-weight:bold;">${formattedNumber}</span>`;
   }
   return value;

--- a/src/app/modules/angular-slickgrid/formatters/dollarColoredFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/dollarColoredFormatter.ts
@@ -1,16 +1,18 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const dollarColoredFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const colorStyle = (value >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}">${formattedNumber}</span>`;
   }
   return value;

--- a/src/app/modules/angular-slickgrid/formatters/dollarFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/dollarFormatter.ts
@@ -1,15 +1,17 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const dollarFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
-    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/app/modules/angular-slickgrid/formatters/formatterUtilities.ts
+++ b/src/app/modules/angular-slickgrid/formatters/formatterUtilities.ts
@@ -9,7 +9,7 @@ const moment = moment_; // patch to fix rollup "moment has no default export" is
  * 2- Grid Options "formatterOptions"
  * 3- nothing found, return default value provided
  */
-export function getValueFromParamsOrGridOptions(optionName: string, columnDef: Column, grid: any, defaultValue?: any) {
+export function getValueFromParamsOrFormatterOptions(optionName: string, columnDef: Column, grid: any, defaultValue?: any) {
   const gridOptions = ((grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {}) as GridOption;
   const params = columnDef && columnDef.params;
 

--- a/src/app/modules/angular-slickgrid/formatters/percentCompleteFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/percentCompleteFormatter.ts
@@ -1,5 +1,5 @@
 import { Column, Formatter } from './../models/index';
-import { formatNumber, thousandSeparatorFormatted } from './../services/utilities';
+import { formatNumber } from './../services/utilities';
 import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const percentCompleteFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any): string => {

--- a/src/app/modules/angular-slickgrid/formatters/percentCompleteFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/percentCompleteFormatter.ts
@@ -1,16 +1,18 @@
 import { Column, Formatter } from './../models/index';
-import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { formatNumber, thousandSeparatorFormatted } from './../services/utilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const percentCompleteFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any): string => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const colorStyle = (value < 50) ? 'red' : 'green';
-    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%');
+    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%', decimalSeparator, thousandSeparator);
     const outputFormattedValue = value > 100 ? '100%' : formattedNumber;
     return `<span style='color:${colorStyle}'>${outputFormattedValue}</span>`;
   }

--- a/src/app/modules/angular-slickgrid/formatters/percentFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/percentFormatter.ts
@@ -1,17 +1,19 @@
 import { Column } from './../models/column.interface';
 import { Formatter } from './../models/formatter.interface';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const percentFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any): string => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const percentValue = value * 100;
-    return formatNumber(percentValue, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%');
+    return formatNumber(percentValue, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/app/modules/angular-slickgrid/formatters/percentSymbolFormatter.ts
+++ b/src/app/modules/angular-slickgrid/formatters/percentSymbolFormatter.ts
@@ -1,16 +1,18 @@
 import { Column } from './../models/column.interface';
 import { Formatter } from './../models/formatter.interface';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const percentSymbolFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any): string => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
-    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%');
+    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/avgTotalsDollarFormatters.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/avgTotalsDollarFormatters.spec.ts
@@ -40,6 +40,20 @@ describe('avgTotalsDollarFormatter', () => {
     expect(output).toBe('-$2.45');
   });
 
+  it('should display a negative average with dollar sign and thousand separator when its input is negative', () => {
+    const columnDef = { id: 'column3', field: 'column3', params: { thousandSeparator: ',' } } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.45 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, {});
+    expect(output).toBe('-$12,345,678.45');
+  });
+
+  it('should display a negative average with dollar sign, comma as decimal separator and underscore as thousand separator when its input is negative', () => {
+    const columnDef = { id: 'column3', field: 'column3', params: { decimalSeparator: ',', thousandSeparator: '_' } } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.45 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, {});
+    expect(output).toBe('-$12_345_678,45');
+  });
+
   it('should display a negative average with parentheses instead of the negative sign with dollar sign when its input is negative', () => {
     const columnDef = { id: 'column3', field: 'column3', params: { displayNegativeNumberWithParentheses: true } } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
@@ -47,12 +61,27 @@ describe('avgTotalsDollarFormatter', () => {
     expect(output).toBe('($2.40)');
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative average with parentheses instead of the negative sign with dollar sign and thousand separator when its input is negative', () => {
+    const columnDef = { id: 'column3', field: 'column3', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.4 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, {});
+    expect(output).toBe('($12,345,678.40)');
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
     const output = avgTotalsDollarFormatter(totals, columnDef, gridStub);
     expect(output).toBe('($2.40)');
+  });
+
+  it('should display a negative average with parentheses and thousand separator when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as GridOption);
+    const columnDef = { id: 'column3', field: 'column3' } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.4 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, gridStub);
+    expect(output).toBe('($12,345,678.40)');
   });
 
   it('should display an average number with at least 2 decimals but no more than 4 by default, and dollar sign when a positive number is provided', () => {
@@ -104,5 +133,21 @@ describe('avgTotalsDollarFormatter', () => {
     expect(output1).toBe('Avg: $123.46');
     expect(output2).toBe('$345.2 (avg)');
     expect(output3).toBe('Avg: ($2.450)/item');
+  });
+
+  it('should display an average number with prefix, suffix and thousand separator', () => {
+    const totals = { avg: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = avgTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Avg: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = avgTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (avg)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = avgTotalsDollarFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Avg: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Avg: $12_345_678,46');
+    expect(output2).toBe('$345_678,2 (avg)');
+    expect(output3).toBe('Avg: ($345_678,450)/item');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/avgTotalsFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/avgTotalsFormatter.spec.ts
@@ -43,6 +43,18 @@ describe('avgTotalsFormatter', () => {
     expect(output2).toBe('-34.57');
   });
 
+  it('should display a negative average and thousand separator when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
   it('should display a negative average with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { avg: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
@@ -53,7 +65,19 @@ describe('avgTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative average with and thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345_678,57)');
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
@@ -112,5 +136,21 @@ describe('avgTotalsFormatter', () => {
     expect(output1).toBe('Avg: 123.46');
     expect(output2).toBe('345.2 (avg)');
     expect(output3).toBe('Avg: (2.450)/item');
+  });
+
+  it('should display an average number with prefix, suffix and thousand separator', () => {
+    const totals = { avg: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = avgTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Avg: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (avg)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = avgTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Avg: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Avg: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (avg)');
+    expect(output3).toBe('Avg: (345_678,450)/item');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/avgTotalsPercentageFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/avgTotalsPercentageFormatter.spec.ts
@@ -43,6 +43,18 @@ describe('avgTotalsPercentageFormatter', () => {
     expect(output2).toBe('-34.57%');
   });
 
+  it('should display a negative percentage average and thousand separator when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsPercentageFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678%');
+    expect(output2).toBe('-345,678.57%');
+    expect(output3).toBe('-345_678,57%');
+  });
+
   it('should display a negative percentage average with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { avg: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
@@ -53,7 +65,19 @@ describe('avgTotalsPercentageFormatter', () => {
     expect(output2).toBe('(34.57%)');
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative percentage average and thousand separator with parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsPercentageFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678%)');
+    expect(output2).toBe('(345,678.57%)');
+    expect(output3).toBe('(345_678,57%)');
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
@@ -112,5 +136,21 @@ describe('avgTotalsPercentageFormatter', () => {
     expect(output1).toBe('Avg: 123.46%');
     expect(output2).toBe('345.2% (avg)');
     expect(output3).toBe('Avg: (2.450%)/item');
+  });
+
+  it('should display an average number with prefix, suffix and thousand separator', () => {
+    const totals = { avg: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = avgTotalsPercentageFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Avg: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (avg)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = avgTotalsPercentageFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Avg: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Avg: 12_345_678,46%');
+    expect(output2).toBe('345_678,2% (avg)');
+    expect(output3).toBe('Avg: (345_678,450%)/item');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/maxTotalsFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/maxTotalsFormatter.spec.ts
@@ -43,6 +43,18 @@ describe('maxTotalsFormatter', () => {
     expect(output2).toBe('-34.57');
   });
 
+  it('should display a negative maximum and thousand separator when its input is negative', () => {
+    const totals = { max: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = maxTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
   it('should display a negative maximum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { max: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
@@ -53,7 +65,19 @@ describe('maxTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative maximum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { max: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = maxTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345_678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { max: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('maxTotalsFormatter', () => {
     expect(output1).toBe('Max: 123.46');
     expect(output2).toBe('345.2 (max)');
     expect(output3).toBe('Max: (2.450)/item');
+  });
+
+  it('should display a max number with prefix, suffix and thousand separator', () => {
+    const totals = { max: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = maxTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Max: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (max)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = maxTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Max: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Max: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (max)');
+    expect(output3).toBe('Max: (345_678,450)/item');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/minTotalsFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/minTotalsFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('minTotalsFormatter', () => {
     expect(output2).toBe('-34.57');
   });
 
-  it('should display a negative number with parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative minimum and thousand separator when its input is negative', () => {
+    const totals = { min: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
+  it('should display a negative minimum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { min: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('minTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative minimum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { min: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345_678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { min: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('minTotalsFormatter', () => {
     expect(output1).toBe('min: 123.46');
     expect(output2).toBe('345.2 (max)');
     expect(output3).toBe('min: (2.450)/item');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { min: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Min: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (min)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = minTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Min: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Min: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (min)');
+    expect(output3).toBe('Min: (345_678,450)/item');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsBoldFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsBoldFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsBoldFormatter', () => {
     expect(output2).toBe('<b>-34.57</b>');
   });
 
-  it('should display a negative maximum with parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>-12,345,678</b>');
+    expect(output2).toBe('<b>-345,678.57</b>');
+    expect(output3).toBe('<b>-345_678,57</b>');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsBoldFormatter', () => {
     expect(output2).toBe('<b>(34.57)</b>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>(12,345,678)</b>');
+    expect(output2).toBe('<b>(345,678.57)</b>');
+    expect(output3).toBe('<b>(345_678,57)</b>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -109,18 +133,34 @@ describe('sumTotalsBoldFormatter', () => {
   it('should display a sum number a prefix and suffix', () => {
     const totals = { sum: { column1: 123.45678, column2: 345.2, column3: -2.45 } };
 
-    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'sum: ' } } as Column, {});
-    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (max)' } } as Column, {});
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)' } } as Column, {});
     const output3 = sumTotalsBoldFormatter(
       totals, {
         id: 'column3',
         field: 'column3',
-        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'sum: ', groupFormatterSuffix: '/item' }
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item' }
       } as Column
     );
 
-    expect(output1).toBe('<b>sum: 123.46</b>');
-    expect(output2).toBe('<b>345.2 (max)</b>');
-    expect(output3).toBe('<b>sum: (2.450)/item</b>');
+    expect(output1).toBe('<b>Sum: 123.46</b>');
+    expect(output2).toBe('<b>345.2 (sum)</b>');
+    expect(output3).toBe('<b>Sum: (2.450)/item</b>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsBoldFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<b>Sum: 12_345_678,46</b>');
+    expect(output2).toBe('<b>345_678,2 (sum)</b>');
+    expect(output3).toBe('<b>Sum: (345_678,450)/item</b>');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsColoredFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsColoredFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">-34.57</span>');
   });
 
-  it('should display a negative sum in red with parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsColoredFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">-12,345,678</span>');
+    expect(output2).toBe('<span style="color:red">-345,678.57</span>');
+    expect(output3).toBe('<span style="color:red">-345_678,57</span>');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsColoredFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">(34.57)</span>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsColoredFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">(12,345,678)</span>');
+    expect(output2).toBe('<span style="color:red">(345,678.57)</span>');
+    expect(output3).toBe('<span style="color:red">(345_678,57)</span>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsColoredFormatter', () => {
     expect(output1).toBe('<span style="color:green">sum: 123.46</span>');
     expect(output2).toBe('<span style="color:green">345.2 (max)</span>');
     expect(output3).toBe('<span style="color:red">sum: (2.450)/item</span>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsColoredFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsColoredFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<span style="color:green">Sum: 12_345_678,46</span>');
+    expect(output2).toBe('<span style="color:green">345_678,2 (sum)</span>');
+    expect(output3).toBe('<span style="color:red">Sum: (345_678,450)/item</span>');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarBoldFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarBoldFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarBoldFormatter', () => {
     expect(output2).toBe('<b>-$34.57</b>');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>-$12,345,678.00</b>');
+    expect(output2).toBe('<b>-$345,678.57</b>');
+    expect(output3).toBe('<b>-$345_678,57</b>');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarBoldFormatter', () => {
     expect(output2).toBe('<b>($34.57)</b>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>($12,345,678.00)</b>');
+    expect(output2).toBe('<b>($345,678.57)</b>');
+    expect(output3).toBe('<b>($345_678,57)</b>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarBoldFormatter', () => {
     expect(output1).toBe('<b>sum: $123.46</b>');
     expect(output2).toBe('<b>$345.2 (max)</b>');
     expect(output3).toBe('<b>sum: ($2.450)/item</b>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarBoldFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<b>Sum: $12_345_678,46</b>');
+    expect(output2).toBe('<b>$345_678,2 (sum)</b>');
+    expect(output3).toBe('<b>Sum: ($345_678,450)/item</b>');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredBoldFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredBoldFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarColoredBoldFormatter', () => {
     expect(output2).toBe('<span style="color:red; font-weight: bold;">-$34.57</span>');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red; font-weight: bold;">-$12,345,678.00</span>');
+    expect(output2).toBe('<span style="color:red; font-weight: bold;">-$345,678.57</span>');
+    expect(output3).toBe('<span style="color:red; font-weight: bold;">-$345_678,57</span>');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarColoredBoldFormatter', () => {
     expect(output2).toBe('<span style="color:red; font-weight: bold;">($34.57)</span>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red; font-weight: bold;">($12,345,678.00)</span>');
+    expect(output2).toBe('<span style="color:red; font-weight: bold;">($345,678.57)</span>');
+    expect(output3).toBe('<span style="color:red; font-weight: bold;">($345_678,57)</span>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarColoredBoldFormatter', () => {
     expect(output1).toBe('<span style="color:green; font-weight: bold;">sum: $123.46</span>');
     expect(output2).toBe('<span style="color:green; font-weight: bold;">$345.2 (max)</span>');
     expect(output3).toBe('<span style="color:red; font-weight: bold;">sum: ($2.450)/item</span>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarColoredBoldFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<span style="color:green; font-weight: bold;">Sum: $12_345_678,46</span>');
+    expect(output2).toBe('<span style="color:green; font-weight: bold;">$345_678,2 (sum)</span>');
+    expect(output3).toBe('<span style="color:red; font-weight: bold;">Sum: ($345_678,450)/item</span>');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">-$34.57</span>');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">-$12,345,678.00</span>');
+    expect(output2).toBe('<span style="color:red">-$345,678.57</span>');
+    expect(output3).toBe('<span style="color:red">-$345_678,57</span>');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">($34.57)</span>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">($12,345,678.00)</span>');
+    expect(output2).toBe('<span style="color:red">($345,678.57)</span>');
+    expect(output3).toBe('<span style="color:red">($345_678,57)</span>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarColoredFormatter', () => {
     expect(output1).toBe('<span style="color:green">sum: $123.46</span>');
     expect(output2).toBe('<span style="color:green">$345.2 (max)</span>');
     expect(output3).toBe('<span style="color:red">sum: ($2.450)/item</span>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarColoredFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<span style="color:green">Sum: $12_345_678,46</span>');
+    expect(output2).toBe('<span style="color:green">$345_678,2 (sum)</span>');
+    expect(output3).toBe('<span style="color:red">Sum: ($345_678,450)/item</span>');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsDollarFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarFormatter', () => {
     expect(output2).toBe('-$34.57');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-$12,345,678.00');
+    expect(output2).toBe('-$345,678.57');
+    expect(output3).toBe('-$345_678,57');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarFormatter', () => {
     expect(output2).toBe('($34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('($12,345,678.00)');
+    expect(output2).toBe('($345,678.57)');
+    expect(output3).toBe('($345_678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarFormatter', () => {
     expect(output1).toBe('sum: $123.46');
     expect(output2).toBe('$345.2 (max)');
     expect(output3).toBe('sum: ($2.450)/item');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Sum: $12_345_678,46');
+    expect(output2).toBe('$345_678,2 (sum)');
+    expect(output3).toBe('Sum: ($345_678,450)/item');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/__tests__/sumTotalsFormatter.spec.ts
@@ -38,12 +38,26 @@ describe('sumTotalsFormatter', () => {
 
     const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1' } as Column, {});
     const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2 } } as Column, {});
+    const output3 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',' } } as Column, {});
 
     expect(output1).toBe('-123');
     expect(output2).toBe('-34.57');
+    expect(output3).toBe('-34,57');
   });
 
-  it('should display a negative maximum with parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +67,19 @@ describe('sumTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345 678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -112,5 +138,21 @@ describe('sumTotalsFormatter', () => {
     expect(output1).toBe('sum: 123.46');
     expect(output2).toBe('345.2 (max)');
     expect(output3).toBe('sum: (2.450)/item');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Sum: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (sum)');
+    expect(output3).toBe('Sum: (345_678,450)/item');
   });
 });

--- a/src/app/modules/angular-slickgrid/grouping-formatters/avgTotalsDollarFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/avgTotalsDollarFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const avgTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const avgTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, colu
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/avgTotalsFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/avgTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
-import { decimalFormatted } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { decimalFormatted, thousandSeparatorFormatted } from '../services/utilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,9 +8,11 @@ export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   let prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     if (val < 0) {
@@ -19,16 +21,18 @@ export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
         prefix += '-';
       } else {
         if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-          return `${prefix}(${Math.round(val)})${suffix}`;
+          const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+          return `${prefix}(${outputVal})${suffix}`;
         }
-        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal)})${suffix}`;
+        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)})${suffix}`;
       }
     }
 
     if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-      return `${prefix}${Math.round(val)}${suffix}`;
+      const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+      return `${prefix}${outputVal}${suffix}`;
     }
-    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal)}${suffix}`;
+    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${suffix}`;
   }
   return '';
 };

--- a/src/app/modules/angular-slickgrid/grouping-formatters/avgTotalsPercentageFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/avgTotalsPercentageFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
-import { decimalFormatted } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { decimalFormatted, thousandSeparatorFormatted } from '../services/utilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,9 +8,11 @@ export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, 
   const params = columnDef && columnDef.params;
   let prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     if (val < 0) {
@@ -19,16 +21,18 @@ export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, 
         prefix += '-';
       } else {
         if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-          return `${prefix}(${Math.round(val)}%)${suffix}`;
+          const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+          return `${prefix}(${outputVal}%)${suffix}`;
         }
-        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal)}%)${suffix}`;
+        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}%)${suffix}`;
       }
     }
 
     if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-      return `${prefix}${Math.round(val)}%${suffix}`;
+      const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+      return `${prefix}${outputVal}%${suffix}`;
     }
-    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal)}%${suffix}`;
+    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}%${suffix}`;
   }
   return '';
 };

--- a/src/app/modules/angular-slickgrid/grouping-formatters/maxTotalsFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/maxTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const maxTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const maxTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/minTotalsFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/minTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const minTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const minTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsBoldFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsBoldFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsBoldFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsBoldFormatter: GroupTotalsFormatter = (totals: any, column
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `<b>${prefix}${formattedNumber}${suffix}</b>`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsColoredFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsColoredFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsColoredFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,13 +8,15 @@ export const sumTotalsColoredFormatter: GroupTotalsFormatter = (totals: any, col
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     const colorStyle = (val >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}">${prefix}${formattedNumber}${suffix}</span>`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarBoldFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarBoldFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarBoldFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsDollarBoldFormatter: GroupTotalsFormatter = (totals: any, 
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<b>${prefix}${formattedNumber}${suffix}</b>`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarColoredBoldFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarColoredBoldFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarColoredBoldFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,13 +8,15 @@ export const sumTotalsDollarColoredBoldFormatter: GroupTotalsFormatter = (totals
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     const colorStyle = (val >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}; font-weight: bold;">${prefix}${formattedNumber}${suffix}</span>`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarColoredFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarColoredFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarColoredFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,13 +8,15 @@ export const sumTotalsDollarColoredFormatter: GroupTotalsFormatter = (totals: an
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     const colorStyle = (val >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}">${prefix}${formattedNumber}${suffix}</span>`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsDollarFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, colu
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsFormatter.ts
+++ b/src/app/modules/angular-slickgrid/grouping-formatters/sumTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/app/modules/angular-slickgrid/models/formatterOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/formatterOption.interface.ts
@@ -1,6 +1,9 @@
 export interface FormatterOption {
   /** What separator to use to display a Date, for example using "." it could be "2002.01.01" */
-  dateSeparator?: '/' | '-' | '.' | ' ';
+  dateSeparator?: '/' | '-' | '.' | ' ' | '';
+
+  /** Defaults to dot ".", separator to use as the decimal separator, example $123.55 or $123,55 */
+  decimalSeparator?: '.' | ',';
 
   /** Defaults to false, option to display negative numbers wrapped in parentheses, example: -$12.50 becomes ($12.50) */
   displayNegativeNumberWithParentheses?: boolean;
@@ -10,4 +13,7 @@ export interface FormatterOption {
 
   /** Defaults to undefined, maximum number of decimals */
   maxDecimal?: number;
+
+  /** Defaults to empty string, thousand separator on a number. Example: 12345678 becomes 12,345,678 */
+  thousandSeparator?: ',' | '_' | '.' | ' ' | '';
 }

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -173,7 +173,7 @@ export function findOrDefault(array: any[], logic: (item: any) => boolean, defau
   * @param minDecimal
   * @param maxDecimal
   */
-export function decimalFormatted(input: number | string, minDecimal?: number, maxDecimal?: number): string {
+export function decimalFormatted(input: number | string, minDecimal?: number, maxDecimal?: number, decimalSeparator: '.' | ',' = '.', thousandSeparator: ',' | '_' | '.' | ' ' | '' = ''): string {
   if (isNaN(+input)) {
     return input as string;
   }
@@ -188,10 +188,20 @@ export function decimalFormatted(input: number | string, minDecimal?: number, ma
   while ((amount.length - amount.indexOf('.')) <= minDec) {
     amount += '0';
   }
+
+  // do we want to display our number with a custom separator in each thousand position
+  if (thousandSeparator) {
+    amount = thousandSeparatorFormatted(amount, thousandSeparator);
+  }
+
+  // when using a separator that is not a dot, replace it with the new separator
+  if (decimalSeparator !== '.') {
+    amount = amount.replace('.', decimalSeparator);
+  }
   return amount;
 }
 
-export function formatNumber(input: number | string, minDecimal?: number, maxDecimal?: number, displayNegativeNumberWithParentheses?: boolean, symbolPrefix = '', symbolSuffix = ''): string {
+export function formatNumber(input: number | string, minDecimal?: number, maxDecimal?: number, displayNegativeNumberWithParentheses?: boolean, symbolPrefix = '', symbolSuffix = '', decimalSeparator: '.' | ',' = '.', thousandSeparator: ',' | '_' | '.' | ' ' | '' = ''): string {
   if (isNaN(+input)) {
     return input as string;
   }
@@ -202,20 +212,23 @@ export function formatNumber(input: number | string, minDecimal?: number, maxDec
     const absValue = Math.abs(calculatedValue);
     if (displayNegativeNumberWithParentheses) {
       if (!isNaN(minDecimal) || !isNaN(maxDecimal)) {
-        return `(${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal)}${symbolSuffix})`;
+        return `(${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${symbolSuffix})`;
       }
-      return `(${symbolPrefix}${absValue}${symbolSuffix})`;
+      const formattedValue = thousandSeparatorFormatted(`${absValue}`, thousandSeparator);
+      return `(${symbolPrefix}${formattedValue}${symbolSuffix})`;
     } else {
       if (!isNaN(minDecimal) || !isNaN(maxDecimal)) {
-        return `-${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal)}${symbolSuffix}`;
+        return `-${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${symbolSuffix}`;
       }
-      return `-${symbolPrefix}${absValue}${symbolSuffix}`;
+      const formattedValue = thousandSeparatorFormatted(`${absValue}`, thousandSeparator);
+      return `-${symbolPrefix}${formattedValue}${symbolSuffix}`;
     }
   } else {
     if (!isNaN(minDecimal) || !isNaN(maxDecimal)) {
-      return `${symbolPrefix}${decimalFormatted(input, minDecimal, maxDecimal)}${symbolSuffix}`;
+      return `${symbolPrefix}${decimalFormatted(input, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${symbolSuffix}`;
     }
-    return `${symbolPrefix}${input}${symbolSuffix}`;
+    const formattedValue = thousandSeparatorFormatted(`${input}`, thousandSeparator);
+    return `${symbolPrefix}${formattedValue}${symbolSuffix}`;
   }
 }
 
@@ -589,6 +602,21 @@ export function setDeepValue(obj: any, path: string | string[], value: any) {
   } else {
     obj[path[0]] = value;
   }
+}
+
+/**
+ * Format a number or a string into a string that is separated every thousand,
+ * the default separator is a comma but user can optionally pass a different one
+ * @param inputValue
+ * @param separator default to comma ","
+ * @returns string
+ */
+export function thousandSeparatorFormatted(inputValue: string | number | null, separator: ',' | '_' | '.' | ' ' | '' = ','): string | null {
+  if (inputValue !== null && inputValue !== undefined) {
+    const stringValue = `${inputValue}`;
+    return stringValue.replace(/(?<!\.\d+)\B(?=(\d{3})+\b)/g, separator);
+  }
+  return inputValue as null;
 }
 
 /**


### PR DESCRIPTION
- add possibility to use a custom decimal and/or thousand separator(s) to all Formatters and Grouping Formatters that can use it

For example 
```ts
loadGrid() {
  this.columnDefinitions = [ 
    // through the column definition "params"
    { id: 'price', field: 'price', params: { thousandSeparator: ',' } },
  ];

  this.gridOptions = {
    // you customize the date separator through "formatterOptions"
    formatterOptions: {
      // Defaults to dot ".", separator to use as the decimal separator, example $123.55 or $123,55
      decimalSeparator: ',', // can be any of '.' | ','

      // Defaults to empty string, thousand separator on a number. Example: 12345678 becomes 12,345,678
      thousandSeparator: ',', // can be any of ',' | '_' | ' ' | ''
    },
  }
}
```