### PR TITLE
fix(formatters): decimalSeparator & thousandSeparator work tgt, fix #411

### DIFF
--- a/src/app/modules/angular-slickgrid/services/__tests__/utilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/utilities.spec.ts
@@ -351,6 +351,17 @@ describe('Service/Utilies', () => {
       expect(output2).toBe('12,345,678');
     });
 
+    it('should return a string without decimals but using dot (.) as thousand separator when these arguments are null or undefined and the input provided is an integer', () => {
+      const input = 12345678;
+      const decimalSeparator = ',';
+      const thousandSeparator = '.';
+      const output1 = formatNumber(input, null, null, false, '', '', decimalSeparator, thousandSeparator);
+      const output2 = formatNumber(input, undefined, undefined, false, '', '', decimalSeparator, thousandSeparator);
+
+      expect(output1).toBe('12.345.678');
+      expect(output2).toBe('12.345.678');
+    });
+
     it('should return a formatted string wrapped in parentheses when the input number is negative and the displayNegativeNumberWithParentheses argument is enabled', () => {
       const input = -123;
       const displayNegativeNumberWithParentheses = true;
@@ -390,6 +401,16 @@ describe('Service/Utilies', () => {
       const thousandSeparator = ',';
       const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses, currencyPrefix, '', decimalSeparator, thousandSeparator);
       expect(output).toBe('-$12,345,678.00');
+    });
+
+    it('should return a formatted currency string and thousand separator using dot (.) and decimal using comma (,) when those are provided', () => {
+      const input = -12345678.32;
+      const displayNegativeNumberWithParentheses = false;
+      const currencyPrefix = '$';
+      const decimalSeparator = ',';
+      const thousandSeparator = '.';
+      const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses, currencyPrefix, '', decimalSeparator, thousandSeparator);
+      expect(output).toBe('-$12.345.678,32');
     });
 
     it('should return a formatted currency string with symbol prefix/suffix wrapped in parentheses when the input number is negative, when all necessary arguments are filled', () => {

--- a/src/app/modules/angular-slickgrid/services/__tests__/utilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/utilities.spec.ts
@@ -369,13 +369,6 @@ describe('Service/Utilies', () => {
       expect(output).toBe('(123.00)');
     });
 
-    it('should return a formatted string wrapped in parentheses when the input number is negative and the displayNegativeNumberWithParentheses argument is enabled', () => {
-      const input = -123;
-      const displayNegativeNumberWithParentheses = true;
-      const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses);
-      expect(output).toBe('(123.00)');
-    });
-
     it('should return a formatted string and thousand separator wrapped in parentheses when the input number is negative and the displayNegativeNumberWithParentheses argument is enabled', () => {
       const input = -12345678;
       const displayNegativeNumberWithParentheses = true;

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -208,7 +208,7 @@ export function decimalFormatted(input: number | string, minDecimal?: number, ma
   let output = '';
   if (integerNumber !== undefined && decimalNumber !== undefined) {
     output = `${integerNumber}${decimalSeparator}${decimalNumber}`;
-  } else {
+  } else if (integerNumber !== undefined && integerNumber !== null) {
     output = integerNumber;
   }
   return output;

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -189,16 +189,29 @@ export function decimalFormatted(input: number | string, minDecimal?: number, ma
     amount += '0';
   }
 
+  const decimalSplit = amount.split('.');
+  let integerNumber;
+  let decimalNumber;
+
   // do we want to display our number with a custom separator in each thousand position
   if (thousandSeparator) {
-    amount = thousandSeparatorFormatted(amount, thousandSeparator);
+    integerNumber = decimalSplit.length >= 1 ? thousandSeparatorFormatted(decimalSplit[0], thousandSeparator) : undefined;
+  } else {
+    integerNumber = decimalSplit.length >= 1 ? decimalSplit[0] : amount;
   }
 
   // when using a separator that is not a dot, replace it with the new separator
-  if (decimalSeparator !== '.') {
-    amount = amount.replace('.', decimalSeparator);
+  if (decimalSplit.length > 1) {
+    decimalNumber = decimalSplit[1];
   }
-  return amount;
+
+  let output = '';
+  if (integerNumber !== undefined && decimalNumber !== undefined) {
+    output = `${integerNumber}${decimalSeparator}${decimalNumber}`;
+  } else {
+    output = integerNumber;
+  }
+  return output;
 }
 
 /**


### PR DESCRIPTION
- when using both together, 1 was cancelling the other. To fix this, I rewrote the code use text split by the decimal and then recombining them as a new text with necessary thousand & decimal separators

- [x] fix code
- [x] add unit tests to cover both properties used at the same time

with updated code, the result is now as shown below

1. first column has `thousandSeparator: '.'` and `decimalSeparator: ','`
2. second column has `thousandSeparator: ','` and `decimalSeparator: '.'`

![image](https://user-images.githubusercontent.com/643976/76909566-e75e2c80-6881-11ea-8a84-46c13d97ee0b.png)
