### PR TITLE
fix(styling): use latest SlickGrid version and fix some styling issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.22.1",
     "rxjs": "^6.3.3",
-    "slickgrid": "^2.4.16",
+    "slickgrid": "^2.4.17",
     "text-encoding-utf-8": "^1.0.2",
     "tslib": "^1.10.0",
     "vinyl-paths": "^2.1.0"

--- a/src/app/examples/grid-menu.component.ts
+++ b/src/app/examples/grid-menu.component.ts
@@ -115,12 +115,13 @@ export class GridMenuComponent implements OnInit {
             command: 'command1',
             positionOrder: 91,
             cssClass: 'orange',
+            iconCssClass: 'fa fa-warning',
             // you can use the "action" callback and/or use "onCallback" callback from the grid options, they both have the same arguments
             action: (e, args) => alert(args.command),
             itemUsabilityOverride: (args) => {
-              // for example disable the command if there's any filter entered
-              if (this.angularGrid) {
-                return this.isObjectEmpty(this.angularGrid.filterService.getColumnFilters());
+              // for example disable the command if there's any hidden column(s)
+              if (args && Array.isArray(args.columns)) {
+                return args.columns.length === args.visibleColumns.length;
               }
               return true;
             },

--- a/src/app/modules/angular-slickgrid/global-grid-options.ts
+++ b/src/app/modules/angular-slickgrid/global-grid-options.ts
@@ -20,7 +20,6 @@ export const GlobalGridOptions: GridOption = {
   checkboxSelector: {
     cssClass: 'slick-cell-checkboxsel'
   },
-  fadeSpeed: 0, // this should go inside columnPicker but there's a bug in that plugin and it's pulling it from grid options instead
   columnPicker: {
     fadeSpeed: 0,
     hideForceFitButton: false,

--- a/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
@@ -254,9 +254,6 @@ export interface GridOption {
   /** Some default options to set for the export service */
   exportOptions?: ExportOption;
 
-  /** @deprecated Animation fade speed when opening/closing the column picker */
-  fadeSpeed?: number;
-
   /** Defaults to 25, which is the grid footer row panel height */
   footerRowHeight?: number;
 

--- a/src/app/modules/angular-slickgrid/styles/_variables.scss
+++ b/src/app/modules/angular-slickgrid/styles/_variables.scss
@@ -155,7 +155,6 @@ $column-picker-close-padding:             0px !default;
 $column-picker-close-opacity:             0.9 !default;
 $column-picker-item-border:               1px solid transparent !default;
 $column-picker-item-border-radius:        0px !default;
-$column-picker-item-disabled-color:       silver !default;
 $column-picker-item-padding:              2px 4px !default;
 $column-picker-item-hover-border:         1px solid #BFBDBD !default;
 $column-picker-item-hover-color:          #fafafa !default;

--- a/src/app/modules/angular-slickgrid/styles/slick-controls.scss
+++ b/src/app/modules/angular-slickgrid/styles/slick-controls.scss
@@ -318,5 +318,8 @@
 
 /* Disabled */
 .slick-gridmenu-item-disabled {
-  color: silver;
+  color: $grid-menu-item-disabled-color;
+  .slick-gridmenu-icon, .slick-gridmenu-content {
+    color: $grid-menu-item-disabled-color;
+  }
 }

--- a/src/app/modules/angular-slickgrid/styles/slick-plugins.scss
+++ b/src/app/modules/angular-slickgrid/styles/slick-plugins.scss
@@ -90,6 +90,9 @@
       background: inherit !important;
       color: $cell-menu-item-disabled-color;
       cursor: inherit;
+      .slick-cell-menu-icon, .slick-cell-menu-content {
+        color: $cell-menu-item-disabled-color;
+      }
     }
   }
 
@@ -193,6 +196,9 @@
       background: inherit !important;
       color: $context-menu-item-disabled-color;
       cursor: inherit;
+      .slick-context-menu-icon, .slick-context-menu-content {
+        color: $context-menu-item-disabled-color;
+      }
     }
   }
 
@@ -376,6 +382,9 @@
   background: inherit !important;
   color: $header-menu-item-disabled-color;
   cursor: inherit;
+  .slick-header-menuicon, .slick-header-menucontent {
+    color: $header-menu-item-disabled-color;
+  }
 }
 
 // ----------------------------------------------

