### PR TITLE
fix(presets): compound filters operator not working correctly w/presets

### DIFF
--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -169,7 +169,7 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
         filters: [
           // you can use OperatorType or type them as string, e.g.: operator: 'EQ'
           { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
-          { columnId: 'name', searchTerms: ['John'], operator: OperatorType.startsWith },
+          { columnId: 'name', searchTerms: ['John Doe'], operator: OperatorType.contains },
           { columnId: 'company', searchTerms: ['xyz'], operator: 'IN' },
 
           // use a date range with 2 searchTerms values

--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -169,7 +169,7 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
         filters: [
           // you can use OperatorType or type them as string, e.g.: operator: 'EQ'
           { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
-          { columnId: 'name', searchTerms: ['John Doe'], operator: OperatorType.contains },
+          { columnId: 'name', searchTerms: ['John'], operator: OperatorType.startsWith },
           { columnId: 'company', searchTerms: ['xyz'], operator: 'IN' },
 
           // use a date range with 2 searchTerms values

--- a/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundDateFilter.ts
@@ -275,7 +275,8 @@ export class CompoundDateFilter implements Filter {
     this.$filterInputElm.data('columnId', fieldId);
 
     if (this.operator) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
 
     // if there's a search term, we will add the "filled" class for styling purposes

--- a/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundInputFilter.ts
@@ -233,7 +233,8 @@ export class CompoundInputFilter implements Filter {
     this.$filterInputElm.data('columnId', fieldId);
 
     if (this.operator) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
 
     // if there's a search term, we will add the "filled" class for styling purposes

--- a/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/compoundSliderFilter.ts
@@ -258,7 +258,8 @@ export class CompoundSliderFilter implements Filter {
     this.$filterInputElm.data('columnId', fieldId);
 
     if (this.operator) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
 
     // if there's a search term, we will add the "filled" class for styling purposes

--- a/src/app/modules/angular-slickgrid/services/__tests__/graphql.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/graphql.service.spec.ts
@@ -785,11 +785,39 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
+    it('should return a query with search having the operator EndsWith when the Column Filter was provided as EndsWith', () => {
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:EndsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
+      const mockColumn = { id: 'gender', field: 'gender', filter: { operator: 'EndsWith' } } as Column;
+      const mockColumnFilters = {
+        gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['le'] },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
+
     it('should return a query with search having the operator StartsWith when the operator was provided as a*', () => {
       const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:StartsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['le'], operator: 'a*' },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
+
+    it('should return a query with search having the operator StartsWith when the operator was provided as StartsWith', () => {
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:gender, operator:StartsWith, value:"le"}]) { totalCount,nodes{ id,company,gender,name } }}`;
+      const mockColumn = { id: 'gender', field: 'gender' } as Column;
+      const mockColumnFilters = {
+        gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['le'], operator: 'StartsWith' },
       } as ColumnFilters;
 
       service.init(serviceOptions, paginationOptions, gridStub);

--- a/src/app/modules/angular-slickgrid/services/__tests__/grid-odata.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/grid-odata.service.spec.ts
@@ -297,13 +297,13 @@ describe('GridOdataService', () => {
     });
 
     it('should return a query with a new filter when previous filters exists', () => {
-      const expectation = `$top=10&$filter=(Gender eq 'female' and FirstName eq 'John')`;
+      const expectation = `$top=10&$filter=(Gender eq 'female' and endswith(FirstName, 'John'))`;
       const querySpy = jest.spyOn(service.odataService, 'buildQuery');
       const resetSpy = jest.spyOn(service, 'resetPaginationOptions');
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnName = { id: 'firstName', field: 'firstName' } as Column;
       const mockColumnFilter = { columnDef: mockColumn, columnId: 'gender', operator: 'EQ', searchTerms: ['female'] } as ColumnFilter;
-      const mockColumnFilterName = { columnDef: mockColumnName, columnId: 'firstName', operator: 'StartsWith', searchTerms: ['John'] } as ColumnFilter;
+      const mockColumnFilterName = { columnDef: mockColumnName, columnId: 'firstName', operator: 'EndsWith', searchTerms: ['John'] } as ColumnFilter;
       const mockFilterChangedArgs = {
         columnDef: mockColumn,
         columnId: 'gender',
@@ -323,7 +323,7 @@ describe('GridOdataService', () => {
       expect(resetSpy).toHaveBeenCalled();
       expect(currentFilters).toEqual([
         { columnId: 'gender', operator: 'EQ', searchTerms: ['female'] },
-        { columnId: 'firstName', operator: 'StartsWith', searchTerms: ['John'] }
+        { columnId: 'firstName', operator: 'EndsWith', searchTerms: ['John'] }
       ]);
     });
 
@@ -359,7 +359,7 @@ describe('GridOdataService', () => {
       });
 
       it('should return a query with a new filter when previous filters exists when "enablePagination" is set to False', () => {
-        const expectation = `$filter=(Gender eq 'female' and FirstName eq 'John')`;
+        const expectation = `$filter=(Gender eq 'female' and startswith(FirstName, 'John'))`;
         const querySpy = jest.spyOn(service.odataService, 'buildQuery');
         const resetSpy = jest.spyOn(service, 'resetPaginationOptions');
         const mockColumn = { id: 'gender', field: 'gender' } as Column;


### PR DESCRIPTION
- grid presets should work with short/long operator names, basically StartsWith/EndsWith were not working correctly while a*/*z were working correctly, both options should work