### PR TITLE
fix(header): re-create header grouping title after changing picker cols

### DIFF
--- a/src/app/modules/angular-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
@@ -82,7 +82,6 @@ describe('GroupingAndColspanService', () => {
   let service: GroupingAndColspanService;
   let translate: TranslateService;
   let slickgridEventHandler: SlickEventHandler;
-  let slickgridEvent;
 
   beforeEach(() => {
     const div = document.createElement('div');
@@ -104,7 +103,6 @@ describe('GroupingAndColspanService', () => {
     service = TestBed.get(GroupingAndColspanService);
     translate = TestBed.get(TranslateService);
     slickgridEventHandler = service.eventHandler;
-    slickgridEvent = new Slick.Event();
 
     translate.setTranslation('en', {
       ALL_SELECTED: 'All Selected',
@@ -130,7 +128,6 @@ describe('GroupingAndColspanService', () => {
     jest.clearAllMocks();
     service.dispose();
     gridStub.getOptions = () => gridOptionMock;
-    slickgridEvent.unsubscribe();
   });
 
   it('should create the service', () => {
@@ -239,13 +236,15 @@ describe('GroupingAndColspanService', () => {
 
     it('should call the "renderPreHeaderRowGroupingTitles" after changing column visibility from column picker', () => {
       const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
-      const instanceMock = { onColumnsChanged: slickgridEvent };
+      const slickEvent1 = new Slick.Event();
+      const slickEvent2 = new Slick.Event();
+      const instanceMock = { onColumnsChanged: slickEvent1, onMenuClose: slickEvent2 };
       const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       const extensionMock = { name: ExtensionName.columnPicker, addon: instanceMock, instance: instanceMock, class: null };
       jest.spyOn(extensionServiceStub, 'getExtensionByName').mockReturnValue(extensionMock);
       service.init(gridStub, dataViewStub);
 
-      slickgridEvent.notify({ columns: columnsMock }, new Slick.EventData(), gridStub);
+      slickEvent1.notify({ columns: columnsMock }, new Slick.EventData(), gridStub);
       jest.runAllTimers(); // fast-forward timer
 
       expect(spy).toHaveBeenCalledTimes(3);
@@ -255,16 +254,36 @@ describe('GroupingAndColspanService', () => {
 
     it('should call the "renderPreHeaderRowGroupingTitles" after changing column visibility from grid menu', () => {
       const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
-      const instanceMock = { onColumnsChanged: slickgridEvent };
+      const slickEvent1 = new Slick.Event();
+      const slickEvent2 = new Slick.Event();
+      const instanceMock = { onColumnsChanged: slickEvent1, onMenuClose: slickEvent2 };
       const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       const extensionMock = { name: ExtensionName.columnPicker, addon: instanceMock, instance: instanceMock, class: null };
       jest.spyOn(extensionServiceStub, 'getExtensionByName').mockReturnValue(extensionMock);
       service.init(gridStub, dataViewStub);
 
-      slickgridEvent.notify({ columns: columnsMock }, new Slick.EventData(), gridStub);
+      slickEvent1.notify({ columns: columnsMock }, new Slick.EventData(), gridStub);
       jest.runAllTimers(); // fast-forward timer
 
       expect(spy).toHaveBeenCalledTimes(3);
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 50);
+    });
+
+    it('should call the "renderPreHeaderRowGroupingTitles" after changing column visibility & closing the grid menu', () => {
+      const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
+      const slickEvent1 = new Slick.Event();
+      const slickEvent2 = new Slick.Event();
+      const instanceMock = { onColumnsChanged: slickEvent1, onMenuClose: slickEvent2 };
+      const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
+      const extensionMock = { name: ExtensionName.columnPicker, addon: instanceMock, instance: instanceMock, class: null };
+      jest.spyOn(extensionServiceStub, 'getExtensionByName').mockReturnValue(extensionMock);
+      service.init(gridStub, dataViewStub);
+
+      slickEvent2.notify({ allColumns: columnsMock }, new Slick.EventData(), gridStub);
+      jest.runAllTimers(); // fast-forward timer
+
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(setTimeout).toHaveBeenCalledTimes(1);
       expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 50);
     });

--- a/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
+++ b/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
@@ -56,8 +56,9 @@ export class GroupingAndColspanService {
         }
 
         const gridMenuExtension = this.extensionService.getExtensionByName(ExtensionName.gridMenu);
-        if (gridMenuExtension && gridMenuExtension.instance && gridMenuExtension.instance.onColumnsChanged) {
+        if (gridMenuExtension && gridMenuExtension.instance && gridMenuExtension.instance.onColumnsChanged && gridMenuExtension.instance.onMenuClose) {
           this._eventHandler.subscribe(gridMenuExtension.instance.onColumnsChanged, () => this.renderPreHeaderRowGroupingTitles());
+          this._eventHandler.subscribe(gridMenuExtension.instance.onMenuClose, () => this.renderPreHeaderRowGroupingTitles());
         }
 
         // also not sure why at this point, but it seems that I need to call the 1st create in a delayed execution

--- a/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
+++ b/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Optional } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
 
-import { Column, GridOption, SlickEventHandler } from './../models/index';
+import { Column, GridOption, SlickEventHandler, ExtensionName } from './../models/index';
 import { ExtensionUtility } from '../extensions/extensionUtility';
+import { ExtensionService } from './extension.service';
 import { ResizerService } from './resizer.service';
 
 // using external non-typed js libraries
@@ -16,7 +16,7 @@ export class GroupingAndColspanService {
   private _eventHandler: SlickEventHandler;
   private _grid: any;
 
-  constructor(private extensionUtility: ExtensionUtility, private resizerService: ResizerService, @Optional() private translate: TranslateService) {
+  constructor(private extensionUtility: ExtensionUtility, private extensionService: ExtensionService, private resizerService: ResizerService) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -48,6 +48,17 @@ export class GroupingAndColspanService {
         this._eventHandler.subscribe(grid.onColumnsReordered, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(dataView.onRowCountChanged, () => this.renderPreHeaderRowGroupingTitles());
         this.resizerService.onGridAfterResize.subscribe(() => this.renderPreHeaderRowGroupingTitles());
+
+        // for both picker (columnPicker/gridMenu) we also need to re-create after hiding/showing columns
+        const columnPickerExtension = this.extensionService.getExtensionByName(ExtensionName.columnPicker);
+        if (columnPickerExtension && columnPickerExtension.instance && columnPickerExtension.instance.onColumnsChanged) {
+          this._eventHandler.subscribe(columnPickerExtension.instance.onColumnsChanged, () => this.renderPreHeaderRowGroupingTitles());
+        }
+
+        const gridMenuExtension = this.extensionService.getExtensionByName(ExtensionName.gridMenu);
+        if (gridMenuExtension && gridMenuExtension.instance && gridMenuExtension.instance.onColumnsChanged) {
+          this._eventHandler.subscribe(gridMenuExtension.instance.onColumnsChanged, () => this.renderPreHeaderRowGroupingTitles());
+        }
 
         // also not sure why at this point, but it seems that I need to call the 1st create in a delayed execution
         // probably some kind of timing issues and delaying it until the grid is fully ready does help


### PR DESCRIPTION
- after hiding/showing columns from ColumnPicker/GridMenu we need to re-create the header grouping titles