### PR TITLE
feat(sorting): provide method to apply grid sorting dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ You like and use this great library `Angular-Slickgrid`? Please upvote :star: an
 
 ### Angular Compatibility
 - version `1.x.x` for Angular 4 to 6 
-   - Angular 6, is only supported through `rxjs-compat` as shown in this [post](https://github.com/ghiscoding/Angular-Slickgrid/issues/36#issuecomment-395710915). It's preferable to upgrade to Angular 7+ to avoid using the `rxjs-compat` version. 
-- version `2.x.x` for Angular 7+
-
-#### Angular 8+
-When running `ng update` to upgrade to Angular 8, one of the biggest change which is noticeable in the build, is that they change the target to `ES2015`. At first there was some issues, but starting with version `2.11.0`, the build target of `ES2015` should work and allow you to use smaller bundles on mordern browser. If you see any bundle problems, please try to switch to `ES5` and see if that makes a difference before opening an issue.
+   - Angular 6, is only supported through `rxjs-compat` as shown in this [post](https://github.com/ghiscoding/Angular-Slickgrid/issues/36#issuecomment-395710915). It's preferable to upgrade to Angular 7+ to avoid using the `rxjs-compat` package. 
+- version `2.x.x` for Angular 7+ 
+  - since version `2.11.0`, you can also change your build `target` to `ES2015` for modern browser.
 
 ### Installation
 Refer to the [Wiki - HOWTO Step by Step](https://github.com/ghiscoding/angular-slickgrid/wiki/HOWTO---Step-by-Step)

--- a/README.md
+++ b/README.md
@@ -26,18 +26,6 @@ You like and use this great library `Angular-Slickgrid`? Please upvote :star: an
 - [Bootstrap 3 demo](https://ghiscoding.github.io/Angular-Slickgrid) / [examples repo](https://github.com/ghiscoding/angular-slickgrid-demos/tree/master/bootstrap3-demo-with-translate)
 - [Bootstrap 4 demo](https://ghiscoding.github.io/angular-slickgrid-demos) / [examples repo](https://github.com/ghiscoding/angular-slickgrid-demos/tree/master/bootstrap4-demo-with-translate)
 
-### Angular Compatibility
-- version `1.x.x` for Angular 4 to 6 
-   - Angular 6, is only supported through `rxjs-compat` as shown in this [post](https://github.com/ghiscoding/Angular-Slickgrid/issues/36#issuecomment-395710915). It's preferable to upgrade to Angular 7+ to avoid using the `rxjs-compat` package. 
-- version `2.x.x` for Angular 7+ 
-  - since version `2.11.0`, you can also change your build `target` to `ES2015` for modern browser.
-
-### Installation
-Refer to the [Wiki - HOWTO Step by Step](https://github.com/ghiscoding/angular-slickgrid/wiki/HOWTO---Step-by-Step)
-
-#### How to load data with `HttpClient`?
-You might notice that all demos are coded with mocked dataset in each examples, that is mainly for demo purposes, but you might be wondering how to connect this with an `HttpClient`? Easy... just replace the mocked data, assigned to the `dataset` property, by your `HttpClient` call and that's it. The `dataset` property can be changed or refreshed at any time, which is why you can use local data and/or connect it to a `Promise` or an `Observable` with `HttpClient` (internally it's just a SETTER that refreshes the grid). See [Example 24](https://ghiscoding.github.io/Angular-Slickgrid/#/gridtabs) for a demo showing how to load a JSON file with `HttpClient`.
-
 #### Working Demo
 For a complete and working local demo, you can clone the [Angular-Slickgrid Demos](https://github.com/ghiscoding/angular-slickgrid-demos) repository. That repo is updated frequently and is used for both the [Bootstrap 3 demo](https://ghiscoding.github.io/Angular-Slickgrid) and [Bootstrap 4 demo](https://ghiscoding.github.io/angular-slickgrid-demos).
 ```bash
@@ -46,6 +34,18 @@ cd bootstrap4-demo-with-translate
 npm install
 npm start
 ```
+
+### Angular Compatibility
+- version `1.x.x` for Angular 4 to 6 
+   - Angular 6, is only supported through `rxjs-compat` as shown in this [post](https://github.com/ghiscoding/Angular-Slickgrid/issues/36#issuecomment-395710915). It's preferable to upgrade to Angular 7+ to avoid using the `rxjs-compat` package. 
+- version `2.x.x` for Angular 7+ 
+  - since version `2.11.0`, you can also change your build `target` to `ES2015` for modern browser.
+
+### Installation
+Refer to the [Wiki - HOWTO Step by Step](https://github.com/ghiscoding/angular-slickgrid/wiki/HOWTO---Step-by-Step) and/or clone the [Angular-Slickgrid Demos](https://github.com/ghiscoding/angular-slickgrid-demos).
+
+#### How to load data with `HttpClient`?
+You might notice that all demos are coded with mocked dataset in each examples, that is mainly for demo purposes, but you might be wondering how to connect this with an `HttpClient`? Easy... just replace the mocked data, assigned to the `dataset` property, by your `HttpClient` call and that's it. The `dataset` property can be changed or refreshed at any time, which is why you can use local data and/or connect it to a `Promise` or an `Observable` with `HttpClient` (internally it's just a SETTER that refreshes the grid). See [Example 24](https://ghiscoding.github.io/Angular-Slickgrid/#/gridtabs) for a demo showing how to load a JSON file with `HttpClient`.
 
 #### Material Theme
 Technically speaking, `Material` theme is not provided, but it should still work. 

--- a/src/app/examples/grid-clientside.component.html
+++ b/src/app/examples/grid-clientside.component.html
@@ -12,6 +12,9 @@
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
     Set Filters Dynamically
   </button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" (click)="setSortingDynamically()">
+    Set Sorting Dynamically
+  </button>
 
   <angular-slickgrid gridId="grid4" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
     [dataset]="dataset" (onAngularGridCreated)="angularGridReady($event)"

--- a/src/app/examples/grid-clientside.component.html
+++ b/src/app/examples/grid-clientside.component.html
@@ -7,8 +7,12 @@
     <b>Metrics:</b> {{metrics.startTime | date: 'yyyy-MM-dd HH:mm aaaaa\'m\''}} | {{metrics.itemCount}} of
     {{metrics.totalItemCount}} items
   </span>
-  <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
-  <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" data-test="clear-filters" (click)="angularGrid.filterService.clearFilters()">
+    Clear Filters
+  </button>
+  <button class="btn btn-default btn-sm" data-test="clear-sorting" (click)="angularGrid.sortService.clearSorting()">
+    Clear Sorting
+  </button>
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
     Set Filters Dynamically
   </button>

--- a/src/app/examples/grid-clientside.component.ts
+++ b/src/app/examples/grid-clientside.component.ts
@@ -184,7 +184,7 @@ export class GridClientSideComponent implements OnInit {
       // use columnDef searchTerms OR use presets as shown below
       presets: {
         filters: [
-          { columnId: 'duration', searchTerms: [10, 220] },
+          { columnId: 'duration', searchTerms: [10, 98] },
           // { columnId: 'complete', searchTerms: ['5'], operator: '>' },
           { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },
           // { columnId: 'effort-driven', searchTerms: [true] },
@@ -256,6 +256,14 @@ export class GridClientSideComponent implements OnInit {
       { columnId: 'complete', searchTerms: [95], operator: '<' },
       { columnId: 'effort-driven', searchTerms: [true] },
       { columnId: 'start', operator: '>=', searchTerms: ['2001-02-28'] },
+    ]);
+  }
+
+  setSortingDynamically() {
+    this.angularGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'duration', direction: 'ASC' },
+      { columnId: 'start', direction: 'DESC' },
     ]);
   }
 

--- a/src/app/examples/grid-draggrouping.component.html
+++ b/src/app/examples/grid-draggrouping.component.html
@@ -37,8 +37,12 @@
       <button class="btn btn-default btn-xs" (click)="groupByDurationEffortDriven()">
         Group by Duration then Effort-Driven
       </button>
+      |
       <button class="btn btn-default btn-xs" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
         Set Filters Dynamically
+      </button>
+      <button class="btn btn-default btn-xs" data-test="set-dynamic-sorting" (click)="setSortingDynamically()">
+        Set Sorting Dynamically
       </button>
     </div>
     <div class="col-sm-12">

--- a/src/app/examples/grid-draggrouping.component.ts
+++ b/src/app/examples/grid-draggrouping.component.ts
@@ -361,16 +361,23 @@ export class GridDraggableGroupingComponent implements OnInit {
     return index;
   }
 
-  toggleDraggableGroupingRow() {
-    this.clearGrouping();
-    this.gridObj.setPreHeaderPanelVisibility(!this.gridObj.getOptions().showPreHeaderPanel);
-  }
-
   setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       { columnId: 'percentComplete', operator: '>=', searchTerms: ['55'] },
       { columnId: 'cost', operator: '<', searchTerms: ['80'] },
     ]);
+  }
+
+  setSortingDynamically() {
+    this.angularGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'percentComplete', direction: 'ASC' },
+    ]);
+  }
+
+  toggleDraggableGroupingRow() {
+    this.clearGrouping();
+    this.gridObj.setPreHeaderPanelVisibility(!this.gridObj.getOptions().showPreHeaderPanel);
   }
 }

--- a/src/app/examples/grid-graphql.component.html
+++ b/src/app/examples/grid-graphql.component.html
@@ -37,6 +37,9 @@
         <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
           <i class="fa fa-caret-right fa-lg"></i>
         </button>
+        <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" (click)="setSortingDynamically()">
+          Set Sorting Dynamically
+        </button>
       </div>
     </div>
     <div class="col-sm-7">

--- a/src/app/examples/grid-graphql.component.html
+++ b/src/app/examples/grid-graphql.component.html
@@ -11,7 +11,8 @@
         </span>
       </div>
 
-      <button class="btn btn-default btn-sm" (click)="clearAllFiltersAndSorts()" title="Clear all Filters & Sorts">
+      <button class="btn btn-default btn-sm" data-test="clear-filters-sorting" (click)="clearAllFiltersAndSorts()"
+        title="Clear all Filters & Sorts">
         <i class="fa fa-filter text-danger"></i>
         Clear all Filter & Sorts
       </button>

--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -286,6 +286,14 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
     ]);
   }
 
