### PR TITLE
feat(events): allow to bypass changed events when calling updateFilters/Sorting

### DIFF
--- a/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
@@ -617,7 +617,7 @@ describe('SortService', () => {
       jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1, mockColumn2]);
     });
 
-    it('should throw an error when there are no filters defined in the column definitions', (done) => {
+    it('should throw an error when there are no sorters defined in the column definitions', (done) => {
       try {
         gridOptionMock.enableSorting = false;
         service.bindLocalOnSort(gridStub, dataViewStub);
@@ -628,7 +628,7 @@ describe('SortService', () => {
       }
     });
 
-    it('should trigger an "emitSortChanged" local when using "bindLocalOnSort" and also expect sorters to be set in ColumnFilters', () => {
+    it('should trigger an "emitSortChanged" local when using "bindLocalOnSort" and also expect sorters to be set in CurrentLocalSorter', () => {
       const emitSpy = jest.spyOn(service, 'emitSortChanged');
 
       service.bindLocalOnSort(gridStub, dataViewStub);
@@ -641,7 +641,20 @@ describe('SortService', () => {
       ]);
     });
 
-    it('should trigger an "emitSortChanged" remote when using "bindLocalOnSort" and also expect sorters to be set in ColumnFilters', () => {
+    it('should expect sorters to be set in CurrentLocalSorter when using "bindLocalOnSort" without triggering a sort changed event when 2nd flag argument is set to false', () => {
+      const emitSpy = jest.spyOn(service, 'emitSortChanged');
+
+      service.bindLocalOnSort(gridStub, dataViewStub);
+      service.updateSorting(mockNewSorters, false);
+
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(service.getCurrentLocalSorters()).toEqual([
+        { columnId: 'firstName', direction: 'ASC' },
+        { columnId: 'isActive', direction: 'DESC' }
+      ]);
+    });
+
+    it('should trigger an "emitSortChanged" remote when using "bindBackendOnSort" and also expect sorters to be sent to the backend when using "bindBackendOnSort"', () => {
       gridOptionMock.backendServiceApi = {
         service: backendServiceStub,
         process: () => new Promise((resolve) => resolve(jest.fn())),
@@ -649,13 +662,29 @@ describe('SortService', () => {
       const emitSpy = jest.spyOn(service, 'emitSortChanged');
       const backendUpdateSpy = jest.spyOn(backendServiceStub, 'updateSorters');
 
-      service.bindLocalOnSort(gridStub, dataViewStub);
+      service.bindBackendOnSort(gridStub, dataViewStub);
       service.updateSorting(mockNewSorters);
 
       expect(emitSpy).toHaveBeenCalledWith('remote');
       expect(service.getCurrentLocalSorters()).toEqual([]);
       expect(backendUpdateSpy).toHaveBeenCalledWith(undefined, mockNewSorters);
       expect(mockRefreshBackendDataset).toHaveBeenCalledWith(gridOptionMock);
+    });
+
+    it('should expect sorters to be sent to the backend when using "bindBackendOnSort" without triggering a sort changed event neither a backend query when both flag arguments are set to false', () => {
+      gridOptionMock.backendServiceApi = {
+        service: backendServiceStub,
+        process: () => new Promise((resolve) => resolve(jest.fn())),
+      };
+      const emitSpy = jest.spyOn(service, 'emitSortChanged');
+      const backendUpdateSpy = jest.spyOn(backendServiceStub, 'updateSorters');
+
+      service.bindBackendOnSort(gridStub, dataViewStub);
+      service.updateSorting(mockNewSorters, false, false);
+
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(backendUpdateSpy).toHaveBeenCalledWith(undefined, mockNewSorters);
+      expect(mockRefreshBackendDataset).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -233,7 +233,7 @@ export class SortService {
       backendApi.preProcess();
     }
 
-    // query backend, except when it's called by a ClearFilters then we won't
+    // query backend
     const query = backendApi.service.processOnSortChanged(event, args);
     const totalItems = gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems;
     executeBackendCallback(backendApi, query, args, startTime, totalItems, this.emitSortChanged.bind(this));
@@ -287,23 +287,40 @@ export class SortService {
     return SortDirectionNumber.neutral;
   }
 
-  updateSorting(sorters: CurrentSorter[]) {
+  /**
+   * Update Sorting (sorters) dynamically just by providing an array of sorter(s).
+   * You can also choose emit (default) a Sort Changed event that will be picked by the Grid State Service.
+   *
+   * Also for backend service only, you can choose to trigger a backend query (default) or not if you wish to do it later,
+   * this could be useful when using updateFilters & updateSorting and you wish to only send the backend query once.
+   * @param sorters array
+   * @param triggerEvent defaults to True, do we want to emit a sort changed event?
+   * @param triggerBackendQuery defaults to True, which will query the backend.
+   */
+  updateSorting(sorters: CurrentSorter[], emitChangedEvent = true, triggerBackendQuery = true) {
     if (!this._gridOptions || !this._gridOptions.enableSorting) {
       throw new Error('[Angular-Slickgrid] in order to use "updateSorting" method, you need to have Sortable Columns defined in your grid and "enableSorting" set in your Grid Options');
     }
 
-    const backendApi = this._gridOptions && this._gridOptions.backendServiceApi;
+    if (Array.isArray(sorters)) {
+      const backendApi = this._gridOptions && this._gridOptions.backendServiceApi;
 
-    if (backendApi) {
-      const backendApiService = backendApi && backendApi.service;
-      if (backendApiService) {
-        backendApiService.updateSorters(undefined, sorters);
-        refreshBackendDataset(this._gridOptions);
-        this.emitSortChanged(EmitterType.remote);
+      if (backendApi) {
+        const backendApiService = backendApi && backendApi.service;
+        if (backendApiService) {
+          backendApiService.updateSorters(undefined, sorters);
+          if (triggerBackendQuery) {
+            refreshBackendDataset(this._gridOptions);
+          }
+        }
+      } else {
+        this.loadGridSorters(sorters);
       }
-    } else {
-      this.loadGridSorters(sorters);
-      this.emitSortChanged(EmitterType.local);
+
+      if (emitChangedEvent) {
+        const emitterType = backendApi ? EmitterType.remote : EmitterType.local;
+        this.emitSortChanged(emitterType);
+      }
     }
   }
 }


### PR DESCRIPTION
- allow to bypass changed events when calling updateFilters / updateSorting
- also allow to bypass calling the backend query (
   - useful when calling both updates in sequence and we want only 1 query sent