### PR TITLE
feat(sort): add valueCouldBeUndefined column flag to help sorting

### DIFF
--- a/src/app/modules/angular-slickgrid/models/column.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/column.interface.ts
@@ -225,6 +225,13 @@ export interface Column {
   /** Editor Validator */
   validator?: EditorValidator;
 
+  /**
+   * Can the value be undefined? Typically undefined values are disregarded when sorting, when set this flag will adds extra logic to Sorting and also sort undefined value.
+   * This is an extra flag that user has to enable by themselve because Sorting undefined values has unwanted behavior in some use case
+   * (for example Row Detail has UI inconsistencies since undefined is used in the plugin's logic)
+   */
+  valueCouldBeUndefined?: boolean;
+
   /** Width of the column in pixels (number only). */
   width?: number;
 }

--- a/src/app/modules/angular-slickgrid/sorters/__tests__/dateIsoSorter.spec.ts
+++ b/src/app/modules/angular-slickgrid/sorters/__tests__/dateIsoSorter.spec.ts
@@ -1,5 +1,5 @@
 import { sortByFieldType } from '../sorterUtilities';
-import { FieldType, SortDirectionNumber } from '../../models';
+import { Column, FieldType, SortDirectionNumber } from '../../models';
 
 describe('the Date ISO (without time) Sorter', () => {
   it('should return an array of US dates sorted ascending when only valid dates are provided', () => {
@@ -29,5 +29,23 @@ describe('the Date ISO (without time) Sorter', () => {
     const inputArray = ['1998-10-08', null, '1998-08-08', '2001-01-01', '1998-12-14'];
     inputArray.sort((value1, value2) => sortByFieldType(FieldType.dateIso, value1, value2, direction));
     expect(inputArray).toEqual(['2001-01-01', '1998-12-14', '1998-10-08', '1998-08-08', null]);
+  });
+
+  it('should return a sorted ascending array and move the undefined values to the end of the array when "valueCouldBeUndefined" is set', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name', valueCouldBeUndefined: true } as Column;
+    const direction = SortDirectionNumber.asc;
+    const inputArray = ['1998-10-08', undefined, '1998-08-08', '2001-01-01', '1998-12-14'];
+    inputArray.sort((value1, value2) => sortByFieldType(FieldType.dateIso, value1, value2, direction, columnDef));
+    expect(inputArray).toEqual(['1998-08-08', '1998-10-08', '1998-12-14', '2001-01-01', undefined]);
+  });
+
+  it('should return a sorted descending array and move the undefined values to the end of the array when "valueCouldBeUndefined" is set', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name', valueCouldBeUndefined: true } as Column;
+    const direction = SortDirectionNumber.desc;
+    const inputArray = ['1998-10-08', undefined, '1998-08-08', '2001-01-01', '1998-12-14'];
+    inputArray.sort((value1, value2) => sortByFieldType(FieldType.dateIso, value1, value2, direction, columnDef));
+    expect(inputArray).toEqual(['2001-01-01', '1998-12-14', '1998-10-08', '1998-08-08', undefined]);
   });
 });

