### PR TITLE
feat(excel): add some extra styling & width options for Excel export

### DIFF
--- a/src/app/examples/grid-contextmenu.component.ts
+++ b/src/app/examples/grid-contextmenu.component.ts
@@ -256,7 +256,11 @@ export class GridContextMenuComponent implements OnInit {
       enableSorting: true,
       enableTranslate: true,
       excelExportOptions: {
-        exportWithFormatter: true
+        exportWithFormatter: true,
+        customColumnWidth: 15,
+
+        // you can customize how the header titles will be styled (defaults to Bold)
+        columnHeaderStyle: { font: { bold: true, italic: true } }
       },
       i18n: this.translate,
 

--- a/src/app/modules/angular-slickgrid/models/column.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/column.interface.ts
@@ -60,11 +60,20 @@ export interface Column {
   /** Defaults to false, which leads to exclude the column from getting a header menu. For example, the checkbox row selection should not have a header menu. */
   excludeFromHeaderMenu?: boolean;
 
+  /** If defined this will be set as column width in Excel */
+  exportColumnWidth?: number;
+
   /**
    * Export with a Custom Formatter, useful when we want to use a different Formatter for the export.
    * For example, we might have a boolean field with "Formatters.checkmark" but we would like see a translated value for (True/False).
    */
   exportCustomFormatter?: Formatter;
+
+  /**
+   * Export with a Custom Group Total Formatter, useful when we want to use a different Formatter for the export.
+   * For example, we might have a boolean field with "Formatters.checkmark" but we would like see a translated value for (True/False).
+   */
+  exportCustomGroupTotalsFormatter?: GroupTotalsFormatter;
 
   /**
    * Defaults to false, which leads to Formatters being evaluated on export.

--- a/src/app/modules/angular-slickgrid/models/excelExportOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/excelExportOption.interface.ts
@@ -6,6 +6,12 @@ export interface ExcelExportOption {
   /** Defaults to true, when grid is using Grouping, it will show indentation of the text with collapsed/expanded symbol as well */
   addGroupIndentation?: boolean;
 
+  /** If defined apply the style to header columns. Else use the bold style */
+  columnHeaderStyle?: any;
+
+  /** If set then this will be used as column width for all columns */
+  customColumnWidth?: number;
+
   /** Defaults to false, which leads to all Formatters of the grid being evaluated on export. You can also override a column by changing the propery on the column itself */
   exportWithFormatter?: boolean;
 


### PR DESCRIPTION
code referenced from another fork in this particular [commit](https://github.com/drinac/Angular-Slickgrid/commit/275e099c8a55f0eb43935249dbf71e0c02066afe) 

- add the following `excelExportOptions`
  - `customColumnWidth` 
  - `columnHeaderStyle`
- add the following Column options
  - `exportColumnWidth`
  - `exportCustomGroupTotalsFormatter`