### PR TITLE
fix(filter): when entering filter operator it shouldn't do any filtering

### DIFF
--- a/src/app/examples/grid-grouping.component.ts
+++ b/src/app/examples/grid-grouping.component.ts
@@ -106,7 +106,7 @@ export class GridGroupingComponent implements OnInit {
         minWidth: 70,
         width: 100,
         filterable: true,
-        filter: { model: Filters.compoundInput },
+        filter: { model: Filters.compoundInputNumber },
         type: FieldType.number,
         sortable: true,
         exportWithFormatter: true,

--- a/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/filter.service.spec.ts
@@ -612,6 +612,17 @@ describe('FilterService', () => {
       expect(output).toBe(true);
     });
 
+    it('should return True when the searchTerms is equal to the operator', () => {
+      const mockColumn1 = { id: 'age', field: 'age', filterable: true } as Column;
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1]);
+
+      service.init(gridStub);
+      const columnFilters = { age: { columnDef: mockColumn1, columnId: 'age', operator: '<=', searchTerms: ['<='] } };
+      const output = service.customLocalFilter(mockItem1, { dataView: dataViewStub, grid: gridStub, columnFilters });
+
+      expect(output).toBe(true);
+    });
+
     it('should return False when input value from datacontext is not equal to the searchTerms', () => {
       const searchValue = 'Johnny';
       const mockColumn1 = { id: 'firstName', field: 'firstName', filterable: true } as Column;

--- a/src/app/modules/angular-slickgrid/services/filter.service.ts
+++ b/src/app/modules/angular-slickgrid/services/filter.service.ts
@@ -311,8 +311,8 @@ export class FilterService {
         }
       }
 
-      // no need to query if search value is empty
-      if (searchTerm === '' && (!searchValues || (Array.isArray(searchValues) && searchValues.length === 0))) {
+      // no need to query if search value is empty or if the search value is in fact equal to the operator
+      if (searchTerm === '' && (!searchValues || (Array.isArray(searchValues) && (searchValues.length === 0 || searchValues.length === 1 && operator === searchValues[0])))) {
         return true;
       }
 


### PR DESCRIPTION
- just by changing the operator from a compound filter shouldn't do any search yet and shouldn't result to an empty grid, we should only start searching when there's a real value entered