### PR TITLE
fix(state): Clear Sort should trigger only 1 event & fix Pagination

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
@@ -1124,12 +1124,13 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
       });
 
       it('should call trigger a gridStage change event when "onPaginationChanged" from the Pagination Service is triggered', () => {
-        const mockPagination = { pageNumber: 2, pageSize: 20, pageSizes: [5, 10, 15, 20] } as Pagination;
+        const mockPagination = { pageNumber: 2, pageSize: 20 } as Pagination;
         const mockServicePagination = {
           ...mockPagination,
           dataFrom: 5,
           dataTo: 10,
           pageCount: 1,
+          pageSizes: [5, 10, 15, 20],
         } as ServicePagination;
         const spy = jest.spyOn(gridStateServiceStub.onGridStateChanged, 'next');
         jest.spyOn(gridStateServiceStub, 'getCurrentGridState').mockReturnValue({ columns: [], pagination: mockPagination } as GridState);

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -309,14 +309,14 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
     if (this.gridOptions.enableRowSelection || this.gridOptions.enableCheckboxSelector) {
       this.gridService.setSelectedRows([]);
     }
-    const { pageNumber, pageSize, pageSizes } = pagination;
+    const { pageNumber, pageSize } = pagination;
     if (this.sharedService) {
       if (pageSize) {
-        this.sharedService.currentPagination = { pageNumber, pageSize, pageSizes };
+        this.sharedService.currentPagination = { pageNumber, pageSize };
       }
     }
     this.gridStateService.onGridStateChanged.next({
-      change: { newValues: { pageNumber, pageSize, pageSizes }, type: GridStateType.pagination },
+      change: { newValues: { pageNumber, pageSize }, type: GridStateType.pagination },
       gridState: this.gridStateService.getCurrentGridState()
     });
   }

--- a/src/app/modules/angular-slickgrid/models/currentPagination.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/currentPagination.interface.ts
@@ -4,7 +4,4 @@ export interface CurrentPagination {
 
   /** Grid page size */
   pageSize: number;
-
-  /** The available page sizes */
-  pageSizes: number[];
 }

--- a/src/app/modules/angular-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -164,7 +164,7 @@ describe('PaginationService', () => {
       service.changeItemPerPage(30);
 
       expect(service.getCurrentPageNumber()).toBe(0);
-      expect(service.getCurrentItemPerPageCount()).toBe(30);
+      expect(service.getCurrentItemPerPage()).toBe(30);
     });
 
     it('should be on page 1 with 2 pages when total items is 51 and we set 50 per page', () => {
@@ -176,7 +176,7 @@ describe('PaginationService', () => {
       service.changeItemPerPage(50);
 
       expect(service.getCurrentPageNumber()).toBe(1);
-      expect(service.getCurrentItemPerPageCount()).toBe(50);
+      expect(service.getCurrentItemPerPage()).toBe(50);
     });
 
     it('should be on page 1 with 2 pages when total items is 100 and we set 50 per page', () => {
@@ -188,7 +188,7 @@ describe('PaginationService', () => {
       service.changeItemPerPage(50);
 
       expect(service.getCurrentPageNumber()).toBe(1);
-      expect(service.getCurrentItemPerPageCount()).toBe(50);
+      expect(service.getCurrentItemPerPage()).toBe(50);
     });
   });
 

--- a/src/app/modules/angular-slickgrid/services/backend-utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/backend-utilities.ts
@@ -48,7 +48,7 @@ main.onBackendError = function backendError(e: any, backendApi: BackendServiceAp
 main.executeBackendCallback = function exeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, emitActionChangedCallback?: (type: EmitterType) => void, httpCancelRequests$?: Subject<void>) {
   if (backendServiceApi) {
     // emit an onFilterChanged event when it's not called by a clear filter
-    if (args && !args.clearFilterTriggered) {
+    if (args && !args.clearFilterTriggered && !args.clearSortTriggered) {
       emitActionChangedCallback(EmitterType.remote);
     }
 

--- a/src/app/modules/angular-slickgrid/services/graphql.service.ts
+++ b/src/app/modules/angular-slickgrid/services/graphql.service.ts
@@ -259,7 +259,6 @@ export class GraphqlService implements BackendService {
     this._currentPagination = {
       pageNumber: 1,
       pageSize: paginationOptions.first || DEFAULT_PAGE_SIZE,
-      pageSizes: this._gridOptions && this._gridOptions.pagination && this._gridOptions.pagination.pageSizes,
     };
 
     this.updateOptions({ paginationOptions });
@@ -456,11 +455,10 @@ export class GraphqlService implements BackendService {
    * @param newPage
    * @param pageSize
    */
-  updatePagination(newPage: number, pageSize: number, pageSizes?: number[]) {
+  updatePagination(newPage: number, pageSize: number) {
     this._currentPagination = {
       pageNumber: newPage,
       pageSize,
-      pageSizes,
     };
 
     let paginationOptions;

--- a/src/app/modules/angular-slickgrid/services/grid-odata.service.ts
+++ b/src/app/modules/angular-slickgrid/services/grid-odata.service.ts
@@ -79,7 +79,6 @@ export class GridOdataService implements BackendService {
       this._currentPagination = {
         pageNumber: 1,
         pageSize: this._odataService.options.top || this.defaultOptions.top || DEFAULT_PAGE_SIZE,
-        pageSizes: this._gridOptions && this._gridOptions.pagination && this._gridOptions.pagination.pageSizes,
       };
     }
 
@@ -399,11 +398,10 @@ export class GridOdataService implements BackendService {
    * @param newPage
    * @param pageSize
    */
-  updatePagination(newPage: number, pageSize: number, pageSizes?: number[]) {
+  updatePagination(newPage: number, pageSize: number) {
     this._currentPagination = {
       pageNumber: newPage,
       pageSize,
-      pageSizes,
     };
 
     // unless user specifically set "enablePagination" to False, we'll update pagination options in every other cases

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -108,10 +108,10 @@ export class SortService {
       // however for a local grid, we need to pass a sort column and so we will sort by the 1st column
       if (triggerQueryEvent) {
         if (this._isBackendGrid) {
-          this.onBackendSortChanged(undefined, { grid: this._grid, sortCols: [] });
+          this.onBackendSortChanged(undefined, { grid: this._grid, sortCols: [], clearSortTriggered: true });
         } else {
           if (this._columnDefinitions && Array.isArray(this._columnDefinitions)) {
-            this.onLocalSortChanged(this._grid, this._dataView, new Array({ sortAsc: true, sortCol: this._columnDefinitions[0] }));
+            this.onLocalSortChanged(this._grid, this._dataView, new Array({ sortAsc: true, sortCol: this._columnDefinitions[0], clearSortTriggered: true }));
           }
         }
       } else if (this._isBackendGrid) {
@@ -219,7 +219,7 @@ export class SortService {
     return sortCols;
   }
 
-  onBackendSortChanged(event: Event, args: any) {
+  onBackendSortChanged(event: Event, args: { multiColumnSort?: boolean; grid: any; sortCols: ColumnSort[]; clearSortTriggered?: boolean }) {
     if (!args || !args.grid) {
       throw new Error('Something went wrong when trying to bind the "onBackendSortChanged(event, args)" function, it seems that "args" is not populated correctly');
     }

--- a/test/cypress/integration/example05.spec.js
+++ b/test/cypress/integration/example05.spec.js
@@ -56,7 +56,7 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 3, pageSize: 20, pageSizes: [10, 15, 20, 25, 30, 40, 50, 75, 100] }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 3, pageSize: 20 }, type: 'pagination' });
       });
     });
 
@@ -87,6 +87,11 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10&$orderby=Name asc&$filter=(Gender eq 'male')`);
         });
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(1);
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+      });
     });
 
     it('should change Pagination to last page', () => {
@@ -115,6 +120,11 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10&$skip=40&$orderby=Name asc&$filter=(Gender eq 'male')`);
         });
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(1);
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
+      });
     });
 
     it('should change Pagination to first page using the external button', () => {
@@ -144,6 +154,11 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10&$orderby=Name asc&$filter=(Gender eq 'male')`);
         });
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(1);
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+      });
     });
 
     it('should change Pagination to last page using the external button', () => {
@@ -173,6 +188,11 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10&$skip=40&$orderby=Name asc&$filter=(Gender eq 'male')`);
         });
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(1);
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
+      });
     });
 
     it('should Clear all Filters and expect to go back to first page', () => {
@@ -211,6 +231,12 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10&$orderby=Name asc`);
         });
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(2);
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: [], type: 'filter' });
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+      });
     });
 
     it('should Clear all Sorting', () => {
@@ -232,6 +258,11 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10`);
         });
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(1);
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: [], type: 'sorter' });
+      });
     });
 
     it('should use "substringof" when OData version is set to 2', () => {
@@ -476,18 +507,18 @@ describe('Example 5 - OData Grid', () => {
       cy.get('.search-filter.filter-name')
         .find('input')
         .clear()
-        .type('xyz');
+        .type('xy');
 
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
-          expect($span.text()).to.eq(`$top=10&$filter=(contains(Name, 'xyz'))`);
+          expect($span.text()).to.eq(`$top=10&$filter=(contains(Name, 'xy'))`);
         });
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
     });
 
