### PR TITLE
feat(extension): add latest slickgrid with RowMove improvements

### DIFF
--- a/src/app/examples/grid-rowmove.component.html
+++ b/src/app/examples/grid-rowmove.component.html
@@ -1,13 +1,10 @@
 <div class="container-fluid">
-    <h2>{{title}}</h2>
-    <div class="subtitle" [innerHTML]="subTitle"></div>
+  <h2>{{title}}</h2>
+  <div class="subtitle" [innerHTML]="subTitle"></div>
 
-    <div class="col-sm-12">
-        <angular-slickgrid gridId="grid2"
-            (onAngularGridCreated)="angularGridReady($event)"
-            [columnDefinitions]="columnDefinitions"
-            [gridOptions]="gridOptions"
-            [dataset]="dataset">
-        </angular-slickgrid>
-    </div>
+  <div class="col-sm-12">
+    <angular-slickgrid gridId="grid17" (onAngularGridCreated)="angularGridReady($event)"
+      [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions" [dataset]="dataset">
+    </angular-slickgrid>
+  </div>
 </div>

--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -1,16 +1,25 @@
 import { Component, OnInit } from '@angular/core';
-import { AngularGridInstance, Column, Formatters, GridOption } from './../modules/angular-slickgrid';
+import { AngularGridInstance, Column, ExtensionName, Formatters, GridOption } from './../modules/angular-slickgrid';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   templateUrl: './grid-rowmove.component.html'
 })
 export class GridRowMoveComponent implements OnInit {
-  title = 'Example 17: Row Move Plugin';
+  title = 'Example 17: Row Move & Checkbox Selector';
   subTitle = `This example demonstrates using the <b>Slick.Plugins.RowMoveManager</b> plugin to easily move a row in the grid.<br/>
     <ul>
       <li>Click to select, Ctrl+Click to toggle selection, Shift+Click to select a range.</li>
       <li>Drag one or more rows by the handle (icon) to reorder</li>
+      <li>If you plan to use Row Selection + Row Move, then use "singleRowMove: true" and "disableRowSelection: true"</li>
+      <li>You can change "columnIndexPosition" to move the icon position of any extension (RowMove, RowDetail or RowSelector icon)</li>
+      <ul>
+        <li>You will also want to enable the DataView "syncGridSelection: true" to keep row selection even after a row move</li>
+      </ul>
+      <li>If you plan to use only Row Move, then you could keep default values (or omit them completely) of "singleRowMove: false" and "disableRowSelection: false"</li>
+      <ul>
+        <li>SingleRowMove has the name suggest will only move 1 row at a time, by default it will move any row(s) that are selected unless you disable the flag</li>
+      </ul>
     </ul>
   `;
 
@@ -28,18 +37,12 @@ export class GridRowMoveComponent implements OnInit {
     this.angularGrid = angularGrid;
   }
 
+  get rowMoveInstance(): any {
+    return this.angularGrid && this.angularGrid.extensionService.getSlickgridAddonInstance(ExtensionName.rowMoveManager) || {};
+  }
+
   ngOnInit(): void {
     this.columnDefinitions = [
-      {
-        id: '#', field: '', name: '', width: 40,
-        behavior: 'selectAndMove',
-        selectable: false, resizable: false,
-        cssClass: 'cell-reorder dnd',
-        excludeFromExport: true,
-        excludeFromColumnPicker: true,
-        excludeFromHeaderMenu: true,
-        excludeFromGridMenu: true
-      },
       { id: 'title', name: 'Title', field: 'title' },
       { id: 'duration', name: 'Duration', field: 'duration', sortable: true },
       { id: '%', name: '% Complete', field: 'percentComplete', sortable: true },
@@ -55,13 +58,31 @@ export class GridRowMoveComponent implements OnInit {
         sidePadding: 10
       },
       enableCellNavigation: true,
-      enableRowMoveManager: true,
-      gridMenu: {
-        iconCssClass: 'fa fa-ellipsis-v',
+      enableCheckboxSelector: true,
+      enableRowSelection: true,
+      rowSelectionOptions: {
+        // True (Single Selection), False (Multiple Selections)
+        selectActiveRow: false
       },
+      dataView: {
+        syncGridSelection: true, // enable this flag so that the row selection follows the row even if we move it to another position
+      },
+      enableRowMoveManager: true,
       rowMoveManager: {
+        // when using Row Move + Row Selection, you want to enable the following 2 flags so it doesn't cancel row selection
+        singleRowMove: true,
+        disableRowSelection: true,
+        cancelEditOnDrag: true,
         onBeforeMoveRows: (e, args) => this.onBeforeMoveRow(e, args),
         onMoveRows: (e, args) => this.onMoveRows(e, args),
+
+        // you can change the move icon position of any extension (RowMove, RowDetail or RowSelector icon)
+        // note that you might have to play with the position when using multiple extension
+        // since it really depends on which extension get created first to know what their real position are
+        // columnIndexPosition: 1,
+
+        // you can also override the usability of the rows, for example make every 2nd row the only moveable rows,
+        // usabilityOverride: (row, dataContext, grid) => dataContext.id % 2 === 1
       },
       enableTranslate: true,
       i18n: this.translate
@@ -105,13 +126,10 @@ export class GridRowMoveComponent implements OnInit {
     const left = this.dataset.slice(0, insertBefore);
     const right = this.dataset.slice(insertBefore, this.dataset.length);
     rows.sort((a, b) => a - b);
-
     for (let i = 0; i < rows.length; i++) {
       extractedRows.push(this.dataset[rows[i]]);
     }
-
     rows.reverse();
-
     for (let i = 0; i < rows.length; i++) {
       const row = rows[i];
       if (row < insertBefore) {
@@ -120,14 +138,13 @@ export class GridRowMoveComponent implements OnInit {
         right.splice(row - insertBefore, 1);
       }
     }
-    const updatedDataset = left.concat(extractedRows.concat(right));
+    const tmpDataset = left.concat(extractedRows.concat(right));
     const selectedRows = [];
     for (let i = 0; i < rows.length; i++) {
       selectedRows.push(left.length + i);
     }
+
     this.angularGrid.slickGrid.resetActiveCell();
-    this.angularGrid.slickGrid.setData(updatedDataset);
-    this.angularGrid.slickGrid.setSelectedRows(selectedRows);
-    this.angularGrid.slickGrid.render();
+    this.dataset = tmpDataset;
   }
 }

--- a/src/app/modules/angular-slickgrid/models/rowMoveManager.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/rowMoveManager.interface.ts
@@ -1,9 +1,34 @@
 export interface RowMoveManager {
-  /** defaults to false, option to cancel edit on drag */
+  /** Defaults to false, option to cancel editing while dragging a row */
   cancelEditOnDrag?: boolean;
 
+  /**  Column definition id(defaults to "_move") */
+  columnId?: string;
+
+  /**
+   * Defaults to 0, the column index position in the grid by default it will show as the first column (index 0).
+   * Also note that the index position might vary if you use other extensions, after each extension is created,
+   * it will add an offset to take into consideration (1.CheckboxSelector, 2.RowDetail, 3.RowMove)
+   */
+  columnIndexPosition?: number;
+
+  /**  A CSS class to be added to the menu item container. */
+  cssClass?: string;
+
+  /**  Defaults to False, do we want to disable the row selection?  */
+  disableRowSelection?: boolean;
+
+  /**  Defaults to False, do we want a single row move? Setting this to false means that 1 or more rows can be selected to move together.  */
+  singleRowMove?: boolean;
+
+  /**  Width of the column */
+  width?: string;
+
+  /** Override the logic for showing (or not) the move icon (use case example: only every 2nd row is moveable) */
+  usabilityOverride?: (row: number, dataContext: any, grid: any) => boolean;
+
   // --
-  // Events
+  // SlickGrid Events
 
   /** Fired after extension (plugin) is registered by SlickGrid */
   onExtensionRegistered?: (plugin: any) => void;

--- a/src/app/modules/angular-slickgrid/services/__tests__/extension.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/extension.service.spec.ts
@@ -307,19 +307,26 @@ describe('ExtensionService', () => {
         expect(gridSpy).toHaveBeenCalled();
         expect(extCreateSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
         expect(rowSelectionInstance).not.toBeNull();
-        expect(extRegisterSpy).toHaveBeenCalled(); expect(output).toEqual({ name: ExtensionName.rowDetailView, addon: instanceMock, instance: instanceMock, class: extensionStub } as ExtensionModel);
+        expect(extRegisterSpy).toHaveBeenCalled();
+        expect(output).toEqual({ name: ExtensionName.rowDetailView, addon: instanceMock, instance: instanceMock, class: extensionStub } as ExtensionModel);
       });
 
       it('should register the RowMoveManager addon when "enableRowMoveManager" is set in the grid options', () => {
+        const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
         const gridOptionsMock = { enableRowMoveManager: true } as GridOption;
-        const extSpy = jest.spyOn(extensionStub, 'register').mockReturnValue(instanceMock);
+        const extCreateSpy = jest.spyOn(extensionStub, 'create').mockReturnValue(instanceMock);
+        const extRegisterSpy = jest.spyOn(extensionStub, 'register');
         const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
 
+        service.createExtensionsBeforeGridCreation(columnsMock, gridOptionsMock);
         service.bindDifferentExtensions();
+        const rowSelectionInstance = service.getExtensionByName(ExtensionName.rowSelection);
         const output = service.getExtensionByName(ExtensionName.rowMoveManager);
 
         expect(gridSpy).toHaveBeenCalled();
-        expect(extSpy).toHaveBeenCalled();
+        expect(extCreateSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
+        expect(rowSelectionInstance).not.toBeNull();
+        expect(extRegisterSpy).toHaveBeenCalled();
         expect(output).toEqual({ name: ExtensionName.rowMoveManager, addon: instanceMock, instance: instanceMock, class: extensionStub } as ExtensionModel);
       });
 

--- a/src/app/modules/angular-slickgrid/services/excelExport.service.ts
+++ b/src/app/modules/angular-slickgrid/services/excelExport.service.ts
@@ -57,7 +57,6 @@ export class ExcelExportService {
   /**
    * Initialize the Export Service
    * @param grid
-   * @param gridOptions
    * @param dataView
    */
   init(grid: any, dataView: any): void {

--- a/test/cypress/integration/example17.spec.js
+++ b/test/cypress/integration/example17.spec.js
@@ -1,0 +1,90 @@
+/// <reference types="Cypress" />
+
+describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', () => {
+  const fullTitles = ['', '', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Completed'];
+
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/rowmove`);
+    cy.get('h2').should('contain', 'Example 17: Row Move & Checkbox Selector');
+  });
+
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#grid17')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should drag opened Row Detail to another position in the grid', () => {
+    cy.get('[style="top:35px"] > .slick-cell.cell-reorder').as('moveIconTask1');
+    cy.get('[style="top:105px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+
+    cy.get('@moveIconTask3').should('have.length', 1);
+
+    cy.get('@moveIconTask3')
+      .trigger('mousedown', { button: 0, force: true })
+      .trigger('mousemove', 'bottomRight');
+
+    cy.get('@moveIconTask1')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { force: true });
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 0);
+  });
+
+  it('should expect row to be moved to another row index', () => {
+    cy.get('.slick-viewport-top.slick-viewport-left')
+      .scrollTo('top');
+
+    cy.get('[style="top:0px"] > .slick-cell:nth(2)').should('contain', 'Task 0');
+    cy.get('[style="top:35px"] > .slick-cell:nth(2)').should('contain', 'Task 1');
+    cy.get('[style="top:70px"] > .slick-cell:nth(2)').should('contain', 'Task 3');
+    cy.get('[style="top:105px"] > .slick-cell:nth(2)').should('contain', 'Task 2');
+    cy.get('[style="top:140px"] > .slick-cell:nth(2)').should('contain', 'Task 4');
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 0);
+  });
+
+  it('should select 2 rows (Task 3,4), then move row and expect the 2 rows to still be selected without any others', () => {
+    cy.get('[style="top:70px"] > .slick-cell:nth(1)').click();
+    cy.get('[style="top:140px"] > .slick-cell:nth(1)').click();
+
+    cy.get('[style="top:70px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+    cy.get('[style="top:175px"] > .slick-cell.cell-reorder').as('moveIconTask5');
+
+    cy.get('@moveIconTask3').should('have.length', 1);
+
+    cy.get('@moveIconTask3')
+      .trigger('mousedown', { button: 0, force: true })
+      .trigger('mousemove', 'bottomRight');
+
+    cy.get('@moveIconTask5')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { force: true });
+
+    cy.get('.slick-viewport-top.slick-viewport-left')
+      .scrollTo('top');
+
+    cy.get('[style="top:0px"] > .slick-cell:nth(2)').should('contain', 'Task 0');
+    cy.get('[style="top:35px"] > .slick-cell:nth(2)').should('contain', 'Task 1');
+    cy.get('[style="top:70px"] > .slick-cell:nth(2)').should('contain', 'Task 2');
+    cy.get('[style="top:105px"] > .slick-cell:nth(2)').should('contain', 'Task 4');
+    cy.get('[style="top:140px"] > .slick-cell:nth(2)').should('contain', 'Task 5');
+    cy.get('[style="top:175px"] > .slick-cell:nth(2)').should('contain', 'Task 3');
+
+    // Task 4 and 3 should be selected
+    cy.get('input[type="checkbox"]:checked').should('have.length', 2);
+    cy.get('[style="top:105px"] > .slick-cell:nth(1) input[type="checkbox"]:checked').should('have.length', 1);
+    cy.get('[style="top:175px"] > .slick-cell:nth(1) input[type="checkbox"]:checked').should('have.length', 1);
+  });
+});

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^4.2.0",
+    "cypress": "^4.3.0",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",


### PR DESCRIPTION
- now create column definition just by the enableRowMoveManager flag
- also keep row selection with dataview syncGridSelection
- latest slickgrid version also brought the usabilityOverride callback method that was added in RowMoveManager plugin
- possible ref #256