### PR TITLE
fix(editor): float validator should accept decimal even without 0 suffix

### DIFF
--- a/src/app/modules/angular-slickgrid/editorValidators/floatValidator.ts
+++ b/src/app/modules/angular-slickgrid/editorValidators/floatValidator.ts
@@ -35,7 +35,7 @@ export function floatValidator(inputValue: any, options: FloatValidatorOptions):
   } else if (isRequired && inputValue === '') {
     isValid = false;
     outputMsg = errorMsg || Constants.VALIDATION_REQUIRED_FIELD;
-  } else if (inputValue !== '' && (isNaN(inputValue as number) || (decPlaces === 0 && !/^[-+]?(\d+(\.)?(\d)*)$/.test(inputValue)))) {
+  } else if (inputValue !== '' && (isNaN(inputValue as number) || (decPlaces === 0 && !/^[-+]?(\d*(\.)?(\d)*)$/.test(inputValue)))) {
     // when decimal value is 0 (which is the default), we accept 0 or more decimal values
     isValid = false;
     outputMsg = errorMsg || Constants.VALIDATION_EDITOR_VALID_NUMBER;

--- a/src/app/modules/angular-slickgrid/editors/__tests__/floatEditor.spec.ts
+++ b/src/app/modules/angular-slickgrid/editors/__tests__/floatEditor.spec.ts
@@ -533,6 +533,14 @@ describe('FloatEditor', () => {
 
         expect(validation).toEqual({ valid: true, msg: '' });
       });
+
+      it('should return True when field is required and field is a valid decimal value without 0 suffix', () => {
+        mockColumn.internalColumnEditor.required = true;
+        editor = new FloatEditor(editorArguments);
+        const validation = editor.validate('.5');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
     });
   });
 });


### PR DESCRIPTION
- basically 0.3 and .3 should be both accepted, the second one wasn't and this PR fixes it