### PR TITLE
fix(filter): string filter should also work when using Contains

### DIFF
--- a/src/app/modules/angular-slickgrid/filter-conditions/__tests__/stringFilterCondition.spec.ts
+++ b/src/app/modules/angular-slickgrid/filter-conditions/__tests__/stringFilterCondition.spec.ts
@@ -69,6 +69,12 @@ describe('stringFilterCondition method', () => {
     expect(output).toBe(true);
   });
 
+  it('should return True when search term is a substring of the cell value and the operator is Contains', () => {
+    const options = { dataKey: '', operator: 'Contains', cellValue: 'abbostford', fieldType: FieldType.string, searchTerms: ['bost'] } as FilterConditionOption;
+    const output = stringFilterCondition(options);
+    expect(output).toBe(true);
+  });
+
   it('should return True when input value provided starts with same substring and the operator is empty string', () => {
     const options = { dataKey: '', operator: '', cellValue: 'abbostford', fieldType: FieldType.string, searchTerms: ['abb'] } as FilterConditionOption;
     const output = stringFilterCondition(options);

--- a/src/app/modules/angular-slickgrid/filter-conditions/stringFilterCondition.ts
+++ b/src/app/modules/angular-slickgrid/filter-conditions/stringFilterCondition.ts
@@ -1,5 +1,6 @@
 import { FilterCondition, FilterConditionOption } from '../models/index';
 import { testFilterCondition } from './filterUtilities';
+import { OperatorType } from '../models';
 
 export const stringFilterCondition: FilterCondition = (options: FilterConditionOption) => {
   // make sure the cell value is a string by casting it when possible
@@ -12,11 +13,11 @@ export const stringFilterCondition: FilterCondition = (options: FilterConditionO
     searchTerm = searchTerm.toLowerCase();
   }
 
-  if (options.operator === '*' || options.operator === 'EndsWith') {
+  if (options.operator === '*' || options.operator === OperatorType.endsWith) {
     return cellValue.endsWith(searchTerm);
-  } else if ((options.operator === '' && options.cellValueLastChar === '*') || options.operator === 'StartsWith') {
+  } else if ((options.operator === '' && options.cellValueLastChar === '*') || options.operator === OperatorType.startsWith) {
     return cellValue.startsWith(searchTerm);
-  } else if (options.operator === '') {
+  } else if (options.operator === '' || options.operator === OperatorType.contains) {
     return (cellValue.indexOf(searchTerm) > -1);
   }
   return testFilterCondition(options.operator || '==', cellValue, searchTerm);


### PR DESCRIPTION
- when using OperatorType.empty or OperatorType.contains, they should do a comparison of passing when item contains the substring of search term