### PR TITLE
feat(filters): provide method to apply grid filters dynamically

### DIFF
--- a/src/app/examples/custom-angularComponentFilter.ts
+++ b/src/app/examples/custom-angularComponentFilter.ts
@@ -111,9 +111,7 @@ export class CustomAngularComponentFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values) {
     if (this.componentRef && this.componentRef.instance && this.componentRef.instance.hasOwnProperty('selectedId')) {
       this.componentRef.instance.selectedId = values;

--- a/src/app/examples/custom-inputFilter.ts
+++ b/src/app/examples/custom-inputFilter.ts
@@ -95,9 +95,7 @@ export class CustomInputFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values) {
     if (values) {
       this.$filterElm.val(values);

--- a/src/app/examples/grid-clientside.component.html
+++ b/src/app/examples/grid-clientside.component.html
@@ -9,7 +9,7 @@
   </span>
   <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
   <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
-  <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Some Filters</button>
+  <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Filters Dynamically</button>
 
   <angular-slickgrid gridId="grid2" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
     [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"

--- a/src/app/examples/grid-clientside.component.html
+++ b/src/app/examples/grid-clientside.component.html
@@ -9,7 +9,7 @@
   </span>
   <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
   <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
-  <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Filters Dynamically</button>
+  <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
 
   <angular-slickgrid gridId="grid2" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
     [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"

--- a/src/app/examples/grid-clientside.component.html
+++ b/src/app/examples/grid-clientside.component.html
@@ -9,14 +9,11 @@
   </span>
   <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
   <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Some Filters</button>
 
-  <angular-slickgrid gridId="grid2"
-                     [columnDefinitions]="columnDefinitions"
-                     [gridOptions]="gridOptions"
-                     [dataset]="dataset"
-                     (onAngularGridCreated)="angularGridReady($event)"
-                     (onGridStateChanged)="gridStateChanged($event)"
-                     (onBeforeGridDestroy)="saveCurrentGridState($event)"
-                     (sgOnRowCountChanged)="refreshMetrics($event.detail.eventData, $event.detail.args)">
+  <angular-slickgrid gridId="grid2" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
+    [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"
+    (onGridStateChanged)="gridStateChanged($event)" (onBeforeGridDestroy)="saveCurrentGridState($event)"
+    (sgOnRowCountChanged)="refreshMetrics($event.detail.eventData, $event.detail.args)">
   </angular-slickgrid>
 </div>

--- a/src/app/examples/grid-clientside.component.html
+++ b/src/app/examples/grid-clientside.component.html
@@ -9,9 +9,11 @@
   </span>
   <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
   <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
-  <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
+    Set Filters Dynamically
+  </button>
 
-  <angular-slickgrid gridId="grid2" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
+  <angular-slickgrid gridId="grid4" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
     [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"
     (onGridStateChanged)="gridStateChanged($event)" (onBeforeGridDestroy)="saveCurrentGridState($event)"
     (sgOnRowCountChanged)="refreshMetrics($event.detail.eventData, $event.detail.args)">

--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -19,7 +19,7 @@ import {
 function randomBetween(min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
-const NB_ITEMS = 1000;
+const NB_ITEMS = 1500;
 const URL_SAMPLE_COLLECTION_DATA = 'assets/data/collection_500_numbers.json';
 
 @Component({
@@ -252,8 +252,10 @@ export class GridClientSideComponent implements OnInit {
   setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
-      { columnId: 'duration', searchTerms: [10, 220] },
-      { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },
+      { columnId: 'duration', searchTerms: [2, 25, 48, 50] },
+      { columnId: 'complete', searchTerms: [95], operator: '<' },
+      { columnId: 'effort-driven', searchTerms: [true] },
+      { columnId: 'start', operator: '>=', searchTerms: ['2001-02-28'] },
     ]);
   }
 

--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -250,7 +250,7 @@ export class GridClientSideComponent implements OnInit {
   }
 
   setSomeFilters() {
-    // we can Set Some Filters (or different filters) afterward through the FilterService
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       { columnId: 'duration', searchTerms: [10, 220] },
       { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },

--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -258,12 +258,12 @@ export class GridClientSideComponent implements OnInit {
   }
 
   refreshMetrics(e, args) {
-    if (args && args.current > 0) {
+    if (args && args.current >= 0) {
       setTimeout(() => {
         this.metrics = {
           startTime: new Date(),
-          itemCount: args && args.current,
-          totalItemCount: this.dataset.length
+          itemCount: args && args.current || 0,
+          totalItemCount: this.dataset.length || 0
         };
       });
     }

--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -249,7 +249,7 @@ export class GridClientSideComponent implements OnInit {
     console.log('Client sample, last Grid State:: ', this.angularGrid.gridStateService.getCurrentGridState());
   }
 
-  setSomeFilters() {
+  setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       { columnId: 'duration', searchTerms: [10, 220] },

--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -19,7 +19,7 @@ import {
 function randomBetween(min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
-const NB_ITEMS = 500;
+const NB_ITEMS = 1000;
 const URL_SAMPLE_COLLECTION_DATA = 'assets/data/collection_500_numbers.json';
 
 @Component({
@@ -209,8 +209,8 @@ export class GridClientSideComponent implements OnInit {
     const tempDataset = [];
     for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
       const randomDuration = Math.round(Math.random() * 100);
-      const randomYear = randomBetween(2000, 2025);
-      const randomYearShort = randomBetween(10, 25);
+      const randomYear = randomBetween(2000, 2035);
+      const randomYearShort = randomBetween(10, 35);
       const randomMonth = randomBetween(1, 12);
       const randomMonthStr = (randomMonth < 10) ? `0${randomMonth}` : randomMonth;
       const randomDay = randomBetween(10, 28);
@@ -247,6 +247,14 @@ export class GridClientSideComponent implements OnInit {
   /** Save current Filters, Sorters in LocaleStorage or DB */
   saveCurrentGridState(grid) {
     console.log('Client sample, last Grid State:: ', this.angularGrid.gridStateService.getCurrentGridState());
+  }
+
+  setSomeFilters() {
+    // we can Set Some Filters (or different filters) afterward through the FilterService
+    this.angularGrid.filterService.updateFilters([
+      { columnId: 'duration', searchTerms: [10, 220] },
+      { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },
+    ]);
   }
 
   refreshMetrics(e, args) {

--- a/src/app/examples/grid-draggrouping.component.html
+++ b/src/app/examples/grid-draggrouping.component.html
@@ -1,67 +1,67 @@
 <div class="container-fluid">
-    <h2>{{title}}</h2>
-    <div class="subtitle" [innerHTML]="subTitle"></div>
+  <h2>{{title}}</h2>
+  <div class="subtitle" [innerHTML]="subTitle"></div>
 
-    <form>
-        <div class="row col-sm-12">
-          <button class="btn btn-default btn-xs" (click)="loadData(500)">
-            500 rows
-          </button>
-          <button class="btn btn-default btn-xs" (click)="loadData(50000)">
-            50k rows
-          </button>
-          <button class="btn btn-default btn-xs" (click)="clearGroupsAndSelects()">
-            <i class="fa fa-times"></i> Clear grouping
-          </button>
-          <button class="btn btn-default btn-xs" (click)="collapseAllGroups()">
-            <i class="fa fa-compress"></i> Collapse all groups
-          </button>
-          <button class="btn btn-default btn-xs" (click)="expandAllGroups()">
-            <i class="fa fa-expand"></i> Expand all groups
-          </button>
-          <button class="btn btn-default btn-xs" (click)="toggleDraggableGroupingRow()">
-            Toggle Draggable Grouping Row
-          </button>
-          <button class="btn btn-default btn-xs" (click)="exportToExcel()">
-              <i class="fa fa-file-excel-o text-success"></i> Export to Excel
-            </button>
-        </div>
-
-        <div class="row col-sm-12">
-          <button class="btn btn-default btn-xs" (click)="groupByDurationOrderByCount(false)">
-            Group by duration &amp; sort groups by value
-          </button>
-          <button class="btn btn-default btn-xs" (click)="groupByDurationOrderByCount(true)">
-            Group by duration &amp; sort groups by count
-          </button>
-          <button class="btn btn-default btn-xs" (click)="groupByDurationEffortDriven()">
-            Group by Duration then Effort-Driven
-          </button>
-        </div>
-        <div class="col-sm-12">
-            <br>
-        </div>
-        <div class="row col-sm-12">
-            <div class="form-group">
-                <label for="field1" class="col-sm-2 control-label">Group by field(s)</label>
-                <div class="col-sm-3" *ngFor="let groupField of selectedGroupingFields; let i = index; trackBy: selectTrackByFn">
-                    <select class="form-control col-sm-6" name="groupField{{i}}" [(ngModel)]="selectedGroupingFields[i]" (ngModelChange)="groupByFieldName($event, i)">
-                        <option value=""></option>
-                        <option [ngValue]="field.id" *ngFor="let field of columnDefinitions">{{field.name}}</option>
-                    </select>
-                </div>
-            </div>
-        </div>
-    </form>
-
-    <div class="col-sm-12">
-      <hr>
+  <form>
+    <div class="row col-sm-12">
+      <button class="btn btn-default btn-xs" (click)="loadData(500)">
+        500 rows
+      </button>
+      <button class="btn btn-default btn-xs" (click)="loadData(50000)">
+        50k rows
+      </button>
+      <button class="btn btn-default btn-xs" (click)="clearGroupsAndSelects()">
+        <i class="fa fa-times"></i> Clear grouping
+      </button>
+      <button class="btn btn-default btn-xs" (click)="collapseAllGroups()">
+        <i class="fa fa-compress"></i> Collapse all groups
+      </button>
+      <button class="btn btn-default btn-xs" (click)="expandAllGroups()">
+        <i class="fa fa-expand"></i> Expand all groups
+      </button>
+      <button class="btn btn-default btn-xs" (click)="toggleDraggableGroupingRow()">
+        Toggle Draggable Grouping Row
+      </button>
+      <button class="btn btn-default btn-xs" (click)="exportToExcel()">
+        <i class="fa fa-file-excel-o text-success"></i> Export to Excel
+      </button>
+      <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Filters Dynamically</button>
     </div>
 
-    <angular-slickgrid gridId="grid19"
-        [dataset]="dataset"
-        [columnDefinitions]="columnDefinitions"
-        [gridOptions]="gridOptions"
-        (onAngularGridCreated)="angularGridReady($event)">
-    </angular-slickgrid>
+    <div class="row col-sm-12">
+      <button class="btn btn-default btn-xs" (click)="groupByDurationOrderByCount(false)">
+        Group by duration &amp; sort groups by value
+      </button>
+      <button class="btn btn-default btn-xs" (click)="groupByDurationOrderByCount(true)">
+        Group by duration &amp; sort groups by count
+      </button>
+      <button class="btn btn-default btn-xs" (click)="groupByDurationEffortDriven()">
+        Group by Duration then Effort-Driven
+      </button>
+    </div>
+    <div class="col-sm-12">
+      <br>
+    </div>
+    <div class="row col-sm-12">
+      <div class="form-group">
+        <label for="field1" class="col-sm-2 control-label">Group by field(s)</label>
+        <div class="col-sm-3"
+          *ngFor="let groupField of selectedGroupingFields; let i = index; trackBy: selectTrackByFn">
+          <select class="form-control col-sm-6" name="groupField{{i}}" [(ngModel)]="selectedGroupingFields[i]"
+            (ngModelChange)="groupByFieldName($event, i)">
+            <option value=""></option>
+            <option [ngValue]="field.id" *ngFor="let field of columnDefinitions">{{field.name}}</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </form>
+
+  <div class="col-sm-12">
+    <hr>
+  </div>
+
+  <angular-slickgrid gridId="grid19" [dataset]="dataset" [columnDefinitions]="columnDefinitions"
+    [gridOptions]="gridOptions" (onAngularGridCreated)="angularGridReady($event)">
+  </angular-slickgrid>
 </div>

--- a/src/app/examples/grid-draggrouping.component.html
+++ b/src/app/examples/grid-draggrouping.component.html
@@ -25,7 +25,7 @@
       <button class="btn btn-default btn-xs" (click)="exportToExcel()">
         <i class="fa fa-file-excel-o text-success"></i> Export to Excel
       </button>
-      <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Filters Dynamically</button>
+      <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
     </div>
 
     <div class="row col-sm-12">

--- a/src/app/examples/grid-draggrouping.component.html
+++ b/src/app/examples/grid-draggrouping.component.html
@@ -25,7 +25,6 @@
       <button class="btn btn-default btn-xs" (click)="exportToExcel()">
         <i class="fa fa-file-excel-o text-success"></i> Export to Excel
       </button>
-      <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
     </div>
 
     <div class="row col-sm-12">
@@ -37,6 +36,9 @@
       </button>
       <button class="btn btn-default btn-xs" (click)="groupByDurationEffortDriven()">
         Group by Duration then Effort-Driven
+      </button>
+      <button class="btn btn-default btn-xs" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
+        Set Filters Dynamically
       </button>
     </div>
     <div class="col-sm-12">

--- a/src/app/examples/grid-draggrouping.component.ts
+++ b/src/app/examples/grid-draggrouping.component.ts
@@ -369,7 +369,8 @@ export class GridDraggableGroupingComponent implements OnInit {
   setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
-      { columnId: 'percentComplete', operator: '>=', searchTerms: ['75'] },
+      { columnId: 'percentComplete', operator: '>=', searchTerms: ['55'] },
+      { columnId: 'cost', operator: '<', searchTerms: ['80'] },
     ]);
   }
 }

--- a/src/app/examples/grid-draggrouping.component.ts
+++ b/src/app/examples/grid-draggrouping.component.ts
@@ -292,7 +292,7 @@ export class GridDraggableGroupingComponent implements OnInit {
       format: FileType.xlsx
     });
   }
-  
+
   exportToCsv(type = 'csv') {
     this.angularGrid.exportService.exportToFile({
       delimiter: (type === 'csv') ? DelimiterType.comma : DelimiterType.tab,
@@ -364,5 +364,12 @@ export class GridDraggableGroupingComponent implements OnInit {
   toggleDraggableGroupingRow() {
     this.clearGrouping();
     this.gridObj.setPreHeaderPanelVisibility(!this.gridObj.getOptions().showPreHeaderPanel);
+  }
+
+  setSomeFilters() {
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.angularGrid.filterService.updateFilters([
+      { columnId: 'percentComplete', operator: '>=', searchTerms: ['75'] },
+    ]);
   }
 }

--- a/src/app/examples/grid-draggrouping.component.ts
+++ b/src/app/examples/grid-draggrouping.component.ts
@@ -366,7 +366,7 @@ export class GridDraggableGroupingComponent implements OnInit {
     this.gridObj.setPreHeaderPanelVisibility(!this.gridObj.getOptions().showPreHeaderPanel);
   }
 
-  setSomeFilters() {
+  setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       { columnId: 'percentComplete', operator: '>=', searchTerms: ['75'] },

--- a/src/app/examples/grid-graphql.component.html
+++ b/src/app/examples/grid-graphql.component.html
@@ -34,7 +34,7 @@
         <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
           <i class="fa fa-caret-right fa-lg"></i>
         </button>
-        <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Some Filters</button>
+        <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Filters Dynamically</button>
       </div>
     </div>
     <div class="col-sm-7">

--- a/src/app/examples/grid-graphql.component.html
+++ b/src/app/examples/grid-graphql.component.html
@@ -15,7 +15,7 @@
         <i class="fa fa-filter text-danger"></i>
         Clear all Filter & Sorts
       </button>
-      <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">
+      <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
         Set Filters Dynamically
       </button>
       <button class="btn btn-default btn-sm" (click)="switchLanguage()">

--- a/src/app/examples/grid-graphql.component.html
+++ b/src/app/examples/grid-graphql.component.html
@@ -15,6 +15,9 @@
         <i class="fa fa-filter text-danger"></i>
         Clear all Filter & Sorts
       </button>
+      <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">
+        Set Filters Dynamically
+      </button>
       <button class="btn btn-default btn-sm" (click)="switchLanguage()">
         <i class="fa fa-language"></i>
         Switch Language
@@ -34,7 +37,6 @@
         <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
           <i class="fa fa-caret-right fa-lg"></i>
         </button>
-        <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Filters Dynamically</button>
       </div>
     </div>
     <div class="col-sm-7">

--- a/src/app/examples/grid-graphql.component.html
+++ b/src/app/examples/grid-graphql.component.html
@@ -34,6 +34,7 @@
         <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
           <i class="fa fa-caret-right fa-lg"></i>
         </button>
+        <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Some Filters</button>
       </div>
     </div>
     <div class="col-sm-7">
@@ -45,8 +46,7 @@
   </div>
 
   <angular-slickgrid gridId="grid6" [gridHeight]="200" [gridWidth]="900" [columnDefinitions]="columnDefinitions"
-                     [gridOptions]="gridOptions" [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"
-                     (onGridStateChanged)="gridStateChanged($event)"
-                     (onBeforeGridDestroy)="saveCurrentGridState($event)">
+    [gridOptions]="gridOptions" [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"
+    (onGridStateChanged)="gridStateChanged($event)" (onBeforeGridDestroy)="saveCurrentGridState($event)">
   </angular-slickgrid>
 </div>

--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -66,7 +66,15 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.columnDefinitions = [
-      { id: 'name', field: 'name', headerKey: 'NAME', filterable: true, sortable: true, type: FieldType.string, width: 60 },
+      {
+        id: 'name', field: 'name', headerKey: 'NAME', width: 60,
+        type: FieldType.string,
+        sortable: true,
+        filterable: true,
+        filter: {
+          model: Filters.compoundInput
+        }
+      },
       {
         id: 'gender', field: 'gender', headerKey: 'GENDER', filterable: true, sortable: true, width: 60,
         filter: {
@@ -264,15 +272,16 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
     console.log('GraphQL current grid state', this.angularGrid.gridStateService.getCurrentGridState());
   }
 
-  setSomeFilters() {
+  setFiltersDynamically() {
     const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
     const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
 
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
-      { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
-      { columnId: 'name', searchTerms: ['John Doe'], operator: OperatorType.contains },
-      { columnId: 'company', searchTerms: ['xyz'], operator: 'IN' },
+      { columnId: 'gender', searchTerms: ['female'], operator: OperatorType.equal },
+      { columnId: 'name', searchTerms: ['Jane'], operator: OperatorType.startsWith },
+      { columnId: 'company', searchTerms: ['acme'], operator: 'IN' },
+      { columnId: 'billing.address.zip', searchTerms: ['11'], operator: OperatorType.greaterThanOrEqual },
       { columnId: 'finish', searchTerms: [presetLowestDay, presetHighestDay], operator: OperatorType.rangeInclusive },
     ]);
   }

--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -264,6 +264,19 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
     console.log('GraphQL current grid state', this.angularGrid.gridStateService.getCurrentGridState());
   }
 
+  setSomeFilters() {
+    const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
+    const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
+
+    // we can Set Some Filters (or different filters) afterward through the FilterService
+    this.angularGrid.filterService.updateFilters([
+      { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
+      { columnId: 'name', searchTerms: ['John Doe'], operator: OperatorType.contains },
+      { columnId: 'company', searchTerms: ['xyz'], operator: 'IN' },
+      { columnId: 'finish', searchTerms: [presetLowestDay, presetHighestDay], operator: OperatorType.rangeInclusive },
+    ]);
+  }
+
   switchLanguage() {
     this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
     this.translate.use(this.selectedLanguage);

--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -268,7 +268,7 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
     const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
     const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
 
-    // we can Set Some Filters (or different filters) afterward through the FilterService
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
       { columnId: 'name', searchTerms: ['John Doe'], operator: OperatorType.contains },

--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -94,9 +94,9 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
           } as MultipleSelectOption
         }
       },
-      { id: 'billing.address.street', field: 'billing.address.street', headerKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },
+      { id: 'billingAddressStreet', field: 'billing.address.street', headerKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },
       {
-        id: 'billing.address.zip', field: 'billing.address.zip', headerKey: 'BILLING.ADDRESS.ZIP', width: 60,
+        id: 'billingAddressZip', field: 'billing.address.zip', headerKey: 'BILLING.ADDRESS.ZIP', width: 60,
         type: FieldType.number,
         filterable: true, sortable: true,
         filter: {
@@ -150,8 +150,8 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
           { columnId: 'name', width: 100 },
           { columnId: 'gender', width: 55 },
           { columnId: 'company' },
-          { columnId: 'billing.address.zip' }, // flip column position of Street/Zip to Zip/Street
-          { columnId: 'billing.address.street', width: 120 },
+          { columnId: 'billingAddressZip' }, // flip column position of Street/Zip to Zip/Street
+          { columnId: 'billingAddressStreet', width: 120 },
           { columnId: 'finish', width: 130 },
         ],
         filters: [
@@ -281,7 +281,7 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
       { columnId: 'gender', searchTerms: ['female'], operator: OperatorType.equal },
       { columnId: 'name', searchTerms: ['Jane'], operator: OperatorType.startsWith },
       { columnId: 'company', searchTerms: ['acme'], operator: 'IN' },
-      { columnId: 'billing.address.zip', searchTerms: ['11'], operator: OperatorType.greaterThanOrEqual },
+      { columnId: 'billingAddressZip', searchTerms: ['11'], operator: OperatorType.greaterThanOrEqual },
       { columnId: 'finish', searchTerms: [presetLowestDay, presetHighestDay], operator: OperatorType.rangeInclusive },
     ]);
   }

--- a/src/app/examples/grid-headerbutton.component.ts
+++ b/src/app/examples/grid-headerbutton.component.ts
@@ -49,7 +49,6 @@ export class GridHeaderButtonComponent implements OnInit, OnDestroy {
       enableCellNavigation: true,
       headerButton: {
         onCommand: (e, args) => {
-          console.log(args)
           const column = args.column;
           const button = args.button;
           const command = args.command;

--- a/src/app/examples/grid-odata.component.html
+++ b/src/app/examples/grid-odata.component.html
@@ -14,6 +14,7 @@
         <b>Metrics:</b> {{metrics.endTime | date: 'yyyy-MM-dd HH:mm aaaaa\'m\''}} | {{metrics.executionTime}}ms
         | {{metrics.totalItemCount}} items
       </span>
+      <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
     </div>
     <div class="col-sm-8">
       <div class="alert alert-info" data-test="alert-odata-query">
@@ -46,7 +47,6 @@
     <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
       <i class="fa fa-caret-right fa-lg"></i>
     </button>
-    <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Filters Dynamically</button>
   </div>
 
   <angular-slickgrid gridId="grid5" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"

--- a/src/app/examples/grid-odata.component.html
+++ b/src/app/examples/grid-odata.component.html
@@ -46,7 +46,7 @@
     <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
       <i class="fa fa-caret-right fa-lg"></i>
     </button>
-    <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Some Filters</button>
+    <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Filters Dynamically</button>
   </div>
 
   <angular-slickgrid gridId="grid5" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"

--- a/src/app/examples/grid-odata.component.html
+++ b/src/app/examples/grid-odata.component.html
@@ -14,7 +14,9 @@
         <b>Metrics:</b> {{metrics.endTime | date: 'yyyy-MM-dd HH:mm aaaaa\'m\''}} | {{metrics.executionTime}}ms
         | {{metrics.totalItemCount}} items
       </span>
-      <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
+      <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
+        Set Filters Dynamically
+      </button>
     </div>
     <div class="col-sm-8">
       <div class="alert alert-info" data-test="alert-odata-query">

--- a/src/app/examples/grid-odata.component.html
+++ b/src/app/examples/grid-odata.component.html
@@ -24,16 +24,16 @@
       <span data-test="radioVersion">
         <label class="radio-inline control-label" for="radio2">
           <input type="radio" name="inlineRadioOptions" data-test="version2" id="radio2" checked [value]="2"
-                 (change)="setOdataVersion(2)"> 2
+            (change)="setOdataVersion(2)"> 2
         </label>
         <label class="radio-inline control-label" for="radio4">
           <input type="radio" name="inlineRadioOptions" data-test="version4" id="radio4" [value]="4"
-                 (change)="setOdataVersion(4)"> 4
+            (change)="setOdataVersion(4)"> 4
         </label>
       </span>
       <label class="checkbox-inline control-label" for="enableCount" style="margin-left: 20px">
         <input type="checkbox" id="enableCount" data-test="enable-count" [checked]="isCountEnabled"
-               (click)="changeCountEnableFlag()">
+          (click)="changeCountEnableFlag()">
         <span style="font-weight: bold">Enable Count</span> (add to OData query)
       </label>
     </div>
@@ -46,10 +46,11 @@
     <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
       <i class="fa fa-caret-right fa-lg"></i>
     </button>
+    <button class="btn btn-default btn-xs" (click)="setSomeFilters()">Set Some Filters</button>
   </div>
 
   <angular-slickgrid gridId="grid5" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
-                     [dataset]="dataset" (onGridStateChanged)="gridStateChanged($event)"
-                     (onAngularGridCreated)="angularGridReady($event)">
+    [dataset]="dataset" (onGridStateChanged)="gridStateChanged($event)"
+    (onAngularGridCreated)="angularGridReady($event)">
   </angular-slickgrid>
 </div>

--- a/src/app/examples/grid-odata.component.ts
+++ b/src/app/examples/grid-odata.component.ts
@@ -58,7 +58,8 @@ export class GridOdataComponent implements OnInit {
   ngOnInit(): void {
     this.columnDefinitions = [
       {
-        id: 'name', name: 'Name', field: 'name', sortable: true, type: FieldType.string,
+        id: 'name', name: 'Name', field: 'name', sortable: true,
+        type: FieldType.string,
         filterable: true,
         filter: {
           model: Filters.compoundInput
@@ -161,7 +162,7 @@ export class GridOdataComponent implements OnInit {
     this.angularGrid.paginationService.goToLastPage();
   }
 
-  setSomeFilters() {
+  setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       // { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },

--- a/src/app/examples/grid-odata.component.ts
+++ b/src/app/examples/grid-odata.component.ts
@@ -161,6 +161,14 @@ export class GridOdataComponent implements OnInit {
     this.angularGrid.paginationService.goToLastPage();
   }
 
+  setSomeFilters() {
+    // we can Set Some Filters (or different filters) afterward through the FilterService
+    this.angularGrid.filterService.updateFilters([
+      // { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
+      { columnId: 'name', searchTerms: ['A'], operator: 'a*' },
+    ]);
+  }
+
   /** This function is only here to mock a WebAPI call (since we are using a JSON file for the demo)
    *  in your case the getCustomer() should be a WebAPI function returning a Promise
    */

--- a/src/app/examples/grid-odata.component.ts
+++ b/src/app/examples/grid-odata.component.ts
@@ -162,7 +162,7 @@ export class GridOdataComponent implements OnInit {
   }
 
   setSomeFilters() {
-    // we can Set Some Filters (or different filters) afterward through the FilterService
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       // { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
       { columnId: 'name', searchTerms: ['A'], operator: 'a*' },

--- a/src/app/examples/grid-range.component.html
+++ b/src/app/examples/grid-range.component.html
@@ -1,34 +1,24 @@
 <div class="container-fluid">
   <h2>{{title}}</h2>
-  <div class="subtitle"
-       [innerHTML]="subTitle"></div>
+  <div class="subtitle" [innerHTML]="subTitle"></div>
 
   <br />
-  <span *ngIf="metrics"
-        style="margin-right: 10px">
+  <span *ngIf="metrics" style="margin-right: 10px">
     <b>Metrics:</b> {{metrics.startTime | date: 'yyyy-MM-dd HH:mm aaaaa\'m\''}} | {{metrics.itemCount}} of
     {{metrics.totalItemCount}} items
   </span>
-  <button class="btn btn-default btn-sm"
-          (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
-  <button class="btn btn-default btn-sm"
-          (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
-  <button class="btn btn-default btn-sm"
-          (click)="switchLanguage()"
-          data-test="language">
+  <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
+  <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" (click)="switchLanguage()" data-test="language">
     <i class="fa fa-language"></i>
     Switch Language
   </button>
-  <b>Locale:</b> <span style="font-style: italic"
-        data-test="selected-locale">{{selectedLanguage + '.json'}}</span>
+  <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Filters Dynamically</button>
+  <b>Locale:</b> <span style="font-style: italic" data-test="selected-locale">{{selectedLanguage + '.json'}}</span>
 
-  <angular-slickgrid gridId="grid25"
-                     [columnDefinitions]="columnDefinitions"
-                     [gridOptions]="gridOptions"
-                     [dataset]="dataset"
-                     (onAngularGridCreated)="angularGridReady($event)"
-                     (onGridStateChanged)="gridStateChanged($event)"
-                     (onBeforeGridDestroy)="saveCurrentGridState($event)"
-                     (sgOnRowCountChanged)="refreshMetrics($event.detail.eventData, $event.detail.args)">
+  <angular-slickgrid gridId="grid25" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
+    [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"
+    (onGridStateChanged)="gridStateChanged($event)" (onBeforeGridDestroy)="saveCurrentGridState($event)"
+    (sgOnRowCountChanged)="refreshMetrics($event.detail.eventData, $event.detail.args)">
   </angular-slickgrid>
 </div>

--- a/src/app/examples/grid-range.component.html
+++ b/src/app/examples/grid-range.component.html
@@ -9,7 +9,9 @@
   </span>
   <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
   <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
-  <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
+    Set Filters Dynamically
+  </button>
   <button class="btn btn-default btn-sm" (click)="switchLanguage()" data-test="language">
     <i class="fa fa-language"></i>
     Switch Language

--- a/src/app/examples/grid-range.component.html
+++ b/src/app/examples/grid-range.component.html
@@ -9,11 +9,11 @@
   </span>
   <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
   <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" (click)="setFiltersDynamically()">Set Filters Dynamically</button>
   <button class="btn btn-default btn-sm" (click)="switchLanguage()" data-test="language">
     <i class="fa fa-language"></i>
     Switch Language
   </button>
-  <button class="btn btn-default btn-sm" (click)="setSomeFilters()">Set Filters Dynamically</button>
   <b>Locale:</b> <span style="font-style: italic" data-test="selected-locale">{{selectedLanguage + '.json'}}</span>
 
   <angular-slickgrid gridId="grid25" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -228,4 +228,17 @@ export class GridRangeComponent implements OnInit {
     const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
     this.translate.use(nextLocale).subscribe(() => this.selectedLanguage = nextLocale);
   }
+
+  setSomeFilters() {
+    const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
+    const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
+
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.angularGrid.filterService.updateFilters([
+      { columnId: 'duration', searchTerms: ['14..78'] },
+      { columnId: 'complete', searchTerms: ['13..73'] }, // without operator will default to 'RangeExclusive'
+      { columnId: 'complete', operator: 'RangeInclusive', searchTerms: [12, 82] }, // same result with searchTerms: ['5..80']
+      { columnId: 'finish', operator: 'RangeInclusive', searchTerms: [presetLowestDay, presetHighestDay] },
+    ]);
+  }
 }

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -213,12 +213,12 @@ export class GridRangeComponent implements OnInit {
   }
 
   refreshMetrics(e, args) {
-    if (args && args.current > 0) {
+    if (args && args.current >= 0) {
       setTimeout(() => {
         this.metrics = {
           startTime: new Date(),
-          itemCount: args && args.current,
-          totalItemCount: this.dataset.length
+          itemCount: args && args.current || 0,
+          totalItemCount: this.dataset.length || 0
         };
       });
     }

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -17,7 +17,7 @@ import {
 } from '../modules/angular-slickgrid';
 import * as moment from 'moment-mini';
 
-const NB_ITEMS = 1200;
+const NB_ITEMS = 1500;
 
 function randomBetween(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1) + min);
@@ -230,14 +230,13 @@ export class GridRangeComponent implements OnInit {
   }
 
   setFiltersDynamically() {
-    const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
-    const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
+    const presetLowestDay = moment().add(-5, 'days').format('YYYY-MM-DD');
+    const presetHighestDay = moment().add(25, 'days').format('YYYY-MM-DD');
 
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
-      { columnId: 'duration', searchTerms: ['14..78'] },
-      { columnId: 'complete', searchTerms: ['13..73'] }, // without operator will default to 'RangeExclusive'
-      { columnId: 'complete', operator: 'RangeInclusive', searchTerms: [12, 82] }, // same result with searchTerms: ['5..80']
+      { columnId: 'duration', searchTerms: ['14..78'], operator: 'RangeInclusive' },
+      { columnId: 'complete', operator: 'RangeExclusive', searchTerms: [12, 82] },
       { columnId: 'finish', operator: 'RangeInclusive', searchTerms: [presetLowestDay, presetHighestDay] },
     ]);
   }

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -229,7 +229,7 @@ export class GridRangeComponent implements OnInit {
     this.translate.use(nextLocale).subscribe(() => this.selectedLanguage = nextLocale);
   }
 
-  setSomeFilters() {
+  setFiltersDynamically() {
     const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
     const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
 

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/extensionUtility.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/extensionUtility.spec.ts
@@ -108,8 +108,8 @@ describe('ExtensionUtility', () => {
       });
 
       it('should sort the items by their order property when found and then return the object without the property', () => {
-        const inputArray = [{ field: 'field1', order: 3 }, { field: 'field3', order: 2 }, { field: 'field2', order: -1 }];
-        const expectedArray = [{ field: 'field2', order: -1 }, { field: 'field3', order: 2 }, { field: 'field1', order: 3 }];
+        const inputArray = [{ field: 'field1', order: 3 }, { field: 'field3', order: 2 }, { field: 'field2' }];
+        const expectedArray = [{ field: 'field3', order: 2 }, { field: 'field1', order: 3 }, { field: 'field2' }];
 
         utility.sortItems(inputArray, 'order');
 

--- a/src/app/modules/angular-slickgrid/extensions/extensionUtility.ts
+++ b/src/app/modules/angular-slickgrid/extensions/extensionUtility.ts
@@ -125,7 +125,7 @@ export class ExtensionUtility {
       if (itemA && itemB && itemA.hasOwnProperty(propertyName) && itemB.hasOwnProperty(propertyName)) {
         return itemA[propertyName] - itemB[propertyName];
       }
-      return -1;
+      return 0;
     });
   }
 

--- a/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
@@ -7,7 +7,6 @@ import {
   Extension,
   ExtensionName,
   FileType,
-  GraphqlResult,
   GridOption,
   GridMenu,
   GridMenuItem,
@@ -19,7 +18,6 @@ import { ExportService } from '../services/export.service';
 import { ExtensionUtility } from './extensionUtility';
 import { FilterService } from '../services/filter.service';
 import { SortService } from '../services/sort.service';
-import { castToPromise } from '../services/utilities';
 import { SharedService } from '../services/shared.service';
 import { refreshBackendDataset } from '../services/backend-utilities';
 
@@ -147,9 +145,7 @@ export class GridMenuExtension implements Extension {
     if (gridOptions) {
       this.sharedService.gridOptions = { ...this.sharedService.gridOptions, ...gridOptions };
     }
-
-    const backendApi = this.sharedService.gridOptions.backendServiceApi;
-    refreshBackendDataset(backendApi, this.sharedService.gridOptions);
+    refreshBackendDataset(this.sharedService.gridOptions);
   }
 
   showGridMenu(e) {

--- a/src/app/modules/angular-slickgrid/filters/__tests__/compoundDateFilter.spec.ts
+++ b/src/app/modules/angular-slickgrid/filters/__tests__/compoundDateFilter.spec.ts
@@ -1,7 +1,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { Column, FilterArguments, GridOption, FieldType } from '../../models';
+import { Column, FilterArguments, GridOption, FieldType, OperatorType } from '../../models';
 import { Filters } from '..';
 import { CompoundDateFilter } from '../compoundDateFilter';
 
@@ -140,6 +140,17 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     filter.setValues([mockDate]);
     expect(filter.currentDate).toEqual(mockDate);
+  });
+
+  it('should be able to call "setValues" with a value and an extra operator and expect it to be set as new operator', () => {
+    const mockDate = '2001-01-02T16:02:02.239Z';
+    filter.init(filterArguments);
+    filter.setValues([mockDate], OperatorType.greaterThanOrEqual);
+
+    const filterOperatorElm = divContainer.querySelector<HTMLInputElement>('.input-group-prepend.operator select');
+
+    expect(filter.currentDate).toEqual(mockDate);
+    expect(filterOperatorElm.value).toBe('>=');
   });
 
   it('should trigger input change event and expect the callback to be called with the date provided in the input', () => {

--- a/src/app/modules/angular-slickgrid/filters/__tests__/compoundInputFilter.spec.ts
+++ b/src/app/modules/angular-slickgrid/filters/__tests__/compoundInputFilter.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { Column, FilterArguments, FieldType, GridOption } from '../../models';
+import { Column, FilterArguments, FieldType, GridOption, OperatorType } from '../../models';
 import { Filters } from '..';
 import { CompoundInputFilter } from '../compoundInputFilter';
 
@@ -119,6 +119,21 @@ describe('CompoundInputFilter', () => {
     filterInputElm.dispatchEvent(new (window.window as any).KeyboardEvent('keyup', { keyCode: 97, bubbles: true, cancelable: true }));
 
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '>', searchTerms: ['9'], shouldTriggerQuery: true });
+  });
+
+  it('should be able to call "setValues" with a value and an extra operator and expect it to be set as new operator', () => {
+    mockColumn.type = FieldType.number;
+    const spyCallback = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['9'], OperatorType.greaterThanOrEqual);
+
+    const filterSelectElm = divContainer.querySelector<HTMLInputElement>('.search-filter.filter-duration select');
+
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '>=', searchTerms: ['9'], shouldTriggerQuery: true });
+    expect(filterSelectElm.value).toBe('>=');
   });
 
   it('should trigger an operator change event and expect the callback to be called with the searchTerms and operator defined', () => {

--- a/src/app/modules/angular-slickgrid/filters/__tests__/compoundSliderFilter.spec.ts
+++ b/src/app/modules/angular-slickgrid/filters/__tests__/compoundSliderFilter.spec.ts
@@ -1,4 +1,4 @@
-import { GridOption, FilterArguments, Column } from '../../models';
+import { GridOption, FilterArguments, Column, OperatorType } from '../../models';
 import { Filters } from '..';
 import { CompoundSliderFilter } from '../compoundSliderFilter';
 
@@ -95,6 +95,18 @@ describe('CompoundSliderFilter', () => {
     filterSelectElm.dispatchEvent(new Event('change'));
 
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '<=', searchTerms: ['9'], shouldTriggerQuery: true });
+  });
+
+  it('should be able to call "setValues" with a value and an extra operator and expect it to be set as new operator', () => {
+    const spyCallback = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['9'], OperatorType.greaterThanOrEqual);
+
+    const filterSelectElm = divContainer.querySelector<HTMLInputElement>('.search-filter.filter-duration select');
+    filterSelectElm.dispatchEvent(new Event('change'));
+
+    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '>=', searchTerms: ['9'], shouldTriggerQuery: true });
   });
 
   it('should create the input filter with default search terms range when passed as a filter argument', () => {

--- a/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
@@ -88,7 +88,7 @@ export class AutoCompleteFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this.columnDef && this.columnDef.filter && this.columnDef.filter.operator || this.defaultOperator;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
   }
 
   /** Setter for the filter operator */

--- a/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
@@ -76,6 +76,11 @@ export class AutoCompleteFilter implements Filter {
     return this.columnDef && this.columnDef.filter && this.columnDef.filter.customStructure;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter for the Grid Options pulled through the Grid Object */
   get gridOptions(): GridOption {
     return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
@@ -83,7 +88,14 @@ export class AutoCompleteFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this.columnDef && this.columnDef.filter && this.columnDef.filter.operator || OperatorType.equal;
+    return this.columnDef && this.columnDef.filter && this.columnDef.filter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -145,10 +157,13 @@ export class AutoCompleteFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (values) {
       this.$filterElm.val(values);
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/autoCompleteFilter.ts
@@ -154,9 +154,7 @@ export class AutoCompleteFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (values) {
       this.$filterElm.val(values);

--- a/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
@@ -57,6 +57,11 @@ export class CompoundDateFilter implements Filter {
     return this._currentDate;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.empty;
+  }
+
   /** Getter for the Flatpickr Options */
   get flatpickrOptions(): FlatpickrOption {
     return this._flatpickrOptions || {};
@@ -69,7 +74,7 @@ export class CompoundDateFilter implements Filter {
 
   /** Getter for the Filter Operator */
   get operator(): OperatorType | OperatorString {
-    return this._operator || this.columnFilter.operator || OperatorType.empty;
+    return this._operator || this.columnFilter.operator || this.defaultOperator;
   }
 
   /**
@@ -139,16 +144,25 @@ export class CompoundDateFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  /** Set value(s) in the DOM element, we can optionally pass an operator and/or trigger a change event */
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false) {
     if (this.flatInstance && values && Array.isArray(values)) {
       this._currentDate = values[0] as Date;
       this.flatInstance.setDate(values[0]);
     } else if (this.flatInstance && values && values) {
       this._currentDate = values as Date;
       this.flatInstance.setDate(values);
+    }
+
+    this.operator = operator || this.defaultOperator;
+    if (operator && this.$selectOperatorElm) {
+      this.$selectOperatorElm.val(operator);
+    }
+
+    if (triggerChange) {
+      this._clearFilterTriggered = false;
+      this._shouldTriggerQuery = true;
+      this.onTriggerEvent(new Event('change'));
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
@@ -1,6 +1,8 @@
 import { Optional } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { mapFlatpickrDateFormatWithFieldType } from '../services/utilities';
+import Flatpickr from 'flatpickr';
+import { BaseOptions as FlatpickrBaseOptions } from 'flatpickr/dist/types/options';
+
 import {
   Column,
   ColumnFilter,
@@ -14,8 +16,7 @@ import {
   OperatorType,
   SearchTerm,
 } from './../models/index';
-import Flatpickr from 'flatpickr';
-import { BaseOptions as FlatpickrBaseOptions } from 'flatpickr/dist/types/options';
+import { mapFlatpickrDateFormatWithFieldType, mapOperatorToShortDesignation } from '../services/utilities';
 
 // use Flatpickr from import or 'require', whichever works first
 declare function require(name: string): any;
@@ -69,7 +70,7 @@ export class CompoundDateFilter implements Filter {
 
   /** Getter for the Filter Operator */
   get operator(): OperatorType | OperatorString {
-    return this._operator || this.columnFilter.operator || this.defaultOperator;
+    return (this.columnFilter && this.columnFilter.operator) || this.gridOptions.defaultFilterRangeOperator || this.defaultOperator;
   }
 
   /** Setter for the Filter Operator */
@@ -153,9 +154,9 @@ export class CompoundDateFilter implements Filter {
     }
 
     // set the operator, in the DOM as well, when defined
-    this.operator = operator || this.defaultOperator;
+    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(operator);
+      this.$selectOperatorElm.val(this.operator);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
@@ -16,7 +16,7 @@ import {
   OperatorType,
   SearchTerm,
 } from './../models/index';
-import { mapFlatpickrDateFormatWithFieldType, mapOperatorToShortDesignation } from '../services/utilities';
+import { mapFlatpickrDateFormatWithFieldType, mapOperatorToShorthandDesignation } from '../services/utilities';
 
 // use Flatpickr from import or 'require', whichever works first
 declare function require(name: string): any;
@@ -70,7 +70,7 @@ export class CompoundDateFilter implements Filter {
 
   /** Getter for the Filter Operator */
   get operator(): OperatorType | OperatorString {
-    return (this.columnFilter && this.columnFilter.operator) || this.gridOptions.defaultFilterRangeOperator || this.defaultOperator;
+    return this._operator || (this.columnFilter && this.columnFilter.operator) || this.gridOptions.defaultFilterRangeOperator || this.defaultOperator;
   }
 
   /** Setter for the Filter Operator */
@@ -154,9 +154,10 @@ export class CompoundDateFilter implements Filter {
     }
 
     // set the operator, in the DOM as well, when defined
-    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
@@ -70,7 +70,7 @@ export class CompoundDateFilter implements Filter {
 
   /** Getter for the Filter Operator */
   get operator(): OperatorType | OperatorString {
-    return this._operator || (this.columnFilter && this.columnFilter.operator) || this.gridOptions.defaultFilterRangeOperator || this.defaultOperator;
+    return this._operator || this.columnFilter.operator || this.defaultOperator;
   }
 
   /** Setter for the Filter Operator */

--- a/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
@@ -67,14 +67,14 @@ export class CompoundDateFilter implements Filter {
     return this._flatpickrOptions || {};
   }
 
-  /** Setter for the Filter Operator */
-  set operator(op: OperatorType | OperatorString) {
-    this._operator = op;
-  }
-
   /** Getter for the Filter Operator */
   get operator(): OperatorType | OperatorString {
     return this._operator || this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the Filter Operator */
+  set operator(op: OperatorType | OperatorString) {
+    this._operator = op;
   }
 
   /**
@@ -145,24 +145,17 @@ export class CompoundDateFilter implements Filter {
   }
 
   /** Set value(s) in the DOM element, we can optionally pass an operator and/or trigger a change event */
-  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false) {
-    if (this.flatInstance && values && Array.isArray(values)) {
-      this._currentDate = values[0] as Date;
-      this.flatInstance.setDate(values[0]);
-    } else if (this.flatInstance && values && values) {
-      this._currentDate = values as Date;
-      this.flatInstance.setDate(values);
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
+    if (this.flatInstance && values) {
+      const newValue = Array.isArray(values) ? values[0] : values;
+      this._currentDate = newValue as Date;
+      this.flatInstance.setDate(newValue);
     }
 
+    // set the operator, in the DOM as well, when defined
     this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
       this.$selectOperatorElm.val(operator);
-    }
-
-    if (triggerChange) {
-      this._clearFilterTriggered = false;
-      this._shouldTriggerQuery = true;
-      this.onTriggerEvent(new Event('change'));
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
@@ -129,20 +129,15 @@ export class CompoundInputFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false) {
-    if (values && Array.isArray(values)) {
-      this.$filterInputElm.val(values[0]);
+  setValues(values: SearchTerm[], operator?: OperatorType | OperatorString) {
+    if (values) {
+      const newValue = Array.isArray(values) ? values[0] : values;
+      this.$filterInputElm.val(newValue);
     }
 
     this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
       this.$selectOperatorElm.val(operator);
-    }
-
-    if (triggerChange) {
-      this._clearFilterTriggered = false;
-      this._shouldTriggerQuery = true;
-      this.onTriggerEvent(new Event('change'));
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
@@ -14,7 +14,7 @@ import {
   SearchTerm,
 } from './../models/index';
 import { Constants } from './../constants';
-import { mapOperatorToShortDesignation } from '../services/utilities';
+import { mapOperatorToShorthandDesignation, mapOperatorType } from '../services/utilities';
 
 // using external non-typed js libraries
 declare var $: any;
@@ -128,18 +128,18 @@ export class CompoundInputFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values: SearchTerm[], operator?: OperatorType | OperatorString) {
     if (values) {
       const newValue = Array.isArray(values) ? values[0] : values;
       this.$filterInputElm.val(newValue);
     }
 
-    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    // set the operator, in the DOM as well, when defined
+    this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
@@ -43,6 +43,11 @@ export class CompoundInputFilter implements Filter {
     return this.columnDef && this.columnDef.filter || {};
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.empty;
+  }
+
   /** Getter of input type (text, number, password) */
   get inputType() {
     return this._inputType;
@@ -55,7 +60,7 @@ export class CompoundInputFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this._operator || OperatorType.empty;
+    return this._operator || this.defaultOperator;
   }
 
   /** Getter of the Operator to use when doing the filter comparing */
@@ -124,9 +129,20 @@ export class CompoundInputFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm[]) {
+  setValues(values: SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false) {
     if (values && Array.isArray(values)) {
       this.$filterInputElm.val(values[0]);
+    }
+
+    this.operator = operator || this.defaultOperator;
+    if (operator && this.$selectOperatorElm) {
+      this.$selectOperatorElm.val(operator);
+    }
+
+    if (triggerChange) {
+      this._clearFilterTriggered = false;
+      this._shouldTriggerQuery = true;
+      this.onTriggerEvent(new Event('change'));
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
@@ -1,5 +1,5 @@
-import { Constants } from './../constants';
 import { TranslateService } from '@ngx-translate/core';
+
 import {
   Column,
   ColumnFilter,
@@ -13,6 +13,8 @@ import {
   OperatorType,
   SearchTerm,
 } from './../models/index';
+import { Constants } from './../constants';
+import { mapOperatorToShortDesignation } from '../services/utilities';
 
 // using external non-typed js libraries
 declare var $: any;
@@ -135,9 +137,9 @@ export class CompoundInputFilter implements Filter {
       this.$filterInputElm.val(newValue);
     }
 
-    this.operator = operator || this.defaultOperator;
+    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(operator);
+      this.$selectOperatorElm.val(this.operator);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
@@ -34,6 +34,11 @@ export class CompoundSliderFilter implements Filter {
 
   constructor() { }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.empty;
+  }
+
   /** Getter for the Filter Generic Params */
   private get filterParams(): any {
     return this.columnDef && this.columnDef.filter && this.columnDef.filter.params || {};
@@ -44,12 +49,12 @@ export class CompoundSliderFilter implements Filter {
     return this.columnDef && this.columnDef.filter;
   }
 
-  set operator(op: OperatorType | OperatorString) {
-    this._operator = op;
+  get operator(): OperatorType | OperatorString {
+    return this._operator || this.defaultOperator;
   }
 
-  get operator(): OperatorType | OperatorString {
-    return this._operator || OperatorType.empty;
+  set operator(op: OperatorType | OperatorString) {
+    this._operator = op;
   }
 
   /**
@@ -138,7 +143,7 @@ export class CompoundSliderFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (Array.isArray(values)) {
       this._currentValue = +values[0];
       this.$filterInputElm.val(values[0]);
@@ -147,6 +152,12 @@ export class CompoundSliderFilter implements Filter {
       this._currentValue = +values;
       this.$filterInputElm.val(values);
       this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(values);
+    }
+
+    // set the operator, in the DOM as well, when defined
+    this.operator = operator || this.defaultOperator;
+    if (operator && this.$selectOperatorElm) {
+      this.$selectOperatorElm.val(operator);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
@@ -8,6 +8,7 @@ import {
   OperatorType,
   SearchTerm
 } from './../models/index';
+import { mapOperatorToShortDesignation } from '../services/utilities';
 
 // using external non-typed js libraries
 declare var $: any;
@@ -155,9 +156,9 @@ export class CompoundSliderFilter implements Filter {
     }
 
     // set the operator, in the DOM as well, when defined
-    this.operator = operator || this.defaultOperator;
+    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(operator);
+      this.$selectOperatorElm.val(this.operator);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
@@ -8,7 +8,7 @@ import {
   OperatorType,
   SearchTerm
 } from './../models/index';
-import { mapOperatorToShortDesignation } from '../services/utilities';
+import { mapOperatorToShorthandDesignation } from '../services/utilities';
 
 // using external non-typed js libraries
 declare var $: any;
@@ -141,24 +141,18 @@ export class CompoundSliderFilter implements Filter {
     return this._currentValue;
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
-    if (Array.isArray(values)) {
-      this._currentValue = +values[0];
-      this.$filterInputElm.val(values[0]);
-      this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(values[0]);
-    } else if (values) {
-      this._currentValue = +values;
-      this.$filterInputElm.val(values);
-      this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(values);
-    }
+    const newValue = Array.isArray(values) ? values[0] : values;
+    this._currentValue = +newValue;
+    this.$filterInputElm.val(newValue);
+    this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(newValue);
 
     // set the operator, in the DOM as well, when defined
-    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/dateRangeFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/dateRangeFilter.ts
@@ -209,11 +209,8 @@ export class DateRangeFilter implements Filter {
 
         // when using the time picker, we can simulate a keyup event to avoid multiple backend request
         // since backend request are only executed after user start typing, changing the time should be treated the same way
-        if (pickerOptions.enableTime) {
-          this.onTriggerEvent(new CustomEvent('keyup'));
-        } else {
-          this.onTriggerEvent(undefined);
-        }
+        const newEvent = pickerOptions.enableTime ? new CustomEvent('keyup') : undefined;
+        this.onTriggerEvent(newEvent);
       }
     };
 

--- a/src/app/modules/angular-slickgrid/filters/dateRangeFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/dateRangeFilter.ts
@@ -143,7 +143,7 @@ export class DateRangeFilter implements Filter {
    * Set value(s) on the DOM element
    * @params searchTerms
    */
-  setValues(searchTerms: SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false) {
+  setValues(searchTerms: SearchTerm[], operator?: OperatorType | OperatorString) {
     let pickerValues = [];
 
     // get the picker values, if it's a string with the "..", we'll do the split else we'll use the array of search terms
@@ -158,13 +158,8 @@ export class DateRangeFilter implements Filter {
       this.flatInstance.setDate(pickerValues);
     }
 
+    // set the operator when defined
     this.operator = operator || this.defaultOperator;
-
-    if (triggerChange) {
-      this._clearFilterTriggered = false;
-      this._shouldTriggerQuery = true;
-      this.onTriggerEvent(undefined);
-    }
   }
 
   //

--- a/src/app/modules/angular-slickgrid/filters/dateRangeFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/dateRangeFilter.ts
@@ -58,6 +58,11 @@ export class DateRangeFilter implements Filter {
     return this._currentDates;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+  }
+
   /** Getter for the Flatpickr Options */
   get flatpickrOptions(): FlatpickrOption {
     return this._flatpickrOptions || {};
@@ -65,7 +70,14 @@ export class DateRangeFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this.columnFilter.operator || this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -131,7 +143,7 @@ export class DateRangeFilter implements Filter {
    * Set value(s) on the DOM element
    * @params searchTerms
    */
-  setValues(searchTerms: SearchTerm[]) {
+  setValues(searchTerms: SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false) {
     let pickerValues = [];
 
     // get the picker values, if it's a string with the "..", we'll do the split else we'll use the array of search terms
@@ -144,6 +156,14 @@ export class DateRangeFilter implements Filter {
     if (this.flatInstance && searchTerms) {
       this._currentDates = pickerValues;
       this.flatInstance.setDate(pickerValues);
+    }
+
+    this.operator = operator || this.defaultOperator;
+
+    if (triggerChange) {
+      this._clearFilterTriggered = false;
+      this._shouldTriggerQuery = true;
+      this.onTriggerEvent(undefined);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/filters/inputFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/inputFilter.ts
@@ -30,6 +30,11 @@ export class InputFilter implements Filter {
     return this.columnDef && this.columnDef.filter || {};
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter of input type (text, number, password) */
   get inputType() {
     return this._inputType;
@@ -42,7 +47,14 @@ export class InputFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this.columnDef && this.columnDef.filter && this.columnDef.filter.operator || '';
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
@@ -118,10 +130,13 @@ export class InputFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm) {
+  setValues(values: SearchTerm, operator?: OperatorType | OperatorString) {
     if (values) {
       this.$filterElm.val(values);
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/app/modules/angular-slickgrid/filters/inputFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/inputFilter.ts
@@ -127,9 +127,7 @@ export class InputFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values: SearchTerm, operator?: OperatorType | OperatorString) {
     if (values) {
       this.$filterElm.val(values);

--- a/src/app/modules/angular-slickgrid/filters/nativeSelectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/nativeSelectFilter.ts
@@ -135,9 +135,7 @@ export class NativeSelectFilter implements Filter {
     return this._currentValues;
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (Array.isArray(values)) {
       this.$filterElm.val(values[0]);

--- a/src/app/modules/angular-slickgrid/filters/nativeSelectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/nativeSelectFilter.ts
@@ -32,13 +32,25 @@ export class NativeSelectFilter implements Filter {
     return this.columnDef && this.columnDef.filter;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter for the Grid Options pulled through the Grid Object */
   protected get gridOptions(): GridOption {
     return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
   }
 
   get operator(): OperatorType | OperatorString {
-    return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || OperatorType.equal;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -126,7 +138,7 @@ export class NativeSelectFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (Array.isArray(values)) {
       this.$filterElm.val(values[0]);
       this._currentValues = values;
@@ -134,6 +146,9 @@ export class NativeSelectFilter implements Filter {
       this.$filterElm.val(values);
       this._currentValues = [values];
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -327,7 +327,7 @@ export class SelectFilter implements Filter {
   /** Create the HTML template as a string */
   protected buildTemplateHtmlString(optionCollection: any[], searchTerms: SearchTerm[]) {
     let options = '';
-    const fieldId = this.columnDef && this.columnDef.id;
+    const columnId = this.columnDef && this.columnDef.id;
     const separatorBetweenLabels = this.collectionOptions && this.collectionOptions.separatorBetweenTextLabels || '';
     const isEnableTranslate = this.gridOptions && this.gridOptions.enableTranslate;
     const isRenderHtmlEnabled = this.columnFilter && this.columnFilter.enableRenderHtml || false;
@@ -390,7 +390,7 @@ export class SelectFilter implements Filter {
       }
     }
 
-    return `<select class="ms-filter search-filter filter-${fieldId}" ${this.isMultipleSelect ? 'multiple="multiple"' : ''}>${options}</select>`;
+    return `<select class="ms-filter search-filter filter-${columnId}" ${this.isMultipleSelect ? 'multiple="multiple"' : ''}>${options}</select>`;
   }
 
   /** Create a blank entry that can be added to the collection. It will also reuse the same customStructure if need be */

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -94,10 +94,7 @@ export class SelectFilter implements Filter {
 
   /** Getter for the filter operator */
   get operator(): OperatorType | OperatorString {
-    if (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) {
-      return this.columnDef.filter.operator;
-    }
-    return this.defaultOperator;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
   }
 
   /** Setter for the filter operator */

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -202,9 +202,7 @@ export class SelectFilter implements Filter {
     return [];
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (values && this.$filterElm && typeof this.$filterElm.multipleSelect === 'function') {
       values = Array.isArray(values) ? values : [values];

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -208,17 +208,14 @@ export class SelectFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString, triggerChange = false) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (values && this.$filterElm && typeof this.$filterElm.multipleSelect === 'function') {
       values = Array.isArray(values) ? values : [values];
       this.$filterElm.multipleSelect('setSelects', values);
     }
 
+    // set the operator when defined
     this.operator = operator || this.defaultOperator;
-    if (triggerChange) {
-      this._shouldTriggerQuery = true;
-      this.onTriggerEvent(undefined);
-    }
   }
 
   //

--- a/src/app/modules/angular-slickgrid/filters/sliderFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/sliderFilter.ts
@@ -28,6 +28,16 @@ export class SliderFilter implements Filter {
   columnDef: Column;
   callback: FilterCallback;
 
+  /** Getter for the Column Filter */
+  get columnFilter(): ColumnFilter {
+    return this.columnDef && this.columnDef.filter || {};
+  }
+
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter for the Filter Generic Params */
   private get filterParams(): any {
     return this.columnDef && this.columnDef.filter && this.columnDef.filter.params || {};
@@ -39,7 +49,14 @@ export class SliderFilter implements Filter {
   }
 
   get operator(): OperatorType | OperatorString {
-    return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || OperatorType.equal;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -134,7 +151,7 @@ export class SliderFilter implements Filter {
   /**
    * Set value(s) on the DOM element
    */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (Array.isArray(values)) {
       this.$filterElm.val(values[0]);
       this._currentValue = +values[0];
@@ -142,6 +159,9 @@ export class SliderFilter implements Filter {
       this.$filterElm.val(values);
       this._currentValue = +values;
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/app/modules/angular-slickgrid/filters/sliderFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/sliderFilter.ts
@@ -148,9 +148,7 @@ export class SliderFilter implements Filter {
     return this._currentValue;
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (Array.isArray(values)) {
       this.$filterElm.val(values[0]);

--- a/src/app/modules/angular-slickgrid/filters/sliderRangeFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/sliderRangeFilter.ts
@@ -52,6 +52,11 @@ export class SliderRangeFilter implements Filter {
     return this._currentValues;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+  }
+
   /** Getter for the Grid Options pulled through the Grid Object */
   get gridOptions(): GridOption {
     return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
@@ -62,8 +67,16 @@ export class SliderRangeFilter implements Filter {
     return this._sliderOptions || {};
   }
 
+  /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -115,7 +128,7 @@ export class SliderRangeFilter implements Filter {
    * Set value(s) on the DOM element
    * @params searchTerms
    */
-  setValues(searchTerms: SearchTerm | SearchTerm[]) {
+  setValues(searchTerms: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (searchTerms) {
       let sliderValues = [];
 
@@ -133,6 +146,9 @@ export class SliderRangeFilter implements Filter {
         }
       }
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/app/modules/angular-slickgrid/models/backendService.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/backendService.interface.ts
@@ -43,7 +43,7 @@ export interface BackendService {
   resetPaginationOptions: () => void;
 
   /** Update the Filters options with a set of new options */
-  updateFilters?: (columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPreset: boolean) => void;
+  updateFilters?: (columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically: boolean) => void;
 
   /** Update the Pagination component with it's new page number and size */
   updatePagination?: (newPage: number, pageSize: number) => void;

--- a/src/app/modules/angular-slickgrid/services/__tests__/grid-odata.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/grid-odata.service.spec.ts
@@ -1292,6 +1292,22 @@ describe('GridOdataService', () => {
       expect(currentSorters).toEqual([]);
     });
 
+    it('should return a query with the multiple new sorting when "updateSorters" with currentSorter defined as preset on 2nd argument', () => {
+      const expectation = `$top=10&$orderby=Gender asc,FirstName desc`;
+      const mockCurrentSorter = [
+        { columnId: 'gender', direction: 'asc' },
+        { columnId: 'firstName', direction: 'DESC' }
+      ] as CurrentSorter[];
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateSorters(null, mockCurrentSorter);
+      const query = service.buildQuery();
+      const currentSorters = service.getCurrentSorters();
+
+      expect(query).toBe(expectation);
+      expect(currentSorters).toEqual([{ columnId: 'gender', direction: 'asc' }, { columnId: 'firstName', direction: 'desc' }]);
+    });
+
     describe('set "enablePagination" to False', () => {
       beforeEach(() => {
         gridOptionMock.enablePagination = false;

--- a/src/app/modules/angular-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -597,5 +597,21 @@ describe('PaginationService', () => {
         done();
       });
     });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to equal the total items when it is lower than the total itemsPerPage count', (done) => {
+      mockGridOption.pagination.pageNumber = 4;
+      mockGridOption.pagination.totalItems = 100;
+      const mockItems = { name: 'John' };
+
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      gridServiceStub.onItemAdded.next(mockItems);
+      service.changeItemPerPage(200);
+
+      setTimeout(() => {
+        expect(service.pager.from).toBe(1);
+        expect(service.pager.to).toBe(101);
+        done();
+      });
+    });
   });
 });

--- a/src/app/modules/angular-slickgrid/services/__tests__/resizer.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/resizer.service.spec.ts
@@ -80,7 +80,20 @@ describe('Resizer Service', () => {
       beforeEach(() => {
         // @ts-ignore
         navigator.__defineGetter__('userAgent', () => 'Netscape');
+        gridOptionMock.gridId = 'grid1';
       });
+    });
+
+    it('should return null when calling "bindAutoResizeDataGrid" method with a gridId that is not found in the DOM', () => {
+      gridOptionMock.gridId = 'unknown';
+      const output = service.bindAutoResizeDataGrid();
+      expect(output).toBe(null);
+    });
+
+    it('should return null when calling "calculateGridNewDimensions" method with a gridId that is not found in the DOM', () => {
+      gridOptionMock.gridId = 'unknown';
+      const output = service.calculateGridNewDimensions(gridOptionMock);
+      expect(output).toBe(null);
     });
 
     it('should trigger a grid resize when a window resize event occurs', () => {

--- a/src/app/modules/angular-slickgrid/services/__tests__/utilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/utilities.spec.ts
@@ -13,8 +13,9 @@ import {
   htmlEntityEncode,
   mapMomentDateFormatWithFieldType,
   mapFlatpickrDateFormatWithFieldType,
-  mapOperatorType,
   mapOperatorByFieldType,
+  mapOperatorToShorthandDesignation,
+  mapOperatorType,
   parseBoolean,
   parseUtcDate,
   sanitizeHtmlToText,
@@ -687,115 +688,227 @@ describe('Service/Utilies', () => {
 
   describe('mapOperatorType method', () => {
     it('should return OperatoryType associated to "<"', () => {
-      const output = mapOperatorType('<');
-      expect(output).toBe(OperatorType.lessThan);
+      const expectation = OperatorType.lessThan;
+
+      const output1 = mapOperatorType('<');
+      const output2 = mapOperatorType('LT');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "<="', () => {
-      const output = mapOperatorType('<=');
-      expect(output).toBe(OperatorType.lessThanOrEqual);
+      const expectation = OperatorType.lessThanOrEqual;
+
+      const output1 = mapOperatorType('<=');
+      const output2 = mapOperatorType('LE');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to ">"', () => {
-      const output = mapOperatorType('>');
-      expect(output).toBe(OperatorType.greaterThan);
+      const expectation = OperatorType.greaterThan;
+
+      const output1 = mapOperatorType('>');
+      const output2 = mapOperatorType('GT');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to ">="', () => {
-      const output = mapOperatorType('>=');
-      expect(output).toBe(OperatorType.greaterThanOrEqual);
+      const expectation = OperatorType.greaterThanOrEqual;
+
+      const output1 = mapOperatorType('>=');
+      const output2 = mapOperatorType('GE');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "<>", "!=", "neq" or "NEQ"', () => {
+      const expectation = OperatorType.notEqual;
+
       const output1 = mapOperatorType('<>');
       const output2 = mapOperatorType('!=');
-      const output3 = mapOperatorType('neq');
-      const output4 = mapOperatorType('NEQ');
+      const output3 = mapOperatorType('NE');
 
-      expect(output1).toBe(OperatorType.notEqual);
-      expect(output2).toBe(OperatorType.notEqual);
-      expect(output3).toBe(OperatorType.notEqual);
-      expect(output4).toBe(OperatorType.notEqual);
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "*", "a*", ".*", "startsWith"', () => {
-      const output1 = mapOperatorType('*');
-      const output2 = mapOperatorType('.*');
-      const output3 = mapOperatorType('a*');
-      const output4 = mapOperatorType('startsWith');
-      const output5 = mapOperatorType('StartsWith');
+      const expectation = OperatorType.startsWith;
 
-      expect(output1).toBe(OperatorType.startsWith);
-      expect(output2).toBe(OperatorType.startsWith);
-      expect(output3).toBe(OperatorType.startsWith);
-      expect(output4).toBe(OperatorType.startsWith);
-      expect(output5).toBe(OperatorType.startsWith);
+      const output1 = mapOperatorType('*');
+      const output2 = mapOperatorType('a*');
+      const output3 = mapOperatorType('StartsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "*.", "*z", "endsWith"', () => {
-      const output1 = mapOperatorType('*.');
-      const output2 = mapOperatorType('*z');
-      const output3 = mapOperatorType('endsWith');
-      const output4 = mapOperatorType('EndsWith');
+      const expectation = OperatorType.endsWith;
 
-      expect(output1).toBe(OperatorType.endsWith);
-      expect(output2).toBe(OperatorType.endsWith);
-      expect(output3).toBe(OperatorType.endsWith);
-      expect(output4).toBe(OperatorType.endsWith);
+      const output1 = mapOperatorType('*z');
+      const output2 = mapOperatorType('EndsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "=", "==", "eq" or "EQ"', () => {
+      const expectation = OperatorType.equal;
+
       const output1 = mapOperatorType('=');
       const output2 = mapOperatorType('==');
-      const output3 = mapOperatorType('eq');
-      const output4 = mapOperatorType('EQ');
+      const output3 = mapOperatorType('EQ');
 
-      expect(output1).toBe(OperatorType.equal);
-      expect(output2).toBe(OperatorType.equal);
-      expect(output3).toBe(OperatorType.equal);
-      expect(output4).toBe(OperatorType.equal);
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "in", "IN"', () => {
-      const output1 = mapOperatorType('in');
-      const output2 = mapOperatorType('IN');
+      const expectation = OperatorType.in;
 
-      expect(output1).toBe(OperatorType.in);
-      expect(output2).toBe(OperatorType.in);
+      const output1 = mapOperatorType('IN');
+
+      expect(output1).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "notIn", "NIN", "NOT_IN"', () => {
-      const output1 = mapOperatorType('notIn');
-      const output2 = mapOperatorType('NIN');
-      const output3 = mapOperatorType('NOT_IN');
+      const expectation = OperatorType.notIn;
 
-      expect(output1).toBe(OperatorType.notIn);
-      expect(output2).toBe(OperatorType.notIn);
-      expect(output3).toBe(OperatorType.notIn);
+      const output1 = mapOperatorType('NIN');
+      const output2 = mapOperatorType('NOT_IN');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "not_contains", "Not_Contains", "notContains"', () => {
-      const output1 = mapOperatorType('not_contains');
-      const output2 = mapOperatorType('Not_Contains');
-      const output3 = mapOperatorType('notContains');
-      const output4 = mapOperatorType('NotContains');
-      const output5 = mapOperatorType('NOT_CONTAINS');
+      const expectation = OperatorType.notContains;
 
-      expect(output1).toBe(OperatorType.notContains);
-      expect(output2).toBe(OperatorType.notContains);
-      expect(output3).toBe(OperatorType.notContains);
-      expect(output4).toBe(OperatorType.notContains);
-      expect(output5).toBe(OperatorType.notContains);
+      const output1 = mapOperatorType('Not_Contains');
+      const output2 = mapOperatorType('NOT_CONTAINS');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return default OperatoryType associated to contains', () => {
+      const expectation = OperatorType.contains;
+
       const output1 = mapOperatorType('');
       const output2 = mapOperatorType('Contains');
       const output3 = mapOperatorType('CONTAINS');
 
-      expect(output1).toBe(OperatorType.contains);
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+    });
+  });
+
+  describe('mapOperatorToShorthandDesignation method', () => {
+    it('should return Operator shorthand of ">"', () => {
+      const expectation = '>';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.greaterThan);
+      const output2 = mapOperatorToShorthandDesignation('>');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of ">="', () => {
+      const expectation = '>=';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.greaterThanOrEqual);
+      const output2 = mapOperatorToShorthandDesignation('>=');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "<"', () => {
+      const expectation = '<';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.lessThan);
+      const output2 = mapOperatorToShorthandDesignation('<');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "<="', () => {
+      const expectation = '<=';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.lessThanOrEqual);
+      const output2 = mapOperatorToShorthandDesignation('<=');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "<>"', () => {
+      const expectation = '<>';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.notEqual);
+      const output2 = mapOperatorToShorthandDesignation('<>');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "="', () => {
+      const expectation = '=';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.equal);
+      const output2 = mapOperatorToShorthandDesignation('=');
+      const output3 = mapOperatorToShorthandDesignation('==');
+      const output4 = mapOperatorToShorthandDesignation('EQ');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+      expect(output4).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "a*" to represent starts with', () => {
+      const expectation = 'a*';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.startsWith);
+      const output2 = mapOperatorToShorthandDesignation('a*');
+      const output3 = mapOperatorToShorthandDesignation('*');
+      const output4 = mapOperatorToShorthandDesignation('StartsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+      expect(output4).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "*z" to represent ends with', () => {
+      const expectation = '*z';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.endsWith);
+      const output2 = mapOperatorToShorthandDesignation('*z');
+      const output3 = mapOperatorToShorthandDesignation('EndsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+    });
+
+    it('should return same input Operator when no shorthand is found', () => {
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.in);
+      const output2 = mapOperatorToShorthandDesignation(OperatorType.contains);
+      const output3 = mapOperatorToShorthandDesignation(OperatorType.notContains);
+      const output4 = mapOperatorToShorthandDesignation(OperatorType.rangeExclusive);
+      const output5 = mapOperatorToShorthandDesignation(OperatorType.rangeInclusive);
+
+      expect(output1).toBe(OperatorType.in);
       expect(output2).toBe(OperatorType.contains);
-      expect(output3).toBe(OperatorType.contains);
+      expect(output3).toBe(OperatorType.notContains);
+      expect(output4).toBe(OperatorType.rangeExclusive);
+      expect(output5).toBe(OperatorType.rangeInclusive);
     });
   });
 

--- a/src/app/modules/angular-slickgrid/services/backend-utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/backend-utilities.ts
@@ -2,33 +2,10 @@ import { isObservable } from 'rxjs';
 
 import { BackendServiceApi, EmitterType, GraphqlResult, GridOption } from '../models';
 
-/**
- * Execute the backend callback, which are mainly the "process" & "postProcess" methods.
- * Also note that "preProcess" was executed prior to this callback
- */
-export async function executeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, emitActionChangedCallback: (type: EmitterType) => void) {
-  if (backendServiceApi) {
-    // emit an onFilterChanged event when it's not called by a clear filter
-    if (args && !args.clearFilterTriggered) {
-      emitActionChangedCallback(EmitterType.remote);
-    }
-
-    // the processes can be Observables (like HttpClient) or Promises
-    const process = backendServiceApi.process(query);
-    if (process instanceof Promise && process.then) {
-      process.then((processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendServiceApi, totalItems))
-        .catch((error: any) => onBackendError(error, backendServiceApi));
-    } else if (isObservable(process)) {
-      process.subscribe(
-        (processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendServiceApi, totalItems),
-        (error: any) => onBackendError(error, backendServiceApi)
-      );
-    }
-  }
-}
+const main: any = {};
 
 /** Execute the Backend Processes Callback, that could come from an Observable or a Promise callback */
-export function executeBackendProcessesCallback(startTime: Date, processResult: GraphqlResult | any, backendApi: BackendServiceApi, totalItems: number): GraphqlResult | any {
+main.executeBackendProcessesCallback = function exeBackendProcessesCallback(startTime: Date, processResult: GraphqlResult | any, backendApi: BackendServiceApi, totalItems: number): GraphqlResult | any {
   const endTime = new Date();
 
   // define what our internal Post Process callback, only available for GraphQL Service for now
@@ -52,20 +29,46 @@ export function executeBackendProcessesCallback(startTime: Date, processResult: 
     }
     backendApi.postProcess(processResult);
   }
-}
+};
 
 /** On a backend service api error, we will run the "onError" if there is 1 provided or just throw back the error when nothing is provided */
-export function onBackendError(e: any, backendApi: BackendServiceApi) {
+main.onBackendError = function backendError(e: any, backendApi: BackendServiceApi) {
   if (backendApi && backendApi.onError) {
     backendApi.onError(e);
   } else {
     throw e;
   }
-}
+};
+
+/**
+ * Execute the backend callback, which are mainly the "process" & "postProcess" methods.
+ * Also note that "preProcess" was executed prior to this callback
+ */
+main.executeBackendCallback = function exeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, emitActionChangedCallback?: (type: EmitterType) => void) {
+  if (backendServiceApi) {
+    // emit an onFilterChanged event when it's not called by a clear filter
+    if (args && !args.clearFilterTriggered) {
+      emitActionChangedCallback(EmitterType.remote);
+    }
+
+    // the processes can be Observables (like HttpClient) or Promises
+    const process = backendServiceApi.process(query);
+    if (process instanceof Promise && process.then) {
+      process.then((processResult: GraphqlResult | any) => main.executeBackendProcessesCallback(startTime, processResult, backendServiceApi, totalItems))
+        .catch((error: any) => main.onBackendError(error, backendServiceApi));
+    } else if (isObservable(process)) {
+      process.subscribe(
+        (processResult: GraphqlResult | any) => main.executeBackendProcessesCallback(startTime, processResult, backendServiceApi, totalItems),
+        (error: any) => main.onBackendError(error, backendServiceApi)
+      );
+    }
+  }
+};
 
 /** Refresh the dataset through the Backend Service */
-export function refreshBackendDataset(backendApi: BackendServiceApi, gridOptions: GridOption) {
+main.refreshBackendDataset = function refreshBackend(gridOptions: GridOption) {
   let query = '';
+  const backendApi = gridOptions && gridOptions.backendServiceApi;
 
   if (!backendApi || !backendApi.service || !backendApi.process) {
     throw new Error(`BackendServiceApi requires at least a "process" function and a "service" defined`);
@@ -83,16 +86,16 @@ export function refreshBackendDataset(backendApi: BackendServiceApi, gridOptions
       backendApi.preProcess();
     }
 
-    // the processes can be Promises or Observables (like Angular HttpClient)
-    const process = backendApi.process(query);
-    if (process instanceof Promise && process.then) {
-      process.then((processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendApi, gridOptions.pagination.totalItems))
-        .catch((error: any) => onBackendError(error, backendApi));
-    } else if (isObservable(process)) {
-      process.subscribe(
-        (processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendApi, gridOptions.pagination.totalItems),
-        (error: any) => onBackendError(error, backendApi)
-      );
-    }
+    const totalItems = gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems;
+    main.executeBackendCallback(backendApi, query, null, startTime, totalItems);
   }
-}
+};
+
+// export all methods & the main so that it works in all modules but also in Jest unit test
+// export every method as independent constant so that it still works whenever this is used in other modules
+export const executeBackendProcessesCallback = main.executeBackendProcessesCallback;
+export const onBackendError = main.onBackendError;
+export const executeBackendCallback = main.executeBackendCallback;
+export const refreshBackendDataset = main.refreshBackendDataset;
+
+export default main;

--- a/src/app/modules/angular-slickgrid/services/graphql.service.ts
+++ b/src/app/modules/angular-slickgrid/services/graphql.service.ts
@@ -23,7 +23,8 @@ import {
   PaginationChangedArgs,
   SortChangedArgs,
   SortDirection,
-  SortDirectionString
+  SortDirectionString,
+  OperatorString
 } from './../models/index';
 import QueryBuilder from './graphqlQueryBuilder';
 
@@ -345,12 +346,12 @@ export class GraphqlService implements BackendService {
    * loop through all columns to inspect filters & update backend service filteringOptions
    * @param columnFilters
    */
-  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPreset: boolean) {
+  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically: boolean) {
     const searchByArray: GraphqlFilteringOption[] = [];
     let searchValue: string | string[];
 
     // on filter preset load, we need to keep current filters
-    if (isUpdatedByPreset) {
+    if (isUpdatedByPresetOrDynamically) {
       this._currentFilters = this.castFilterToColumnFilters(columnFilters);
     }
 
@@ -360,7 +361,7 @@ export class GraphqlService implements BackendService {
 
         // if user defined some "presets", then we need to find the filters from the column definitions instead
         let columnDef: Column | undefined;
-        if (isUpdatedByPreset && Array.isArray(this._columnDefinitions)) {
+        if (isUpdatedByPresetOrDynamically && Array.isArray(this._columnDefinitions)) {
           columnDef = this._columnDefinitions.find((column: Column) => column.id === columnFilter.columnId);
         } else {
           columnDef = columnFilter.columnDef;
@@ -402,7 +403,7 @@ export class GraphqlService implements BackendService {
           // escaping the search value
           searchValue = searchValue.replace(`'`, `''`); // escape single quotes by doubling them
           if (operator === '*' || operator === 'a*' || operator === '*z' || lastValueChar === '*') {
-            operator = (operator === '*' || operator === '*z') ? 'endsWith' : 'startsWith';
+            operator = ((operator === '*' || operator === '*z') ? 'EndsWith' : 'StartsWith') as OperatorString;
           }
         }
 
@@ -572,7 +573,7 @@ export class GraphqlService implements BackendService {
   // private functions
   // -------------------
   /**
-   * Cast provided filters (could be in multiple formats) into an array of ColumnFilter
+   * Cast provided filters (could be in multiple formats) into an array of CurrentFilter
    * @param columnFilters
    */
   private castFilterToColumnFilters(columnFilters: ColumnFilters | CurrentFilter[]): CurrentFilter[] {

--- a/src/app/modules/angular-slickgrid/services/grid-odata.service.ts
+++ b/src/app/modules/angular-slickgrid/services/grid-odata.service.ts
@@ -229,13 +229,13 @@ export class GridOdataService implements BackendService {
    * loop through all columns to inspect filters & update backend service filters
    * @param columnFilters
    */
-  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPreset?: boolean) {
+  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically?: boolean) {
     let searchBy = '';
     const searchByArray: string[] = [];
     const odataVersion = this._odataService && this._odataService.options && this._odataService.options.version || 2;
 
     // on filter preset load, we need to keep current filters
-    if (isUpdatedByPreset) {
+    if (isUpdatedByPresetOrDynamically) {
       this._currentFilters = this.castFilterToColumnFilters(columnFilters);
     }
 
@@ -246,7 +246,7 @@ export class GridOdataService implements BackendService {
 
         // if user defined some "presets", then we need to find the filters from the column definitions instead
         let columnDef: Column | undefined;
-        if (isUpdatedByPreset && Array.isArray(this._columnDefinitions)) {
+        if (isUpdatedByPresetOrDynamically && Array.isArray(this._columnDefinitions)) {
           columnDef = this._columnDefinitions.find((column: Column) => {
             return column.id === columnFilter.columnId;
           });

--- a/src/app/modules/angular-slickgrid/services/resizer.service.ts
+++ b/src/app/modules/angular-slickgrid/services/resizer.service.ts
@@ -76,7 +76,7 @@ export class ResizerService {
     const gridDomElm = $(`#${gridOptions.gridId}`);
     const autoResizeOptions = gridOptions && gridOptions.autoResize || {};
     const containerElm = (autoResizeOptions && autoResizeOptions.containerId) ? $(`#${autoResizeOptions.containerId}`) : $(`#${gridOptions.gridContainerId}`);
-    if (!window || containerElm === undefined || gridDomElm === undefined) {
+    if (!window || containerElm === undefined || gridDomElm === undefined || gridDomElm.offset() === undefined) {
       return null;
     }
 

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -67,15 +67,10 @@ export function htmlEncode(inputValue: string): string {
     '<': '&lt;',
     '>': '&gt;',
     '"': '&quot;',
-    '\'': '&#39;',
-    // '/': '&#x2F;',
-    // '`': '&#x60;',
-    // '=': '&#x3D;'
+    '\'': '&#39;'
   };
   // all symbols::  /[&<>"'`=\/]/g
-  return inputValue.replace(/[&<>"']/g, (s) => {
-    return entityMap[s];
-  });
+  return inputValue.replace(/[&<>"']/g, (s) => entityMap[s]);
 }
 
 /** decode text into html entity

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -1,8 +1,9 @@
-import { FieldType, OperatorType } from '../models/index';
 import { Observable, Subscription } from 'rxjs';
-import { first, take } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import * as moment_ from 'moment-mini';
 const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+
+import { FieldType, OperatorString, OperatorType } from '../models/index';
 
 // using external non-typed js libraries
 declare var $: any;
@@ -501,6 +502,58 @@ export function mapOperatorType(operator: string): OperatorType {
   }
 
   return map;
+}
+
+/**
+ * Find equivalent short designation of an Operator Type or Operator String.
+ * When using a Compound Filter, we use the short designation and so we need the mapped value.
+ * For example OperatorType.startsWith short designation is "a*", while OperatorType.greaterThanOrEqual is ">="
+ */
+export function mapOperatorToShortDesignation(operator: OperatorType | OperatorString): OperatorString {
+  let shortOperator: OperatorString = '';
+
+  switch (operator) {
+    case OperatorType.startsWith:
+    case 'a*':
+      shortOperator = 'a*';
+      break;
+    case OperatorType.endsWith:
+    case '*z':
+      shortOperator = '*z';
+      break;
+    case OperatorType.greaterThan:
+    case '>':
+      shortOperator = '>';
+      break;
+    case OperatorType.greaterThanOrEqual:
+    case '>=':
+      shortOperator = '>=';
+      break;
+    case OperatorType.lessThan:
+    case '<':
+      shortOperator = '<';
+      break;
+    case OperatorType.lessThanOrEqual:
+    case '<=':
+      shortOperator = '<=';
+      break;
+    case OperatorType.notEqual:
+    case '<>':
+      shortOperator = '<>';
+      break;
+    case OperatorType.equal:
+    case '=':
+    case '==':
+    case 'EQ':
+      shortOperator = '=';
+      break;
+    default:
+      // any other operator will be considered as already a short expression, so we can return same input operator
+      shortOperator = operator;
+      break;
+  }
+
+  return shortOperator;
 }
 
 /**

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -437,60 +437,53 @@ export function mapFlatpickrDateFormatWithFieldType(fieldType: FieldType): strin
  * @param string operator
  * @returns string map
  */
-export function mapOperatorType(operator: string): OperatorType {
+export function mapOperatorType(operator: OperatorType | OperatorString): OperatorType {
   let map: OperatorType;
 
   switch (operator) {
     case '<':
+    case 'LT':
       map = OperatorType.lessThan;
       break;
     case '<=':
+    case 'LE':
       map = OperatorType.lessThanOrEqual;
       break;
     case '>':
+    case 'GT':
       map = OperatorType.greaterThan;
       break;
     case '>=':
+    case 'GE':
       map = OperatorType.greaterThanOrEqual;
       break;
     case '<>':
     case '!=':
-    case 'neq':
-    case 'NEQ':
+    case 'NE':
       map = OperatorType.notEqual;
       break;
     case '*':
-    case '.*':
     case 'a*':
-    case 'startsWith':
     case 'StartsWith':
       map = OperatorType.startsWith;
       break;
-    case '*.':
     case '*z':
-    case 'endsWith':
     case 'EndsWith':
       map = OperatorType.endsWith;
       break;
     case '=':
     case '==':
-    case 'eq':
     case 'EQ':
       map = OperatorType.equal;
       break;
-    case 'in':
     case 'IN':
       map = OperatorType.in;
       break;
-    case 'notIn':
     case 'NIN':
     case 'NOT_IN':
       map = OperatorType.notIn;
       break;
-    case 'not_contains':
     case 'Not_Contains':
-    case 'notContains':
-    case 'NotContains':
     case 'NOT_CONTAINS':
       map = OperatorType.notContains;
       break;
@@ -509,18 +502,10 @@ export function mapOperatorType(operator: string): OperatorType {
  * When using a Compound Filter, we use the short designation and so we need the mapped value.
  * For example OperatorType.startsWith short designation is "a*", while OperatorType.greaterThanOrEqual is ">="
  */
-export function mapOperatorToShortDesignation(operator: OperatorType | OperatorString): OperatorString {
+export function mapOperatorToShorthandDesignation(operator: OperatorType | OperatorString): OperatorString {
   let shortOperator: OperatorString = '';
 
   switch (operator) {
-    case OperatorType.startsWith:
-    case 'a*':
-      shortOperator = 'a*';
-      break;
-    case OperatorType.endsWith:
-    case '*z':
-      shortOperator = '*z';
-      break;
     case OperatorType.greaterThan:
     case '>':
       shortOperator = '>';
@@ -546,6 +531,15 @@ export function mapOperatorToShortDesignation(operator: OperatorType | OperatorS
     case '==':
     case 'EQ':
       shortOperator = '=';
+      break;
+    case OperatorType.startsWith:
+    case 'a*':
+    case '*':
+      shortOperator = 'a*';
+      break;
+    case OperatorType.endsWith:
+    case '*z':
+      shortOperator = '*z';
       break;
     default:
       // any other operator will be considered as already a short expression, so we can return same input operator

--- a/test/cypress/integration/example25.spec.js
+++ b/test/cypress/integration/example25.spec.js
@@ -2,7 +2,9 @@
 import moment from 'moment-mini';
 
 const presetMinComplete = 5;
-const presetMaxComplete = 88;
+const presetMaxComplete = 80;
+const presetMinDuration = 4;
+const presetMaxDuration = 88;
 const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
 const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
 
@@ -50,9 +52,8 @@ describe('Example 25 - Range Filters', () => {
           .each(($cell) => {
             const value = parseInt($cell.text().trim(), 10);
             if (!isNaN(value)) {
-              console.log('duration', value, presetMinComplete, presetMaxComplete, value > presetMinComplete, value < presetMaxComplete)
-              expect(value > presetMinComplete).to.eq(true);
-              expect(value < presetMaxComplete).to.eq(true);
+              expect(value > presetMinDuration).to.eq(true);
+              expect(value < presetMaxDuration).to.eq(true);
             }
           });
       });
@@ -116,7 +117,6 @@ describe('Example 25 - Range Filters', () => {
       });
   });
 
-
   xit('should change the "Finish" date in the picker and expect all rows to be within new dates range', () => {
     cy.contains('Clear Filters')
       .click({ force: true });
@@ -145,5 +145,69 @@ describe('Example 25 - Range Filters', () => {
             expect(isDateBetween).to.eq(true);
           });
       });
+  });
+
+  describe('Set Dymamic Filters', () => {
+    const dynamicMinComplete = 12;
+    const dynamicMaxComplete = 82;
+    const dynamicMinDuration = 14;
+    const dynamicMaxDuration = 78;
+    const dynamicLowestDay = moment().add(-5, 'days').format('YYYY-MM-DD');
+    const dynamicHighestDay = moment().add(25, 'days').format('YYYY-MM-DD');
+
+    it('should click on Set Dynamic Filters', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+    });
+
+    it('should have "% Complete" fields within the exclusive range of the filters presets', () => {
+      cy.get('#grid25')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(2)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                expect(value > dynamicMinComplete).to.eq(true);
+                expect(value < dynamicMaxComplete).to.eq(true);
+              }
+            });
+        });
+    });
+
+    it('should have "Duration" fields within the inclusive range of the dynamic filters', () => {
+      cy.get('#grid25')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(5)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                expect(value >= dynamicMinDuration).to.eq(true);
+                expect(value <= dynamicMaxDuration).to.eq(true);
+              }
+            });
+        });
+    });
+
+    it('should have Finish Dates within the range (inclusive) of the dynamic filters', () => {
+      cy.get('.search-filter.filter-finish')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(`${dynamicLowestDay} to ${dynamicHighestDay}`));
+
+      cy.get('#grid25')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(4)')
+            .each(($cell) => {
+              const isDateBetween = moment($cell.text()).isBetween(dynamicLowestDay, dynamicHighestDay, null, '[]'); // [] is inclusive, () is exclusive
+              expect(isDateBetween).to.eq(true);
+            });
+        });
+    });
   });
 });

--- a/test/cypress/integration/example4.spec.js
+++ b/test/cypress/integration/example4.spec.js
@@ -1,0 +1,108 @@
+/// <reference types="cypress" />
+import moment from 'moment-mini';
+
+describe('Example 4 - Client Side Sort/Filter Grid', () => {
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/clientside`);
+    cy.get('h2').should('contain', 'Example 4: Client Side Sort/Filter');
+  });
+
+  describe('Load Grid with Presets', () => {
+    const presetDurationValues = [220, 10];
+    const presetUsDateShort = '04/20/25';
+
+    it('should have "Duration" fields within the inclusive range of the preset filters', () => {
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(2)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                const foundItems = presetDurationValues.filter(acceptedValue => acceptedValue === value);
+                expect(foundItems).to.have.length(1);
+              }
+            });
+        });
+    });
+
+    it('should have US Date Short within the range of the preset filters', () => {
+      cy.get('.search-filter.filter-usDateShort')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(presetUsDateShort));
+
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(5)')
+            .each(($cell) => {
+              const isDateValid = moment($cell.text(), 'M/D/YY').isBefore(presetUsDateShort);
+              expect(isDateValid).to.eq(true);
+            });
+        });
+    });
+  });
+
+  describe('Set Dymamic Filters', () => {
+    const dynamicDurationValues = [2, 25, 48, 50];
+    const dynamicMaxComplete = 95;
+    const dynamicStartDate = '2001-02-28';
+
+    it('should click on Set Dynamic Filters', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+    });
+
+    it('should have "% Complete" fields within the exclusive range of the filters presets', () => {
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(3)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                expect(value < dynamicMaxComplete).to.eq(true);
+              }
+            });
+        });
+    });
+
+    it('should have "Duration" fields within the inclusive range of the dynamic filters', () => {
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(2)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                const foundItems = dynamicDurationValues.filter(acceptedValue => acceptedValue === value);
+                expect(foundItems).to.have.length(1);
+              }
+            });
+        });
+    });
+
+    it('should have Start Date within the range of the dynamic filters', () => {
+      cy.get('.search-filter.filter-start')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(dynamicStartDate));
+
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(4)')
+            .each(($cell) => {
+              const isDateValid = moment($cell.text()).isSameOrAfter(dynamicStartDate);
+              expect(isDateValid).to.eq(true);
+            });
+        });
+    });
+  });
+});

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -258,6 +258,31 @@ describe('Example 5 - OData Grid', () => {
         .find('.slick-row')
         .should('have.length', 1);
     });
+
+    it('should click on Set Dynamic Filter and expect query and filters to be changed', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+
+      cy.get('.search-filter.filter-name select')
+        .should('have.value', 'a*')
+
+      cy.get('.search-filter.filter-name')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('A'));
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$count=true&$top=10&$filter=(startswith(Name, 'A'))`);
+        });
+
+      cy.get('#grid5')
+        .find('.slick-row')
+        .should('have.length', 5);
+    });
   });
 
   describe('when "enableCount" is unchecked (not set)', () => {
@@ -362,6 +387,31 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$top=10&$skip=90`);
         });
+    });
+
+    it('should click on Set Dynamic Filter and expect query and filters to be changed', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+
+      cy.get('.search-filter.filter-name select')
+        .should('have.value', 'a*')
+
+      cy.get('.search-filter.filter-name')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('A'));
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$filter=(startswith(Name, 'A'))`);
+        });
+
+      cy.get('#grid5')
+        .find('.slick-row')
+        .should('have.length', 5);
     });
 
     it('should use "substringof" when OData version is set to 2', () => {


### PR DESCRIPTION
- prior to this change, we could update filters only through "presets" but that was only on first page load. Now with this new change we will be to update filters on the fly and at any time

- [x] POC (Proof of Concept)
- [x] Should work with Regular Grid (JSON dataset)
- [x] Should work with Backend Services (OData & GraphQL)
- [x] Add Unit Tests
- [x] Add Cypress E2E tests
- [x] Update demos
- [ ] Update [filter](https://github.com/ghiscoding/Angular-Slickgrid/wiki/Input-Filter) Wiki