### PR TITLE
fix(backend): cancel prior http calls to avoid inconsistent data shown

### DIFF
--- a/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
@@ -477,7 +477,7 @@ describe('FilterService', () => {
           expect(service.getColumnFilters()).toEqual({});
           expect(spyFilterChange).not.toHaveBeenCalled();
           expect(spyEmitter).not.toHaveBeenCalled();
-          expect(consoleSpy).toHaveBeenCalledWith(expect.toInclude('[Angular-Slickgrid] please note that the "processOnFilterChanged" method signature, from Backend Service'));
+          expect(consoleSpy).toHaveBeenCalledWith(expect.toInclude('[Angular-Slickgrid] please note that the "processOnFilterChanged" from your Backend Service, should now return a string instead of a Promise.'));
           done();
         });
       });


### PR DESCRIPTION
- when user calls multiple requests, that could happen after typing new input search term in a filter before the previous query is finished and/or calls the (Enter) key multiple times after typing his search term. Calling and queueing multiple queries might re-render the grid unnecessarily with different dataset and produces a flashing effect to the eyes.
- it could also, in some cases, display incorrect data when for example we have 2 queries called in sequence (to filter some data) and the (query 2) resolves before (query 1, because that one was slower), which means they resolved in an inverse sequence, that in terms will end up displaying the wrong final dataset