+  setSortingDynamically() {
+    this.angularGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'billingAddressZip', direction: 'DESC' },
+      { columnId: 'company', direction: 'ASC' },
+    ]);
+  }
+
   switchLanguage() {
     this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
     this.translate.use(this.selectedLanguage);

--- a/src/app/examples/grid-odata.component.html
+++ b/src/app/examples/grid-odata.component.html
@@ -49,6 +49,9 @@
     <button class="btn btn-default btn-xs" data-test="goto-last-page" (click)="goToLastPage()">
       <i class="fa fa-caret-right fa-lg"></i>
     </button>
+    <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" (click)="setSortingDynamically()">
+      Set Sorting Dynamically
+    </button>
   </div>
 
   <angular-slickgrid gridId="grid5" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"

--- a/src/app/examples/grid-odata.component.ts
+++ b/src/app/examples/grid-odata.component.ts
@@ -170,6 +170,12 @@ export class GridOdataComponent implements OnInit {
     ]);
   }
 
+  setSortingDynamically() {
+    this.angularGrid.sortService.updateSorting([
+      { columnId: 'name', direction: 'DESC' },
+    ]);
+  }
+
   /** This function is only here to mock a WebAPI call (since we are using a JSON file for the demo)
    *  in your case the getCustomer() should be a WebAPI function returning a Promise
    */