--- a/src/app/modules/angular-slickgrid/sorters/__tests__/numericSorter.spec.ts
+++ b/src/app/modules/angular-slickgrid/sorters/__tests__/numericSorter.spec.ts
@@ -1,4 +1,4 @@
-import { SortDirectionNumber } from '../../models/sortDirectionNumber.enum';
+import { Column, SortDirectionNumber } from '../../models';
 import { numericSorter } from '../numericSorter';
 
 describe('the Numeric Sorter', () => {
@@ -18,11 +18,11 @@ describe('the Numeric Sorter', () => {
 
   it(`should return an array with unsorted characters showing at the beginning
     then comes numbers sorted ascending when digits and chars are provided`, () => {
-      const direction = SortDirectionNumber.asc;
-      const inputArray = [4, 'y', 39, 1, -15, -2, 0, 5, 500, 50];
-      inputArray.sort((value1, value2) => numericSorter(value1, value2, direction));
-      expect(inputArray).toEqual(['y', -15, -2, 0, 1, 4, 5, 39, 50, 500]);
-    });
+    const direction = SortDirectionNumber.asc;
+    const inputArray = [4, 'y', 39, 1, -15, -2, 0, 5, 500, 50];
+    inputArray.sort((value1, value2) => numericSorter(value1, value2, direction));
+    expect(inputArray).toEqual(['y', -15, -2, 0, 1, 4, 5, 39, 50, 500]);
+  });
 
   it(`should return an array with numbers sorted descending showing at the beginning then characters`, () => {
     const direction = SortDirectionNumber.desc;
@@ -36,5 +36,23 @@ describe('the Numeric Sorter', () => {
     const inputArray = ['z', 'a', '', null];
     inputArray.sort((value1, value2) => numericSorter(value1, value2, direction));
     expect(inputArray).toEqual(['z', 'a', '', null]);
+  });
+
+  it('should return a sorted ascending array and move the undefined values to the end of the array when "valueCouldBeUndefined" is set', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name', valueCouldBeUndefined: true } as Column;
+    const direction = SortDirectionNumber.asc;
+    const inputArray = [4, undefined, 39, 1, -15, -2, 0, 5, 500, 50];
+    inputArray.sort((value1, value2) => numericSorter(value1, value2, direction, columnDef));
+    expect(inputArray).toEqual([-15, -2, 0, 1, 4, 5, 39, 50, 500, undefined]);
+  });
+
+  it('should return a sorted descending array and move the undefined values to the end of the array when "valueCouldBeUndefined" is set', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name', valueCouldBeUndefined: true } as Column;
+    const direction = SortDirectionNumber.desc;
+    const inputArray = [4, undefined, 39, 1, -15, -2, 0, 5, 500, 50];
+    inputArray.sort((value1, value2) => numericSorter(value1, value2, direction, columnDef));
+    expect(inputArray).toEqual([500, 50, 39, 5, 4, 1, 0, -2, -15, undefined]);
   });
 });