--- a/test/cypress/integration/example9.spec.js
+++ b/test/cypress/integration/example9.spec.js
@@ -70,7 +70,29 @@ describe('Example 9 - Grid Menu', () => {
         .each(($child, index) => expect($child.text()).to.eq(smallerTitleList[index]));
     });
 
-    it('should type a filter and then open the Grid Menu and expect the "Command 1" to NOT be usable and expect "Command 2" to NOT be visible', () => {
+    it('should hide a column from the picker and then open the Grid Menu and expect the "Command 1" to NOT be usable', () => {
+      const alertStub = cy.stub();
+      cy.on('window:alert', alertStub);
+
+      cy.get('#grid9')
+        .find('button.slick-gridmenu-button')
+        .trigger('click')
+        .click({ force: true });
+
+      cy.get('.slick-gridmenu-item.orange')
+        .find('.slick-gridmenu-content')
+        .contains('Command 1')
+        .click()
+        .then(() => expect(alertStub.getCall(0)).to.be.null);
+
+      cy.get('#grid9')
+        .get('.slick-gridmenu:visible')
+        .find('span.close')
+        .trigger('click')
+        .click({ force: true });
+    });
+
+    it('should type a filter and then open the Grid Menu and expect the "Command 2" to NOT be visible', () => {
       const alertStub = cy.stub();
       cy.on('window:alert', alertStub);
 
@@ -84,12 +106,6 @@ describe('Example 9 - Grid Menu', () => {
 
       cy.get('.slick-gridmenu-item.red')
         .should('not.exist');
-
-      cy.get('.slick-gridmenu-item.orange')
-        .find('.slick-gridmenu-content')
-        .contains('Command 1')
-        .click()
-        .then(() => expect(alertStub.getCall(0)).to.be.null);
     });
 
     it('should clear all filters and expect no filters in the grid', () => {
@@ -107,7 +123,7 @@ describe('Example 9 - Grid Menu', () => {
         .each(($elm) => expect($elm.text()).to.eq(''));
     });
 
-    it('should clear the filters and then open the Grid Menu and expect the "Command 1" to now be usable and expect "Command 2" to now be visible', () => {
+    it('should clear the filters and then open the Grid Menu and expect the "Command 2" to now be visible', () => {
       const alertStub = cy.stub();
       cy.on('window:alert', alertStub);
 
@@ -119,12 +135,6 @@ describe('Example 9 - Grid Menu', () => {
       cy.get('.slick-gridmenu-item.red')
         .find('.slick-gridmenu-content.italic')
         .should('contain', 'Command 2');
-
-      cy.get('.slick-gridmenu-item.orange')
-        .find('.slick-gridmenu-content')
-        .contains('Command 1')
-        .click()
-        .then(() => expect(alertStub.getCall(0)).to.be.calledWith('command1'));
     });
 
     it('should click on the Grid Menu to show the Title as 1st column again', () => {
@@ -151,6 +161,22 @@ describe('Example 9 - Grid Menu', () => {
         .find('.slick-header-columns')
         .children()
         .each(($child, index) => expect($child.text()).to.eq(fullEnglishTitles[index]));
+    });
+
+    it('should now expect the "Command 1" to be usable since all columns are visible', () => {
+      const alertStub = cy.stub();
+      cy.on('window:alert', alertStub);
+
+      cy.get('#grid9')
+        .find('button.slick-gridmenu-button')
+        .trigger('click')
+        .click({ force: true });
+
+      cy.get('.slick-gridmenu-item.orange')
+        .find('.slick-gridmenu-content')
+        .contains('Command 1')
+        .click()
+        .then(() => expect(alertStub.getCall(0)).to.be.calledWith('command1'));
     });
 
     it('should hover over the Title column and click on "Hide Column" command and remove 1st column from grid', () => {


### PR DESCRIPTION
- styling issue was with item/command being disabled, their parent css were not changing to grey but they should. For example, if we disable a Grid Menu command, then it's text content and icon should turn grey regardless of any parent css classes (cssClass, textCssClass)