--- a/src/app/examples/grid-range.component.html
+++ b/src/app/examples/grid-range.component.html
@@ -12,6 +12,9 @@
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
     Set Filters Dynamically
   </button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" (click)="setSortingDynamically()">
+    Set Sorting Dynamically
+  </button>
   <button class="btn btn-default btn-sm" (click)="switchLanguage()" data-test="language">
     <i class="fa fa-language"></i>
     Switch Language

--- a/src/app/examples/grid-range.component.html
+++ b/src/app/examples/grid-range.component.html
@@ -7,8 +7,12 @@
     <b>Metrics:</b> {{metrics.startTime | date: 'yyyy-MM-dd HH:mm aaaaa\'m\''}} | {{metrics.itemCount}} of
     {{metrics.totalItemCount}} items
   </span>
-  <button class="btn btn-default btn-sm" (click)="angularGrid.filterService.clearFilters()">Clear Filters</button>
-  <button class="btn btn-default btn-sm" (click)="angularGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" data-test="clear-filters" (click)="angularGrid.filterService.clearFilters()">
+    Clear Filters
+  </button>
+  <button class="btn btn-default btn-sm" data-test="clear-sorting" (click)="angularGrid.sortService.clearSorting()">
+    Clear Sorting
+  </button>
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" (click)="setFiltersDynamically()">
     Set Filters Dynamically
   </button>

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -224,11 +224,6 @@ export class GridRangeComponent implements OnInit {
     }
   }
 
-  switchLanguage() {
-    const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.translate.use(nextLocale).subscribe(() => this.selectedLanguage = nextLocale);
-  }
-
   setFiltersDynamically() {
     const presetLowestDay = moment().add(-5, 'days').format('YYYY-MM-DD');
     const presetHighestDay = moment().add(25, 'days').format('YYYY-MM-DD');
@@ -239,5 +234,18 @@ export class GridRangeComponent implements OnInit {
       { columnId: 'complete', operator: 'RangeExclusive', searchTerms: [12, 82] },
       { columnId: 'finish', operator: 'RangeInclusive', searchTerms: [presetLowestDay, presetHighestDay] },
     ]);
+  }
+
+  setSortingDynamically() {
+    this.angularGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'start', direction: 'DESC' },
+      { columnId: 'complete', direction: 'ASC' },
+    ]);
+  }
+
+  switchLanguage() {
+    const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    this.translate.use(nextLocale).subscribe(() => this.selectedLanguage = nextLocale);
   }
 }

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -231,7 +231,7 @@ export class GridRangeComponent implements OnInit {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.angularGrid.filterService.updateFilters([
       { columnId: 'duration', searchTerms: ['14..78'], operator: 'RangeInclusive' },
-      { columnId: 'complete', operator: 'RangeExclusive', searchTerms: [12, 82] },
+      { columnId: 'complete', operator: 'RangeExclusive', searchTerms: [10, 80] },
       { columnId: 'finish', operator: 'RangeInclusive', searchTerms: [presetLowestDay, presetHighestDay] },
     ]);
   }

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -239,7 +239,7 @@ export class GridRangeComponent implements OnInit {
   setSortingDynamically() {
     this.angularGrid.sortService.updateSorting([
       // orders matter, whichever is first in array will be the first sorted column
-      { columnId: 'start', direction: 'DESC' },
+      { columnId: 'finish', direction: 'DESC' },
       { columnId: 'complete', direction: 'ASC' },
     ]);
   }

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
@@ -130,7 +130,7 @@ const sortServiceStub = {
   bindBackendOnSort: jest.fn(),
   bindLocalOnSort: jest.fn(),
   dispose: jest.fn(),
-  loadLocalGridPresets: jest.fn(),
+  loadGridSorters: jest.fn(),
 } as unknown as SortService;
 
 const mockGroupItemMetaProvider = {
@@ -458,9 +458,9 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         expect(spy).toHaveBeenCalledWith(expect.any(Object));
       });
 
