### PR TITLE
fix(rowDetail): use latest SlickGrid to fix issue with id, fixes #440

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.22.1",
     "rxjs": "^6.3.3",
-    "slickgrid": "2.4.20",
+    "slickgrid": "^2.4.22",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {

--- a/src/app/modules/angular-slickgrid/global-grid-options.ts
+++ b/src/app/modules/angular-slickgrid/global-grid-options.ts
@@ -160,13 +160,13 @@ export const GlobalGridOptions: Partial<GridOption> = {
     pageSize: 25,
     totalItems: 0
   },
-  // @ts-ignore
   // technically speaking the Row Detail requires the process & viewComponent but we'll ignore it just to set certain options
+  // @ts-ignore
   rowDetailView: {
     cssClass: 'detail-view-toggle',
     panelRows: 1,
     keyPrefix: '__',
-    useRowClick: true,
+    useRowClick: false,
     useSimpleViewportCalc: true,
     saveDetailViewOnScroll: false,
   },


### PR DESCRIPTION
- fixes #440
- there was a small issue in core lib when using "datasetIdPropertyName" other than "id" so update to latest SlickGrid version which has the fix
- change default grid options of Row Detail "useRowClick" property to false