### PR TITLE
fix(build): create & use separate excel-builder package to fix security

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@ngx-translate/http-loader": "^4.0.0",
     "core-js": "^2.6.1",
     "dompurify": "^2.0.7",
-    "excel-builder-webpack": "^1.0.3",
+    "excel-builder-webpacker": "^1.0.4",
     "flatpickr": ">=4.5.0",
     "font-awesome": "^4.7.0",
     "jquery": ">=3.4.1",

--- a/src/app/modules/angular-slickgrid/services/excelExport.service.ts
+++ b/src/app/modules/angular-slickgrid/services/excelExport.service.ts
@@ -2,7 +2,7 @@ import { ExcelWorkbook } from './../models/excelWorkbook.interface';
 import { ExcelStylesheet } from './../models/excelStylesheet.interface';
 import { Injectable, Optional } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import * as ExcelBuilder from 'excel-builder-webpack';
+import * as ExcelBuilder from 'excel-builder-webpacker';
 import { Subject } from 'rxjs';
 import * as moment_ from 'moment-mini';
 const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670


### PR DESCRIPTION
- create an external excel-builder-webpacker which is derived from the excel-builder-webpack with the main difference that all npm packages are up to date
- ref #377 