-      it('should call the "executeAfterDataviewCreated" and "loadLocalGridPresets" methods and Sorter Presets are provided in the Grid Options', () => {
+      it('should call the "executeAfterDataviewCreated" and "loadGridSorters" methods and Sorter Presets are provided in the Grid Options', () => {
         const spy = jest.spyOn(component.onDataviewCreated, 'emit');
-        const sortSpy = jest.spyOn(sortServiceStub, 'loadLocalGridPresets');
+        const sortSpy = jest.spyOn(sortServiceStub, 'loadGridSorters');
 
         component.gridOptions = { presets: { sorters: [{ columnId: 'field1', direction: 'DESC' }] } } as GridOption;
         component.ngAfterViewInit();

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
@@ -22,7 +22,7 @@ import { GridOption, CurrentFilter, CurrentSorter, GridStateType, Pagination, Gr
 import { Filters } from '../../filters';
 import { Editors } from '../../editors';
 import * as utilities from '../../services/backend-utilities';
-import { Subject, of, throwError, Observable } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { GridStateChange } from 'dist/public_api';
 import { TestBed } from '@angular/core/testing';
 

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -578,7 +578,7 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
     // if user entered some Sort "presets", we need to reflect them all in the DOM
     if (gridOptions.enableSorting) {
       if (gridOptions.presets && Array.isArray(gridOptions.presets.sorters) && gridOptions.presets.sorters.length > 0) {
-        this.sortService.loadLocalGridPresets(grid, dataView);
+        this.sortService.loadGridSorters(gridOptions.presets.sorters);
       }
     }
   }

--- a/src/app/modules/angular-slickgrid/services/__tests__/bsDropdown.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/bsDropdown.service.spec.ts
@@ -142,6 +142,35 @@ describe('bsdropdown-service', () => {
         expect(showSpy).toHaveBeenCalled();
         expect(service.domContainerElement).toBeTruthy();
       });
+
+      it('should drop up when window height is below parent div offset top', async () => {
+        const divDropdown = document.createElement('div');
+        divDropdown.className = 'dropdown-menu';
+        divDropdown.style.height = '200px';
+        div.appendChild(divDropdown);
+        const compSpy = jest.spyOn(angularUtilServiceStub, 'createAngularComponent').mockReturnValue(mockComponent);
+        const disposeSpy = jest.spyOn(service, 'dispose');
+        const showSpy = jest.spyOn(service, 'dropContainerShow');
+
+        Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 100 });
+        Object.defineProperty(div, 'offsetTop', { writable: true, configurable: true, value: 150 });
+        window.dispatchEvent(new Event('resize'));
+        div.dispatchEvent(new Event('resize'));
+        await service.render({
+          component: TestComponent,
+          args: { row: 0, cell: 0, grid: gridStub },
+          parent: {}
+        });
+
+        service.domElement.trigger('hidden.bs.dropdown');
+
+        expect(service.domElement[0].style.marginTop).toBe('-40px');
+        expect(compSpy).toHaveBeenCalledWith(TestComponent);
+        expect(service.domElement).toBeTruthy();
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+        expect(showSpy).toHaveBeenCalled();
+        expect(service.domContainerElement).toBeTruthy();
+      });
     });
   });
 });

--- a/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
@@ -936,7 +936,7 @@ describe('FilterService', () => {
         service.bindLocalOnFilter(gridStub, dataViewStub);
         service.updateFilters([{ columnId: 'firstName', searchTerms: ['John'] }]);
       } catch (e) {
-        expect(e.toString()).toContain('[Angular-Slickgrid] in order to use "updateFilters" method, you need to have Filters defined in your grid');
+        expect(e.toString()).toContain('[Angular-Slickgrid] in order to use "updateFilters" method, you need to have Filterable Columns defined in your grid');
         done();
       }
     });

--- a/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
@@ -3,6 +3,8 @@ import '../../../../../assets/lib/multiple-select/multiple-select';
 
 import { TestBed, async } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+
 import {
   BackendService,
   Column,
@@ -17,7 +19,11 @@ import { FilterService } from '../filter.service';
 import { FilterFactory } from '../../filters/filterFactory';
 import { SharedService } from '../shared.service';
 import { SlickgridConfig, CollectionService } from '../..';
-import { of, throwError } from 'rxjs';
+import * as utilities from '../../services/backend-utilities';
+
+const mockRefreshBackendDataset = jest.fn();
+// @ts-ignore
+utilities.refreshBackendDataset = mockRefreshBackendDataset;
 
 declare var Slick: any;
 const DOM_ELEMENT_ID = 'row-detail123';
@@ -976,12 +982,13 @@ describe('FilterService', () => {
       service.updateFilters(mockNewFilters);
 
       expect(emitSpy).toHaveBeenCalledWith('remote');
-      expect(clearSpy).toHaveBeenCalledWith(false);
       expect(backendUpdateSpy).toHaveBeenCalledWith(mockNewFilters, true);
       expect(service.getColumnFilters()).toEqual({
         firstName: { columnId: 'firstName', columnDef: mockColumn1, searchTerms: ['Jane'], operator: 'StartsWith' },
         isActive: { columnId: 'isActive', columnDef: mockColumn2, searchTerms: [false], operator: 'EQ' }
       });
+      expect(clearSpy).toHaveBeenCalledWith(false);
+      expect(mockRefreshBackendDataset).toHaveBeenCalledWith(gridOptionMock);
     });
   });
 });