-    it('should display page 0 of 0 but hide pagination from/to numbers when filtered data "xyz" returns an empty dataset', () => {
+    it('should display page 0 of 0 but hide pagination from/to numbers when filtered data "xy" returns an empty dataset', () => {
       cy.get('[data-test=page-number-input]')
         .invoke('val')
         .then(pageNumber => expect(pageNumber).to.eq('0'));
@@ -506,14 +537,14 @@ describe('Example 5 - OData Grid', () => {
 
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
-          expect($span.text()).to.eq(`$top=10&$filter=(contains(Name, 'xyz'))`);
+          expect($span.text()).to.eq(`$top=10&$filter=(contains(Name, 'xy'))`);
         });
     });
 
     it('should erase part of the filter so that it filters with "x"', () => {
       cy.get('.search-filter.filter-name')
         .find('input')
-        .type('{backspace}{backspace}');
+        .type('{backspace}');
 
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
@@ -526,7 +557,7 @@ describe('Example 5 - OData Grid', () => {
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(2);
         expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: [{ columnId: 'name', searchTerms: ['x'] }], type: 'filter' });
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 0, pageSize: 10, pageSizes: [10, 15, 20, 25, 30, 40, 50, 75, 100] }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 

--- a/test/cypress/integration/example10.spec.js
+++ b/test/cypress/integration/example10.spec.js
@@ -297,7 +297,7 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
 
       cy.get('@grid1')
         .find('.filter-title')
-        .type('Task 1111');
+        .type('000');
 
       cy.get('@grid1')
         .find('[data-test=page-count]')
@@ -314,6 +314,49 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
       cy.get('@grid1')
         .find('[data-test=total-items]')
         .contains('0');
+    });
+
+    it('should erase part of the filter to have "00" and expect 4 items in total with 1 page', () => {
+      cy.get('#slickGridContainer-grid1').as('grid1');
+
+      cy.get('@grid1')
+        .find('.filter-title')
+        .type('{backspace}');
+
+      cy.get('@grid1')
+        .find('[data-test=page-count]')
+        .contains('1');
+
+      cy.get('@grid1')
+        .find('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('@grid1')
+        .find('[data-test=item-to]')
+        .contains('4');
+
+      cy.get('@grid1')
+        .find('[data-test=total-items]')
+        .contains('4');
+    });
+
+    it('should also expect Grid2 to be unchanged (after changing Pagination in Grid1 in previous tests)', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+      cy.get('@grid2')
+        .find('[data-test=page-count]')
+        .contains('7');
+
+      cy.get('@grid2')
+        .find('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('@grid2')
+        .find('[data-test=item-to]')
+        .contains('75');
+
+      cy.get('@grid2')
+        .find('[data-test=total-items]')
+        .contains('525');
     });
   });
 });


### PR DESCRIPTION
- calling Clear Sorting from the Grid Menu was triggering 2x Grid State changes while it should be only 1 event
- Pagination was wrong after typing a filter returning 0 items and then removing the filter, the from-to was off
- also remove pageSizes from Grid State, it's not that useful there