### PR TITLE
feat(sorting): header menu clear sort, reset sorting when nothing left

### DIFF
--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -528,9 +528,9 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
       }
       // bind external filter (backend) unless specified to use the local one
       if (gridOptions.backendServiceApi && !gridOptions.backendServiceApi.useLocalFiltering) {
-        this.filterService.bindBackendOnFilter(grid, this.dataView);
+        this.filterService.bindBackendOnFilter(grid, dataView);
       } else {
-        this.filterService.bindLocalOnFilter(grid, this.dataView);
+        this.filterService.bindLocalOnFilter(grid, dataView);
       }
     }
 

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -126,7 +126,6 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
   private _fixedWidth: number | null;
   private _hideHeaderRowAfterPageLoad = false;
   private _isGridInitialized = false;
-  private _isGridHavingFilters = false;
   private _isDatasetInitialized = false;
   private _isPaginationInitialized = false;
   private _isLocalGrid = true;
@@ -241,9 +240,6 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
 
   ngAfterViewInit() {
     this.initialization();
-    if (this.columnDefinitions.findIndex((col) => col.filterable) > -1) {
-      this._isGridHavingFilters = true;
-    }
     this._isGridInitialized = true;
 
     // user must provide a "gridHeight" or use "autoResize: true" in the grid options

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
@@ -14,6 +14,7 @@ const filterServiceStub = {
 } as unknown as FilterService;
 
 const sortServiceStub = {
+  clearSortByColumnId: jest.fn(),
   clearSorting: jest.fn(),
   emitSortChanged: jest.fn(),
   getCurrentColumnSorts: jest.fn(),
@@ -396,58 +397,15 @@ describe('headerMenuExtension', () => {
         expect(filterSpy).toHaveBeenCalledWith(expect.anything(), columnsMock[0].id);
       });
 
-      it('should trigger the command "clear-sort" and expect Sort Service to call "onBackendSortChanged" being called without the sorted column', () => {
-        const mockSortedCols: ColumnSort[] = [{ sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
-        const previousSortSpy = jest.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[1]]).mockReturnValueOnce(mockSortedCols);
-        const backendSortSpy = jest.spyOn(sortServiceStub, 'onBackendSortChanged');
+      it('should trigger the command "clear-sort" and expect "clearSortByColumnId" being called with event and column id', () => {
+        const clearSortSpy = jest.spyOn(sortServiceStub, 'clearSortByColumnId');
         const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
-        const setSortSpy = jest.spyOn(SharedService.prototype.grid, 'setSortColumns');
 
         const instance = extension.register();
         instance.onCommand.notify({ column: columnsMock[0], grid: gridStub, command: 'clear-sort' }, new Slick.EventData(), gridStub);
 
-        expect(previousSortSpy).toHaveBeenCalled();
-        expect(backendSortSpy).toHaveBeenCalledWith(expect.anything(), { multiColumnSort: true, sortCols: [mockSortedCols[1]], grid: gridStub });
+        expect(clearSortSpy).toHaveBeenCalledWith(expect.anything(), columnsMock[0].id);
         expect(onCommandSpy).toHaveBeenCalled();
-        expect(setSortSpy).toHaveBeenCalled();
-      });
-
-      it('should trigger the command "clear-sort" and expect Sort Service to call "onLocalSortChanged" being called without the sorted column', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, backendServiceApi: undefined } as unknown as GridOption;
-        jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const mockSortedCols: ColumnSort[] = [{ sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
-        const previousSortSpy = jest.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[1]]).mockReturnValueOnce(mockSortedCols);
-        const localSortSpy = jest.spyOn(sortServiceStub, 'onLocalSortChanged');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
-        const setSortSpy = jest.spyOn(SharedService.prototype.grid, 'setSortColumns');
-
-        const instance = extension.register();
-        instance.onCommand.notify({ column: columnsMock[0], grid: gridStub, command: 'clear-sort' }, new Slick.EventData(), gridStub);
-
-        expect(previousSortSpy).toHaveBeenCalled();
-        expect(localSortSpy).toHaveBeenCalledWith(gridStub, dataViewStub, [mockSortedCols[1]], true);
-        expect(onCommandSpy).toHaveBeenCalled();
-        expect(setSortSpy).toHaveBeenCalled();
-      });
-
-      it('should trigger the command "clear-sort" and expect "onSort" event triggered when no DataView is provided', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, backendServiceApi: undefined } as unknown as GridOption;
-        const mockSortedCols: ColumnSort[] = [{ sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
-
-        jest.spyOn(SharedService.prototype, 'dataView', 'get').mockReturnValue(undefined);
-        jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
-        const previousSortSpy = jest.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[1]]).mockReturnValueOnce(mockSortedCols);
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
-        const setSortSpy = jest.spyOn(SharedService.prototype.grid, 'setSortColumns');
-        const gridSortSpy = jest.spyOn(gridStub.onSort, 'notify');
-
-        const instance = extension.register();
-        instance.onCommand.notify({ column: columnsMock[0], grid: gridStub, command: 'clear-sort' }, new Slick.EventData(), gridStub);
-
-        expect(previousSortSpy).toHaveBeenCalled();
-        expect(onCommandSpy).toHaveBeenCalled();
-        expect(setSortSpy).toHaveBeenCalled();
-        expect(gridSortSpy).toHaveBeenCalledWith([mockSortedCols[1]]);
       });
 
       it('should trigger the command "sort-asc" and expect Sort Service to call "onBackendSortChanged" being called without the sorted column', () => {

--- a/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
@@ -286,32 +286,7 @@ export class HeaderMenuExtension implements Extension {
   /** Clear the Sort on the current column (if it's actually sorted) */
   private clearColumnSort(event: Event, args: MenuCommandItemCallbackArgs) {
     if (args && args.column && this.sharedService) {
-      // get current sorted columns, prior to calling the new column sort
-      const allSortedCols: ColumnSort[] = this.sortService.getCurrentColumnSorts();
-      const sortedColsWithoutCurrent: ColumnSort[] = this.sortService.getCurrentColumnSorts(args.column.id + '');
-
-      if (Array.isArray(allSortedCols) && Array.isArray(sortedColsWithoutCurrent) && allSortedCols.length !== sortedColsWithoutCurrent.length) {
-        if (this.sharedService.gridOptions && this.sharedService.gridOptions.backendServiceApi) {
-          this.sortService.onBackendSortChanged(event, { multiColumnSort: true, sortCols: sortedColsWithoutCurrent, grid: this.sharedService.grid });
-        } else if (this.sharedService.dataView) {
-          this.sortService.onLocalSortChanged(this.sharedService.grid, this.sharedService.dataView, sortedColsWithoutCurrent, true);
-        } else {
-          // when using customDataView, we will simply send it as a onSort event with notify
-          const isMultiSort = this.sharedService.gridOptions && this.sharedService.gridOptions.multiColumnSort || false;
-          const sortOutput = isMultiSort ? sortedColsWithoutCurrent : sortedColsWithoutCurrent[0];
-          args.grid.onSort.notify(sortOutput);
-        }
-
-        // update the this.sharedService.gridObj sortColumns array which will at the same add the visual sort icon(s) on the UI
-        const updatedSortColumns: ColumnSort[] = sortedColsWithoutCurrent.map((col) => {
-          return {
-            columnId: col && col.sortCol && col.sortCol.id,
-            sortAsc: col && col.sortAsc,
-            sortCol: col && col.sortCol,
-          };
-        });
-        this.sharedService.grid.setSortColumns(updatedSortColumns); // add sort icon in UI
-      }
+      this.sortService.clearSortByColumnId(event, args.column.id);
     }
   }
 

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -104,6 +104,48 @@ export class SortService {
     });
   }
 
+  clearSortByColumnId(event: Event | undefined, columnId: string | number) {
+    // get previously sorted columns
+    const allSortedCols: ColumnSort[] = this.getCurrentColumnSorts();
+    const sortedColsWithoutCurrent: ColumnSort[] = this.getCurrentColumnSorts(`${columnId}`);
+
+    if (Array.isArray(allSortedCols) && Array.isArray(sortedColsWithoutCurrent) && allSortedCols.length !== sortedColsWithoutCurrent.length) {
+      if (this._gridOptions.backendServiceApi) {
+        this.onBackendSortChanged(event, { multiColumnSort: true, sortCols: sortedColsWithoutCurrent, grid: this._grid });
+      } else if (this._dataView) {
+        this.onLocalSortChanged(this._grid, this._dataView, sortedColsWithoutCurrent, true, true);
+      } else {
+        // when using customDataView, we will simply send it as a onSort event with notify
+        const isMultiSort = this._gridOptions && this._gridOptions.multiColumnSort || false;
+        const sortOutput = isMultiSort ? sortedColsWithoutCurrent : sortedColsWithoutCurrent[0];
+        this._grid.onSort.notify(sortOutput);
+      }
+
+      // update the grid sortColumns array which will at the same add the visual sort icon(s) on the UI
+      const updatedSortColumns: ColumnSort[] = sortedColsWithoutCurrent.map((col) => {
+        return {
+          columnId: col && col.sortCol && col.sortCol.id,
+          sortAsc: col && col.sortAsc,
+          sortCol: col && col.sortCol,
+        };
+      });
+      this._grid.setSortColumns(updatedSortColumns); // add sort icon in UI
+    }
+
+    // when there's no more sorting, we re-sort by the default sort field, user can customize it "defaultColumnSortFieldId", defaults to "id"
+    if (Array.isArray(sortedColsWithoutCurrent) && sortedColsWithoutCurrent.length === 0) {
+      this.sortLocalGridByDefaultSortFieldId();
+    }
+  }
+
+  /**
+   * Clear Sorting
+   * - 1st, remove the SlickGrid sort icons (this setSortColumns function call really does only that)
+   * - 2nd, we also need to trigger a sort change
+   *   - for a backend grid, we will trigger a backend sort changed with an empty sort columns array
+   *   - however for a local grid, we need to pass a sort column and so we will sort by the 1st column
+   * @param trigger query event after executing clear filter?
+   */
   clearSorting(triggerQueryEvent = true) {
     if (this._grid && this._gridOptions && this._dataView) {
       // remove any sort icons (this setSortColumns function call really does only that)
@@ -117,9 +159,7 @@ export class SortService {
           this.onBackendSortChanged(undefined, { grid: this._grid, sortCols: [], clearSortTriggered: true });
         } else {
           if (this._columnDefinitions && Array.isArray(this._columnDefinitions)) {
-            const sortColFieldId = this._gridOptions && this._gridOptions.defaultColumnSortFieldId || 'id';
-            const sortCol = { id: sortColFieldId, field: sortColFieldId } as Column;
-            this.onLocalSortChanged(this._grid, this._dataView, new Array({ sortAsc: true, sortCol, clearSortTriggered: true }));
+            this.sortLocalGridByDefaultSortFieldId();
           }
         }
       } else if (this._isBackendGrid) {
@@ -177,7 +217,7 @@ export class SortService {
    * If a column is passed as an argument, that will be exclusion so we won't add this column to our output array since it is already in the array.
    * The usage of this method is that we want to know the sort prior to calling the next sorting command
    */
-  getCurrentColumnSorts(excludedColumnId?: string) {
+  getCurrentColumnSorts(excludedColumnId?: string): { sortCol: Column; sortAsc: boolean; }[] {
     // getSortColumns() only returns sortAsc & columnId, we want the entire column definition
     const oldSortColumns = this._grid && this._grid.getSortColumns();
 
@@ -254,7 +294,7 @@ export class SortService {
     }
   }
 
-  onBackendSortChanged(event: Event, args: { multiColumnSort?: boolean; grid: any; sortCols: ColumnSort[]; clearSortTriggered?: boolean }) {
+  onBackendSortChanged(event: Event, args: { multiColumnSort?: boolean; grid: any; sortCols: ColumnSort[]; clearSortTriggered?: boolean; }) {
     if (!args || !args.grid) {
       throw new Error('Something went wrong when trying to bind the "onBackendSortChanged(event, args)" function, it seems that "args" is not populated correctly');
     }
@@ -279,7 +319,7 @@ export class SortService {
   }
 
   /** When a Sort Changes on a Local grid (JSON dataset) */
-  onLocalSortChanged(grid: any, dataView: any, sortColumns: ColumnSort[], forceReSort = false) {
+  onLocalSortChanged(grid: any, dataView: any, sortColumns: ColumnSort[], forceReSort = false, emitSortChanged = false) {
     const isTreeDataEnabled = this._gridOptions && this._gridOptions.enableTreeData || false;
 
     if (grid && dataView) {
@@ -301,7 +341,23 @@ export class SortService {
 
       grid.invalidate();
       grid.render();
+
+      if (emitSortChanged) {
+        this.emitSortChanged(EmitterType.local, sortColumns.map(col => {
+          return {
+            columnId: col.sortCol && col.sortCol.id || 'id',
+            direction: col.sortAsc ? SortDirection.ASC : SortDirection.DESC
+          };
+        }));
+      }
     }
+  }
+
+  /** Call a local grid sort by its default sort field id (user can customize default field by configuring "defaultColumnSortFieldId" in the grid options, defaults to "id") */
+  sortLocalGridByDefaultSortFieldId() {
+    const sortColFieldId = this._gridOptions && this._gridOptions.defaultColumnSortFieldId || this._gridOptions.datasetIdPropertyName || 'id';
+    const sortCol = { id: sortColFieldId, field: sortColFieldId } as Column;
+    this.onLocalSortChanged(this._grid, this._dataView, new Array({ sortAsc: true, sortCol, clearSortTriggered: true }));
   }
 
   sortComparers(sortColumns: ColumnSort[], dataRow1: any, dataRow2: any): number {

--- a/test/cypress/integration/example05.spec.js
+++ b/test/cypress/integration/example05.spec.js
@@ -56,7 +56,7 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 3, pageSize: 20 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 3, pageSize: 20 }, type: 'pagination' });
       });
     });
 
@@ -90,7 +90,7 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -123,7 +123,7 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -157,7 +157,7 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -191,7 +191,7 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 5, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -234,8 +234,8 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(2);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: [], type: 'filter' });
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: [], type: 'filter' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 
@@ -261,7 +261,7 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(1);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: [], type: 'sorter' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: [], type: 'sorter' });
       });
     });
 