--- a/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
@@ -405,7 +405,7 @@ describe('SortService', () => {
     });
   });
 
-  describe('loadLocalGridPresets method', () => {
+  describe('loadGridSorters method', () => {
     const mockColumns = [{ id: 'firstName', field: 'firstName' }, { id: 'lastName', field: 'lastName' }] as Column[];
 
     beforeEach(() => {
@@ -424,7 +424,7 @@ describe('SortService', () => {
       ];
 
       service.bindLocalOnSort(gridStub, dataViewStub);
-      service.loadLocalGridPresets(gridStub, dataViewStub);
+      service.loadGridSorters(gridOptionMock.presets.sorters);
 
       expect(spySetCols).toHaveBeenCalledWith(expectation);
       expect(spySortChanged).toHaveBeenCalledWith(gridStub, dataViewStub, expectation);
@@ -440,7 +440,7 @@ describe('SortService', () => {
       gridStub.getColumns = undefined;
 
       service.bindLocalOnSort(gridStub, dataViewStub);
-      service.loadLocalGridPresets(gridStub, dataViewStub);
+      service.loadGridSorters(gridOptionMock.presets.sorters);
 
       expect(spySetCols).not.toHaveBeenCalled();
     });
@@ -450,7 +450,7 @@ describe('SortService', () => {
       gridStub.getOptions = undefined;
 
       service.bindLocalOnSort(gridStub, dataViewStub);
-      service.loadLocalGridPresets(gridStub, dataViewStub);
+      service.loadGridSorters(gridOptionMock.presets.sorters);
 
       expect(spySetCols).not.toHaveBeenCalled();
     });

--- a/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
@@ -1,3 +1,5 @@
+import { of, throwError } from 'rxjs';
+
 import {
   BackendService,
   Column,
@@ -11,9 +13,13 @@ import {
 } from '../../models';
 import { Sorters } from '../../sorters';
 import { SortService } from '../sort.service';
-import { of, throwError } from 'rxjs';
+import * as utilities from '../../services/backend-utilities';
 
 declare var Slick: any;
+
+const mockRefreshBackendDataset = jest.fn();
+// @ts-ignore
+utilities.refreshBackendDataset = mockRefreshBackendDataset;
 
 const gridOptionMock = {
   enablePagination: true,
@@ -32,10 +38,12 @@ const dataViewStub = {
 };
 
 const backendServiceStub = {
+  buildQuery: jest.fn(),
   clearSorters: jest.fn(),
   getCurrentFilters: jest.fn(),
   getCurrentPagination: jest.fn(),
   getCurrentSorters: jest.fn(),
+  updateSorters: jest.fn(),
   processOnSortChanged: (event: Event, args: SortChangedArgs) => 'backend query',
 } as unknown as BackendService;
 
@@ -587,6 +595,67 @@ describe('SortService', () => {
         { firstName: 'Christopher', lastName: 'McDonald', age: 40, address: { zip: 555555 } },
       ]);
     });
+  });
 
+  describe('updateSorting method', () => {
+    let mockColumn1: Column;
+    let mockColumn2: Column;
+    let mockNewSorters: CurrentSorter[];
+
+    beforeEach(() => {
+      gridStub.getOptions = () => gridOptionMock;
+      gridOptionMock.enableSorting = true;
+      gridOptionMock.backendServiceApi = undefined;
+
+      mockNewSorters = [
+        { columnId: 'firstName', direction: 'ASC' },
+        { columnId: 'isActive', direction: 'desc' }
+      ];
+      mockColumn1 = { id: 'firstName', name: 'firstName', field: 'firstName', sortable: true };
+      mockColumn2 = { id: 'isActive', name: 'isActive', field: 'isActive', sortable: true };
+      gridStub.getColumns = jest.fn();
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1, mockColumn2]);
+    });
+
+    it('should throw an error when there are no filters defined in the column definitions', (done) => {
+      try {
+        gridOptionMock.enableSorting = false;
+        service.bindLocalOnSort(gridStub, dataViewStub);
+        service.updateSorting([{ columnId: 'firstName', direction: 'ASC' }]);
+      } catch (e) {
+        expect(e.toString()).toContain('[Angular-Slickgrid] in order to use "updateSorting" method, you need to have Sortable Columns defined in your grid');
+        done();
+      }
+    });
+
+    it('should trigger an "emitSortChanged" local when using "bindLocalOnSort" and also expect sorters to be set in ColumnFilters', () => {
+      const emitSpy = jest.spyOn(service, 'emitSortChanged');
+
+      service.bindLocalOnSort(gridStub, dataViewStub);
+      service.updateSorting(mockNewSorters);
+
+      expect(emitSpy).toHaveBeenCalledWith('local');
+      expect(service.getCurrentLocalSorters()).toEqual([
+        { columnId: 'firstName', direction: 'ASC' },
+        { columnId: 'isActive', direction: 'DESC' }
+      ]);
+    });
+
+    it('should trigger an "emitSortChanged" remote when using "bindLocalOnSort" and also expect sorters to be set in ColumnFilters', () => {
+      gridOptionMock.backendServiceApi = {
+        service: backendServiceStub,
+        process: () => new Promise((resolve) => resolve(jest.fn())),
+      };
+      const emitSpy = jest.spyOn(service, 'emitSortChanged');
+      const backendUpdateSpy = jest.spyOn(backendServiceStub, 'updateSorters');
+
+      service.bindLocalOnSort(gridStub, dataViewStub);
+      service.updateSorting(mockNewSorters);
+
+      expect(emitSpy).toHaveBeenCalledWith('remote');
+      expect(service.getCurrentLocalSorters()).toEqual([]);
+      expect(backendUpdateSpy).toHaveBeenCalledWith(undefined, mockNewSorters);
+      expect(mockRefreshBackendDataset).toHaveBeenCalledWith(gridOptionMock);
+    });
   });
 });

--- a/src/app/modules/angular-slickgrid/services/bsDropdown.service.ts
+++ b/src/app/modules/angular-slickgrid/services/bsDropdown.service.ts
@@ -102,10 +102,10 @@ export class BsDropDownService {
               const offset = 35;
               const iElement = $('.dropdown-menu');
               const iElementWrapper = iElement.parent();
-              const IElementWrapperOffset = iElementWrapper.offset() || {};
-              const iElementWrapperOffsetTop = IElementWrapperOffset.top;
+              const iElementWrapperOffset = iElementWrapper.offset() || {};
+              const iElementWrapperOffsetTop = iElementWrapperOffset.top || iElementWrapper && iElementWrapper.length > 0 && iElementWrapper[0].offsetTop;
               const iElementHeight = iElement.height();
-              const windowHeight = $(window).height();
+              const windowHeight = window.innerHeight;
               const shouldDropUp = (windowHeight - iElementHeight - offset) < iElementWrapperOffsetTop;
               let menuMarginTop = '0px';
               if (shouldDropUp) {
@@ -115,7 +115,7 @@ export class BsDropDownService {
               this._domElement.css({ 'margin-top': menuMarginTop });
 
               // set dropdown margin left according to the document width
-              const parentOffset = IElementWrapperOffset.left;
+              const parentOffset = iElementWrapperOffset.left;
               const leftMargin = parentOffset - $(document).width();
               this._domElement.css({ 'margin-left': (this._domElement.width() + leftMargin + 60) + 'px' });
 

--- a/src/app/modules/angular-slickgrid/services/filter.service.ts
+++ b/src/app/modules/angular-slickgrid/services/filter.service.ts
@@ -1,4 +1,8 @@
 import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+import * as isequal_ from 'lodash.isequal';
+const isequal = isequal_; // patch to fix rollup to work
+
 import {
   Column,
   ColumnFilter,
@@ -23,9 +27,6 @@ import { getDescendantProperty } from './utilities';
 import { FilterConditions } from './../filter-conditions';
 import { FilterFactory } from '../filters/filterFactory';
 import { SharedService } from './shared.service';
-import { Subject } from 'rxjs';
-import * as isequal_ from 'lodash.isequal';
-const isequal = isequal_; // patch to fix rollup to work
 
 // using external non-typed js libraries
 declare var Slick: any;
@@ -476,7 +477,7 @@ export class FilterService {
 
   updateFilters(filters: CurrentFilter[]) {
     if (!this._filtersMetadata || this._filtersMetadata.length === 0 || !this._gridOptions || !this._gridOptions.enableFiltering) {
-      throw new Error('[Angular-Slickgrid] in order to use "updateFilters" method, you need to have Filters defined in your grid and "enableFiltering" set in your Grid Options');
+      throw new Error('[Angular-Slickgrid] in order to use "updateFilters" method, you need to have Filterable Columns defined in your grid and "enableFiltering" set in your Grid Options');
     }
 
     if (Array.isArray(filters)) {

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -189,19 +189,19 @@ export class SortService {
     const sortCols: ColumnSort[] = [];
 
     if (Array.isArray(sorters)) {
-      sorters.forEach((presetSorting: CurrentSorter) => {
-        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === presetSorting.columnId);
+      sorters.forEach((sorter: CurrentSorter) => {
+        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === sorter.columnId);
         if (gridColumn) {
           sortCols.push({
             columnId: gridColumn.id,
-            sortAsc: ((presetSorting.direction.toUpperCase() === SortDirection.ASC) ? true : false),
+            sortAsc: ((sorter.direction.toUpperCase() === SortDirection.ASC) ? true : false),
             sortCol: gridColumn
           });
 
           // keep current sorters
           this._currentLocalSorters.push({
             columnId: gridColumn.id + '',
-            direction: presetSorting.direction.toUpperCase() as SortDirectionString
+            direction: sorter.direction.toUpperCase() as SortDirectionString
           });
         }
       });

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -1,3 +1,5 @@
+import { Subject } from 'rxjs';
+
 import {
   Column,
   ColumnSort,
@@ -10,10 +12,9 @@ import {
   SortDirectionNumber,
   SortDirectionString,
 } from './../models/index';
-import { executeBackendCallback } from './backend-utilities';
+import { executeBackendCallback, refreshBackendDataset } from './backend-utilities';
 import { getDescendantProperty } from './utilities';
 import { sortByFieldType } from '../sorters/sorterUtilities';
-import { Subject } from 'rxjs';
 
 // using external non-typed js libraries
 declare var Slick: any;
@@ -188,32 +189,9 @@ export class SortService {
    * @param dataView
    */
   loadLocalGridPresets(grid: any, dataView: any) {
-    const sortCols: ColumnSort[] = [];
-    this._currentLocalSorters = []; // reset current local sorters
-    if (this._gridOptions && this._gridOptions.presets && this._gridOptions.presets.sorters) {
-      const sorters = this._gridOptions.presets.sorters;
-
-      sorters.forEach((presetSorting: CurrentSorter) => {
-        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === presetSorting.columnId);
-        if (gridColumn) {
-          sortCols.push({
-            columnId: gridColumn.id,
-            sortAsc: ((presetSorting.direction.toUpperCase() === SortDirection.ASC) ? true : false),
-            sortCol: gridColumn
-          });
-
-          // keep current sorters
-          this._currentLocalSorters.push({
-            columnId: gridColumn.id + '',
-            direction: presetSorting.direction.toUpperCase() as SortDirectionString
-          });
-        }
-      });
-
-      if (sortCols.length > 0) {
-        this.onLocalSortChanged(grid, dataView, sortCols);
-        grid.setSortColumns(sortCols); // use this to add sort icon(s) in UI
-      }
+    const sorters = this._gridOptions && this._gridOptions.presets && this._gridOptions.presets.sorters;
+    if (Array.isArray(sorters)) {
+      this.loadGridSorting(sorters);
     }
   }
 
@@ -287,5 +265,61 @@ export class SortService {
       }
     }
     return SortDirectionNumber.neutral;
+  }
+
+  updateSorting(sorters: CurrentSorter[]) {
+    if (!this._gridOptions || !this._gridOptions.enableSorting) {
+      throw new Error('[Angular-Slickgrid] in order to use "updateSorting" method, you need to have Sortable Columns defined in your grid and "enableSorting" set in your Grid Options');
+    }
+
+    const backendApi = this._gridOptions && this._gridOptions.backendServiceApi;
+
+    if (backendApi) {
+      const backendApiService = backendApi && backendApi.service;
+      if (backendApiService) {
+        backendApiService.updateSorters(undefined, sorters);
+        refreshBackendDataset(this._gridOptions);
+        this.emitSortChanged(EmitterType.remote);
+      }
+    } else {
+      this.loadGridSorting(sorters);
+      this.emitSortChanged(EmitterType.local);
+    }
+  }
+
+  // --
+  // private functions
+  // -------------------
+
+  /** Load a defined Sort into the grid */
+  private loadGridSorting(sorters: CurrentSorter[]): ColumnSort[] {
+    this._currentLocalSorters = []; // reset current local sorters
+    const sortCols: ColumnSort[] = [];
+
+    if (Array.isArray(sorters)) {
+      sorters.forEach((presetSorting: CurrentSorter) => {
+        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === presetSorting.columnId);
+        if (gridColumn) {
+          sortCols.push({
+            columnId: gridColumn.id,
+            sortAsc: ((presetSorting.direction.toUpperCase() === SortDirection.ASC) ? true : false),
+            sortCol: gridColumn
+          });
+
+          // keep current sorters
+          this._currentLocalSorters.push({
+            columnId: gridColumn.id + '',
+            direction: presetSorting.direction.toUpperCase() as SortDirectionString
+          });
+        }
+      });
+    }
+
+    if (sortCols.length > 0) {
+      this.onLocalSortChanged(this._grid, this._dataView, sortCols);
+      this._grid.setSortColumns(sortCols); // use this to add sort icon(s) in UI
+    }
+
+    return sortCols;
   }
 }

--- a/test/cypress/integration/example25.spec.js
+++ b/test/cypress/integration/example25.spec.js
@@ -148,8 +148,8 @@ describe('Example 25 - Range Filters', () => {
   });
 
   describe('Set Dymamic Filters', () => {
-    const dynamicMinComplete = 12;
-    const dynamicMaxComplete = 82;
+    const dynamicMinComplete = 10;
+    const dynamicMaxComplete = 80;
     const dynamicMinDuration = 14;
     const dynamicMaxDuration = 78;
     const dynamicLowestDay = moment().add(-5, 'days').format('YYYY-MM-DD');

--- a/test/cypress/integration/example25.spec.js
+++ b/test/cypress/integration/example25.spec.js
@@ -14,6 +14,22 @@ describe('Example 25 - Range Filters', () => {
     cy.get('h2').should('contain', 'Example 25: Filtering from Range of Search Values');
   });
 
+  it('should expect the grid to be sorted by "% Complete" descending and then by "Duration" ascending', () => {
+    cy.get('#grid25')
+      .get('.slick-header-column:nth(2)')
+      .find('.slick-sort-indicator-desc')
+      .should('have.length', 1)
+      .siblings('.slick-sort-indicator-numbered')
+      .contains('1');
+
+    cy.get('#grid25')
+      .get('.slick-header-column:nth(5)')
+      .find('.slick-sort-indicator-asc')
+      .should('have.length', 1)
+      .siblings('.slick-sort-indicator-numbered')
+      .contains('2');
+  });
+
   it('should have "% Complete" fields within the range (inclusive) of the filters presets', () => {
     cy.get('#grid25')
       .find('.slick-row')
@@ -208,6 +224,32 @@ describe('Example 25 - Range Filters', () => {
               expect(isDateBetween).to.eq(true);
             });
         });
+    });
+  });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Clear Filters" then "Set Dynamic Sorting" buttons', () => {
+      cy.get('[data-test=clear-filters]')
+        .click();
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+    });
+
+    it('should expect the grid to be sorted by "Duration" ascending and "Start" descending', () => {
+      cy.get('#grid25')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('#grid25')
+        .get('.slick-header-column:nth(4)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
     });
   });
 });

--- a/test/cypress/integration/example4.spec.js
+++ b/test/cypress/integration/example4.spec.js
@@ -44,6 +44,36 @@ describe('Example 4 - Client Side Sort/Filter Grid', () => {
             });
         });
     });
