### PR TITLE
WIP - feat(grouping): re-init draggable grouping after cols change, close #384

### DIFF
--- a/src/app/modules/angular-slickgrid/extensions/__tests__/draggableGroupingExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/draggableGroupingExtension.spec.ts
@@ -8,8 +8,18 @@ import { Grouping } from '../../models';
 
 declare var Slick: any;
 
+const dataViewStub = {
+  collapseAllGroups: jest.fn(),
+  expandAllGroups: jest.fn(),
+  refresh: jest.fn(),
+  getGroups: jest.fn(),
+  getGrouping: jest.fn(),
+  setGrouping: jest.fn(),
+};
+
 const gridStub = {
   getOptions: jest.fn(),
+  onRendered: new Slick.Event(),
   registerPlugin: jest.fn(),
 };
 
@@ -120,6 +130,20 @@ describe('draggableGroupingExtension', () => {
         expect.anything()
       );
       expect(onColumnSpy).toHaveBeenCalledWith(expect.anything(), { caller: 'clear-all', groupColumns: [] });
+    });
+
+    it('should re-initialize the draggable grouping after "onRendered" event is triggered and dataView returns an empty array', () => {
+      jest.spyOn(SharedService.prototype, 'dataView', 'get').mockReturnValue(dataViewStub);
+      const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
+      jest.spyOn(dataViewStub, 'getGroups').mockReturnValue([]);
+
+      const instance = extension.create(gridOptionsMock);
+      const onInitSpy = jest.spyOn(instance, 'init');
+      extension.register();
+      gridStub.onRendered.notify({ startRow: 0, endRow: 3 }, new Slick.EventData(), gridStub);
+
+      expect(handlerSpy).toHaveBeenCalled();
+      expect(onInitSpy).toHaveBeenCalledWith(gridStub);
     });
   });
 });

--- a/src/app/modules/angular-slickgrid/extensions/draggableGroupingExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/draggableGroupingExtension.ts
@@ -53,16 +53,24 @@ export class DraggableGroupingExtension implements Extension {
 
   register(): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
-      this.sharedService.grid.registerPlugin(this._addon);
+      const grid = this.sharedService.grid;
+      grid.registerPlugin(this._addon);
 
-      // Events
-      if (this.sharedService.grid && this.sharedService.gridOptions.draggableGrouping) {
+      if (grid && this.sharedService.gridOptions.draggableGrouping) {
+        // Expose some of the Events
         if (this.sharedService.gridOptions.draggableGrouping.onExtensionRegistered) {
           this.sharedService.gridOptions.draggableGrouping.onExtensionRegistered(this._addon);
         }
         this._eventHandler.subscribe(this._addon.onGroupChanged, (e: any, args: { caller?: string; groupColumns: Grouping[] }) => {
           if (this.sharedService.gridOptions.draggableGrouping && typeof this.sharedService.gridOptions.draggableGrouping.onGroupChanged === 'function') {
             this.sharedService.gridOptions.draggableGrouping.onGroupChanged(e, args);
+          }
+        });
+
+        // if a column was added dynamically, we need to re-initialize the draggable grouping after the render
+        this._eventHandler.subscribe(grid.onRendered, () => {
+          if (this._addon && this.sharedService.dataView.getGroups && this.sharedService.dataView.getGroups().length === 0) {
+            this._addon.init(grid);
           }
         });
       }


### PR DESCRIPTION
- ref #384
- when user modifies or adds new column definitions, the draggable grouping should be re-initialized after the grid finishes re-rendering. 