@@ -309,7 +309,7 @@ describe('Example 5 - OData Grid', () => {
         .click();
 
       cy.get('.search-filter.filter-name select')
-        .should('have.value', 'a*')
+        .should('have.value', 'a*');
 
       cy.get('.search-filter.filter-name')
         .find('input')
@@ -439,7 +439,7 @@ describe('Example 5 - OData Grid', () => {
         .click();
 
       cy.get('.search-filter.filter-name select')
-        .should('have.value', 'a*')
+        .should('have.value', 'a*');
 
       cy.get('.search-filter.filter-name')
         .find('input')
@@ -556,8 +556,8 @@ describe('Example 5 - OData Grid', () => {
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(2);
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: [{ columnId: 'name', searchTerms: ['x'] }], type: 'filter' });
-        expect(win.console.log).to.be.calledWith("Client sample, Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: [{ columnId: 'name', searchTerms: ['x'] }], type: 'filter' });
+        expect(win.console.log).to.be.calledWith('Client sample, Grid State changed:: ', { newValues: { pageNumber: 1, pageSize: 10 }, type: 'pagination' });
       });
     });
 


### PR DESCRIPTION
- when there is no more column to sort, we could resort by default sort id which would display dataset the way it was when it was first loaded
- ref SO question: https://stackoverflow.com/questions/62489108/angular-slickgrid-column-wise-remove-sort-option-not-working-properly
- also found that Clear Column Sort on a Local Grid was not trigger a "sortChanged" event while it should so that the Grid State is also notified