+
+    it('should expect the grid to be sorted by "Duration" descending and "% Complete" ascending', () => {
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
+
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(3)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('.slick-row')
+        .first()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '98');
+
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom')
+        .wait(50);
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '10');
+    });
   });
 
   describe('Set Dymamic Filters', () => {
@@ -103,6 +133,56 @@ describe('Example 4 - Client Side Sort/Filter Grid', () => {
               expect(isDateValid).to.eq(true);
             });
         });
+    });
+  });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Clear Filters" then "Set Dynamic Sorting" buttons', () => {
+      cy.get('[data-test=clear-filters]')
+        .click();
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+    });
+
+    it('should expect the grid to be sorted by "Duration" ascending and "Start" descending', () => {
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
+
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(4)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('.slick-row')
+        .first()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '0');
+
+      // cy.get('.slick-row')
+      //   .first()
+      //   .children('.slick-cell:nth(4)')
+      //   .should('not.contain', '');
+
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom')
+        .wait(50);
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '100');
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(4)')
+        .should('contain', '');
     });
   });
 });

--- a/test/cypress/integration/example4.spec.js
+++ b/test/cypress/integration/example4.spec.js
@@ -8,7 +8,7 @@ describe('Example 4 - Client Side Sort/Filter Grid', () => {
   });
 
   describe('Load Grid with Presets', () => {
-    const presetDurationValues = [220, 10];
+    const presetDurationValues = [98, 10];
     const presetUsDateShort = '04/20/25';
 
     it('should have "Duration" fields within the inclusive range of the preset filters', () => {

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -486,4 +486,45 @@ describe('Example 5 - OData Grid', () => {
         });
     });
   });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Set Filters Dynamically" then on "Set Sorting Dynamically"', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'processing');