--- a/src/app/modules/angular-slickgrid/sorters/__tests__/sorterUtilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/sorters/__tests__/sorterUtilities.spec.ts
@@ -6,19 +6,19 @@ describe('sorterUtilities', () => {
   it('should call the Sorters.numeric when FieldType is number', () => {
     const spy = jest.spyOn(Sorters, 'numeric');
     sortByFieldType(FieldType.number, 0, 4, SortDirectionNumber.asc, { id: 'field1', field: 'field1' });
-    expect(spy).toHaveBeenCalledWith(0, 4, SortDirectionNumber.asc);
+    expect(spy).toHaveBeenCalledWith(0, 4, SortDirectionNumber.asc, { id: 'field1', field: 'field1' });
   });
 
   it('should call the Sorters.numeric when FieldType is integer', () => {
     const spy = jest.spyOn(Sorters, 'numeric');
     sortByFieldType(FieldType.integer, 0, 4, SortDirectionNumber.asc, { id: 'field1', field: 'field1' });
-    expect(spy).toHaveBeenCalledWith(0, 4, SortDirectionNumber.asc);
+    expect(spy).toHaveBeenCalledWith(0, 4, SortDirectionNumber.asc, { id: 'field1', field: 'field1' });
   });
 
   it('should call the Sorters.numeric when FieldType is float', () => {
     const spy = jest.spyOn(Sorters, 'numeric');
     sortByFieldType(FieldType.float, 0, 4, SortDirectionNumber.asc, { id: 'field1', field: 'field1' });
-    expect(spy).toHaveBeenCalledWith(0, 4, SortDirectionNumber.asc);
+    expect(spy).toHaveBeenCalledWith(0, 4, SortDirectionNumber.asc, { id: 'field1', field: 'field1' });
   });
 
   it('should call the Sorters.objectString when FieldType is objectString', () => {

--- a/src/app/modules/angular-slickgrid/sorters/__tests__/stringSorter.spec.ts
+++ b/src/app/modules/angular-slickgrid/sorters/__tests__/stringSorter.spec.ts
@@ -1,4 +1,4 @@
-import { SortDirectionNumber } from '../../models/sortDirectionNumber.enum';
+import { Column, SortDirectionNumber } from '../../models';
 import { stringSorter } from '../stringSorter';
 
 describe('the String Sorter', () => {
@@ -42,5 +42,23 @@ describe('the String Sorter', () => {
     const inputArray = ['amazon', null, 'zebra', '', null, '@at', 'John', 'Abe', 'abc'];
     inputArray.sort((value1, value2) => stringSorter(value1, value2, direction));
     expect(inputArray).toEqual(['zebra', 'amazon', 'abc', 'John', 'Abe', '@at', '', null, null]);
+  });
+
+  it('should return a sorted ascending array and move the undefined values to the end of the array when "valueCouldBeUndefined" is set', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name', valueCouldBeUndefined: true } as Column;
+    const direction = SortDirectionNumber.asc;
+    const inputArray = ['amazon', undefined, 'zebra', undefined, '', '@at', 'John', 'Abe', 'abc'];
+    inputArray.sort((value1, value2) => stringSorter(value1, value2, direction, columnDef));
+    expect(inputArray).toEqual(['', '@at', 'Abe', 'John', 'abc', 'amazon', 'zebra', undefined, undefined]);
+  });
+
+  it('should return a sorted descending array and move the undefined values to the end of the array when "valueCouldBeUndefined" is set', () => {
+    // from MDN specification quote: All undefined elements are sorted to the end of the array.
+    const columnDef = { id: 'name', field: 'name', valueCouldBeUndefined: true } as Column;
+    const direction = SortDirectionNumber.desc;
+    const inputArray = ['amazon', undefined, 'zebra', undefined, '', '@at', 'John', 'Abe', 'abc'];
+    inputArray.sort((value1, value2) => stringSorter(value1, value2, direction, columnDef));
+    expect(inputArray).toEqual(['zebra', 'amazon', 'abc', 'John', 'Abe', '@at', '', undefined, undefined]);
   });
 });

--- a/src/app/modules/angular-slickgrid/sorters/dateUtilities.ts
+++ b/src/app/modules/angular-slickgrid/sorters/dateUtilities.ts
@@ -1,14 +1,15 @@
 import { mapMomentDateFormatWithFieldType } from '../services/utilities';
-import { FieldType, Sorter } from '../models/index';
+import { Column, FieldType, Sorter } from '../models/index';
 import * as moment_ from 'moment-mini';
 const moment = moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
 
-export function compareDates(value1: any, value2: any, sortDirection: number, format: string | moment_.MomentBuiltinFormat, strict?: boolean) {
+export function compareDates(value1: any, value2: any, sortDirection: number, sortColumn: Column, format: string | moment_.MomentBuiltinFormat, strict?: boolean) {
   let diff = 0;
+  const checkForUndefinedValues = sortColumn && sortColumn.valueCouldBeUndefined || false;
 
-  if (value1 === null || value1 === '' || !moment(value1, format, strict).isValid()) {
+  if (value1 === null || value1 === '' || (checkForUndefinedValues && value1 === undefined) || !moment(value1, format, strict).isValid()) {
     diff = -1;
-  } else if (value2 === null || value2 === '' || !moment(value2, format, strict).isValid()) {
+  } else if (value2 === null || value2 === '' || (checkForUndefinedValues && value2 === undefined) || !moment(value2, format, strict).isValid()) {
     diff = 1;
   } else {
     const date1 = moment(value1, format, strict);
@@ -23,10 +24,10 @@ export function compareDates(value1: any, value2: any, sortDirection: number, fo
 export function getAssociatedDateSorter(fieldType: FieldType): Sorter {
   const FORMAT = (fieldType === FieldType.date) ? moment.ISO_8601 : mapMomentDateFormatWithFieldType(fieldType);
 
-  return (value1: any, value2: any, sortDirection: number) => {
+  return (value1: any, value2: any, sortDirection: number, sortColumn: Column) => {
     if (FORMAT === moment.ISO_8601) {
-      return compareDates(value1, value2, sortDirection, FORMAT, false);
+      return compareDates(value1, value2, sortDirection, sortColumn, FORMAT, false);
     }
-    return compareDates(value1, value2, sortDirection, FORMAT, true);
+    return compareDates(value1, value2, sortDirection, sortColumn, FORMAT, true);
   };
 }

--- a/src/app/modules/angular-slickgrid/sorters/numericSorter.ts
+++ b/src/app/modules/angular-slickgrid/sorters/numericSorter.ts
@@ -1,7 +1,8 @@
-import { Sorter } from './../models/sorter.interface';
+import { Column, Sorter } from './../models/index';
 
-export const numericSorter: Sorter = (value1: any, value2: any, sortDirection: number) => {
-  const x = (isNaN(value1) || value1 === '' || value1 === null) ? -99e+10 : parseFloat(value1);
-  const y = (isNaN(value2) || value2 === '' || value2 === null) ? -99e+10 : parseFloat(value2);
+export const numericSorter: Sorter = (value1: any, value2: any, sortDirection: number, sortColumn?: Column) => {
+  const checkForUndefinedValues = sortColumn && sortColumn.valueCouldBeUndefined || false;
+  const x = (isNaN(value1) || value1 === '' || value1 === null || (checkForUndefinedValues && value1 === undefined)) ? -99e+10 : parseFloat(value1);
+  const y = (isNaN(value2) || value2 === '' || value2 === null || (checkForUndefinedValues && value2 === undefined)) ? -99e+10 : parseFloat(value2);
   return sortDirection * (x === y ? 0 : (x > y ? 1 : -1));
 };

--- a/src/app/modules/angular-slickgrid/sorters/sorterUtilities.ts
+++ b/src/app/modules/angular-slickgrid/sorters/sorterUtilities.ts
@@ -9,7 +9,7 @@ export function sortByFieldType(fieldType: FieldType, value1: any, value2: any, 
     case FieldType.float:
     case FieldType.integer:
     case FieldType.number:
-      sortResult = Sorters.numeric(value1, value2, sortDirection);
+      sortResult = Sorters.numeric(value1, value2, sortDirection, sortColumn);
       break;
     case FieldType.date:
     case FieldType.dateIso:
@@ -37,13 +37,13 @@ export function sortByFieldType(fieldType: FieldType, value1: any, value2: any, 
     case FieldType.dateTimeUsShort:
     case FieldType.dateTimeUsShortAmPm:
     case FieldType.dateTimeUsShortAM_PM:
-      sortResult = getAssociatedDateSorter(fieldType).call(this, value1, value2, sortDirection);
+      sortResult = getAssociatedDateSorter(fieldType).call(this, value1, value2, sortDirection, sortColumn);
       break;
     case FieldType.object:
       sortResult = Sorters.objectString(value1, value2, sortDirection, sortColumn);
       break;
     default:
-      sortResult = Sorters.string(value1, value2, sortDirection);
+      sortResult = Sorters.string(value1, value2, sortDirection, sortColumn);
       break;
   }
 

--- a/src/app/modules/angular-slickgrid/sorters/stringSorter.ts
+++ b/src/app/modules/angular-slickgrid/sorters/stringSorter.ts
@@ -1,17 +1,18 @@
-import { Sorter, SortDirectionNumber } from './../models/index';
+import { Column, Sorter, SortDirectionNumber } from './../models/index';
 
-export const stringSorter: Sorter = (value1: any, value2: any, sortDirection: number | SortDirectionNumber) => {
+export const stringSorter: Sorter = (value1: any, value2: any, sortDirection: number | SortDirectionNumber, sortColumn?: Column) => {
   if (sortDirection === undefined || sortDirection === null) {
     sortDirection = SortDirectionNumber.neutral;
   }
   let position = 0;
+  const checkForUndefinedValues = sortColumn && sortColumn.valueCouldBeUndefined || false;
 
-  if (value1 === null) {
-    position = -1;
-  } else if (value2 === null) {
-    position = 1;
-  } else if (value1 === value2) {
+  if (value1 === value2) {
     position = 0;
+  } else if (value1 === null || (checkForUndefinedValues && value1 === undefined)) {
+    position = -1;
+  } else if (value2 === null || (checkForUndefinedValues && value2 === undefined)) {
+    position = 1;
   } else if (sortDirection) {
     position = value1 < value2 ? -1 : 1;
   } else {


### PR DESCRIPTION
- this is an opt-in flag because it could bring unwanted behavior and for example it breaks the Row Detail UI when sorting undefined values, so user can opt-in but it's off by default