### PR TITLE
fix(filter): Select Filter should use default locale without translation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- YOU MUST FILL IN THIS TEMPLATE OR ELSE IT WILL BE AUTO-CLOSE BY THE BOT -->
+
 <!---
 Thanks for filing a Feature Request! However, before you submit, please read the following:
 1. Search open/closed issues before submitting a new one.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- YOU MUST FILL IN THIS TEMPLATE OR ELSE IT WILL BE AUTO-CLOSE BY THE BOT -->
+
 <!---
 Thanks for filing a Feature Request! However, before you submit, please read the following:
 1. Search open/closed issues before submitting a new one.

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- YOU MUST FILL IN THIS TEMPLATE OR ELSE IT WILL BE AUTO-CLOSE BY THE BOT -->
+
 <!---
 Thanks for filing a General issue! However, before you submit, please read the following:
 1. Search open/closed issues before submitting a new one.

--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -1,5 +1,5 @@
 # Comment that will be sent if an issue is judged to be closed
-comment: "This issue was automatically closed by our bot because it does not meet our issue template requirements. Please **fill in** the questions/sections required in the **issue template** before submitting a new issue. Thank you."
+comment: "This issue was automatically closed by our bot because it does not meet our issue template requirements. Please **fill in** the questions/sections which are tagged as <!--REQUIRED--> in the **issue template** before submitting a new issue... Please also consider asking any coding questions on Stack Overflow. Thank you."
 issueConfigs:
 # There can be several configs for different kind of issues.
 - content:

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -451,6 +451,8 @@ export class SelectFilter implements Filter {
 
   /** Initialize the Multiple Select element and its options to use */
   protected initMultipleSelect() {
+    const isTranslateEnabled = this.gridOptions && this.gridOptions.enableTranslate;
+
     // default options used by this Filter, user can overwrite any of these by passing "otions"
     const options: MultipleSelectOption = {
       autoAdjustDropHeight: true,
@@ -478,10 +480,10 @@ export class SelectFilter implements Filter {
       options.okButton = true;
       options.addTitle = true; // show tooltip of all selected items while hovering the filter
       const translationPrefix = getTranslationPrefix(this.gridOptions);
-      options.countSelected = this.translate && this.translate.currentLang && this.translate.instant && this.translate.instant(`${translationPrefix}X_OF_Y_SELECTED`) || this._locales && this._locales.TEXT_X_OF_Y_SELECTED;
-      options.allSelected = this.translate && this.translate.currentLang && this.translate.instant && this.translate.instant(`${translationPrefix}ALL_SELECTED`) || this._locales && this._locales.TEXT_ALL_SELECTED;
-      options.okButtonText = this.translate && this.translate.currentLang && this.translate.instant && this.translate.instant(`${translationPrefix}OK`) || this._locales && this._locales.TEXT_OK;
-      options.selectAllText = this.translate && this.translate.currentLang && this.translate.instant && this.translate.instant(`${translationPrefix}SELECT_ALL`) || this._locales && this._locales.TEXT_SELECT_ALL;
+      options.countSelected = (isTranslateEnabled && this.translate && this.translate.instant) ? this.translate.instant(`${translationPrefix}X_OF_Y_SELECTED`) : this._locales && this._locales.TEXT_X_OF_Y_SELECTED;
+      options.allSelected = (isTranslateEnabled && this.translate && this.translate.instant) ? this.translate.instant(`${translationPrefix}ALL_SELECTED`) : this._locales && this._locales.TEXT_ALL_SELECTED;
+      options.okButtonText = (isTranslateEnabled && this.translate && this.translate.instant) ? this.translate.instant(`${translationPrefix}OK`) : this._locales && this._locales.TEXT_OK;
+      options.selectAllText = (isTranslateEnabled && this.translate && this.translate.instant) ? this.translate.instant(`${translationPrefix}SELECT_ALL`) : this._locales && this._locales.TEXT_SELECT_ALL;
       options.selectAllDelimiter = ['', '']; // remove default square brackets of default text "[Select All]" => "Select All"
     }
 


### PR DESCRIPTION
- when user is using only a single Locale, the Select Filter (single/multi) should use the Locale text instead of the translation text