+      cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+
+      cy.get('[data-test=status]').should('contain', 'processing');
+      cy.get('[data-test=status]').should('contain', 'done');
+    });
+
+    it('should expect the grid to be sorted by "Name" descending', () => {
+      cy.get('#grid5')
+        .get('.slick-header-column:nth(1)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1);
+
+      cy.get('.slick-row')
+        .first()
+        .children('.slick-cell:nth(1)')
+        .should('contain', 'Ayers Hood');
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(1)')
+        .should('contain', 'Alexander Foley');
+
+
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(startswith(Name, 'A'))`);
+        });
+    });
+  });
 });

--- a/test/cypress/integration/example6.spec.js
+++ b/test/cypress/integration/example6.spec.js
@@ -327,4 +327,42 @@ describe('Example 6 - GraphQL Grid', () => {
           {totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Clear All Filters & Sorting" then "Set Dynamic Sorting" buttons', () => {
+      cy.get('[data-test=clear-filters-sorting]')
+        .click();
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'processing');
+      cy.get('[data-test=status]').should('contain', 'done');
+    });
+
+    it('should expect the grid to be sorted by "Zip" descending then by "Company" ascending', () => {
+      cy.get('#grid6')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('#grid6')
+        .get('.slick-header-column:nth(3)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
+
+      cy.get('[data-test=graphql-query-result]')
+        .should(($span) => {
+          const text = removeSpaces($span.text()); // remove all white spaces
+          expect(text).to.eq(removeSpaces(`query{users(first:30,offset:0,
+            orderBy:[{field:"billing.address.zip",direction:DESC},{field:"company",direction:ASC}],locale:"en",userId:123){
+            totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
+        });
+    });
+  });
 });


### PR DESCRIPTION
- prior to this change, we could update Sorting (sorters) only through "presets" the caviat was that it was only on first page load. Now with this new change we will be to update Sorting on the fly at any time.

- [x] POC (Proof of Concept)
- [x] Should work with Regular Grid (JSON dataset)
- [x] Should work with Backend Services (OData & GraphQL)
- [x] Add Unit Tests
- [x] Add Cypress E2E tests
- [x] Update demos
- [ ] Update [sorting](https://github.com/ghiscoding/Angular-Slickgrid/wiki/Sorting) Wiki