### PR TITLE
fix(formatter): add possibility to parse a date formatter as a UTC date

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "jest-extended": "^0.11.5",
     "jest-junit": "^6.4.0",
     "jest-preset-angular": "^6.0.1",
-    "moment-timezone": "^0.5.31",
     "ng-packagr": "~5.3.0",
     "ngx-bootstrap": "^4.3.0",
     "node-sass": "4.14.0",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "jest-extended": "^0.11.5",
     "jest-junit": "^6.4.0",
     "jest-preset-angular": "^6.0.1",
+    "moment-timezone": "^0.5.31",
     "ng-packagr": "~5.3.0",
     "ngx-bootstrap": "^4.3.0",
     "node-sass": "4.14.0",

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -27,7 +27,7 @@ describe('the Date ISO Formatter', () => {
   });
 
   it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
-    const value = new Date('2099-12-31T00:00:00.000Z');
+    const value = new Date('2099-12-30T22:00:00');
 
     const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
     const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -1,7 +1,16 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
+import * as moment from 'moment-mini';
 
 describe('the Date ISO Formatter', () => {
+  beforeEach(() => {
+    jest.mock('moment', () => {
+      const moment = require.requireActual('moment-timezone');
+      moment.tz.setDefault('America/Los_Angeles'); // Whatever timezone you want
+      return moment;
+    });
+  });
+
   it('should return null when no value is provided', () => {
     const value = null;
     const result = Formatters.dateIso(0, 0, value, {} as Column, {});
@@ -27,7 +36,7 @@ describe('the Date ISO Formatter', () => {
   });
 
   it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
-    const value = new Date('2099-12-30T22:00:00');
+    const value = '2099-12-31T00:00:00Z';
 
     const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
     const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -1,6 +1,5 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
-import * as moment from 'moment-timezone';
 
 describe('the Date ISO Formatter', () => {
   it('should return null when no value is provided', () => {
@@ -28,8 +27,7 @@ describe('the Date ISO Formatter', () => {
   });
 
   it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
-    moment.tz.setDefault('America/New_York');
-    const value = moment('2099-12-31T00:00:00.000Z');
+    const value = new Date('2099-12-31T00:00:00.000Z');
 
     const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
     const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -6,7 +6,7 @@ describe('the Date ISO Formatter', () => {
   beforeEach(() => {
     jest.mock('moment', () => {
       const moment = require.requireActual('moment-timezone');
-      moment.tz.setDefault('America/Los_Angeles'); // Whatever timezone you want
+      moment.tz.setDefault('America/New_York'); // Whatever timezone you want
       return moment;
     });
   });
@@ -36,7 +36,7 @@ describe('the Date ISO Formatter', () => {
   });
 
   it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
-    const value = '2099-12-31T00:00:00Z';
+    const value = moment('2099-12-31T00:00:00Z');
 
     const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
     const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -27,7 +27,7 @@ describe('the Date ISO Formatter', () => {
   });
 
   it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
-    const value = new Date(Date.UTC(2099, 11, 31, 0, 0, 0, 0));
+    const value = new Date('2099-12-31T00:00:00.000Z');
 
     const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
     const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -1,16 +1,8 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
-import * as moment from 'moment-mini';
+import * as moment from 'moment-timezone';
 
 describe('the Date ISO Formatter', () => {
-  beforeEach(() => {
-    jest.mock('moment', () => {
-      const moment = require.requireActual('moment-timezone');
-      moment.tz.setDefault('America/New_York'); // Whatever timezone you want
-      return moment;
-    });
-  });
-
   it('should return null when no value is provided', () => {
     const value = null;
     const result = Formatters.dateIso(0, 0, value, {} as Column, {});
@@ -36,7 +28,8 @@ describe('the Date ISO Formatter', () => {
   });
 
   it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
-    const value = moment('2099-12-31T00:00:00Z');
+    moment.tz.setDefault('America/New_York');
+    const value = moment('2099-12-31T00:00:00.000Z');
 
     const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
     const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -25,4 +25,16 @@ describe('the Date ISO Formatter', () => {
     const result = Formatters.dateIso(0, 0, value, {} as Column, {});
     expect(result).toBe('2019-05-01');
   });
+
+  it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
+    const value = new Date(Date.UTC(2099, 11, 31, 0, 0, 0, 0));
+
+    const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
+    const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});
+    const result3 = Formatters.dateIso(0, 0, value, {} as Column, {});
+
+    expect(result1).toBe('2099-12-31');
+    expect(result2).toBe('2099-12-30');
+    expect(result3).toBe('2099-12-30');
+  });
 });

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -1,5 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
+import * as moment from 'moment-timezone';
 
 describe('the Date ISO Formatter', () => {
   it('should return null when no value is provided', () => {
@@ -27,7 +28,8 @@ describe('the Date ISO Formatter', () => {
   });
 
   it('should return a formatted date value without time date provided has TZ but we specifically mention to parse as UTC ', () => {
-    const value = new Date('2099-12-31T00:00:00.000Z');
+    moment.tz.setDefault('America/New_York');
+    const value = moment('2099-12-31T00:00:00.000Z');
 
     const result1 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: true } } as Column, {});
     const result2 = Formatters.dateIso(0, 0, value, { params: { parseDateAsUtc: false } } as Column, {});

--- a/src/app/modules/angular-slickgrid/formatters/formatterUtilities.ts
+++ b/src/app/modules/angular-slickgrid/formatters/formatterUtilities.ts
@@ -28,9 +28,13 @@ export function getAssociatedDateFormatter(fieldType: FieldType, defaultSeparato
   return (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
     const gridOptions = ((grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {}) as GridOption;
     const customSeparator = gridOptions && gridOptions.formatterOptions && gridOptions.formatterOptions.dateSeparator || defaultSeparator;
+    const isParsingAsUtc = columnDef && columnDef.params && columnDef.params.parseDateAsUtc || false;
 
     const isDateValid = moment(value, defaultDateFormat, false).isValid();
-    let outputDate = (value && isDateValid) ? moment(value).format(defaultDateFormat) : value;
+    let outputDate = value;
+    if (value && isDateValid) {
+      outputDate = isParsingAsUtc ? moment.utc(value).format(defaultDateFormat) : moment(value).format(defaultDateFormat);
+    }
 
     // user can customize the separator through the "formatterOptions"
     // if that is the case we need to replace the default "/" to the new separator

--- a/test/jest-global-setup.js
+++ b/test/jest-global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'EST';
+};

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     },
     __TRANSFORM_HTML__: true,
   },
+  globalSetup: '<rootDir>/test/jest-global-setup.js',
   collectCoverage: false,
   collectCoverageFrom: [
     'src/app/modules/**/*.{js,ts}',

--- a/test/setup-jest.ts
+++ b/test/setup-jest.ts
@@ -1,7 +1,2 @@
 import 'jest-preset-angular';
 import './jest-global-mocks';
-
-// use NewYork timezone as default accross the Jest tests
-const moment = require('moment-timezone');
-moment.tz.setDefault('America/New_York');
-jest.setMock('moment', moment)

--- a/test/setup-jest.ts
+++ b/test/setup-jest.ts
@@ -1,2 +1,7 @@
 import 'jest-preset-angular';
 import './jest-global-mocks';
+
+// use NewYork timezone as default accross the Jest tests
+const moment = require('moment-timezone');
+moment.tz.setDefault('America/New_York');
+jest.setMock('moment', moment)


### PR DESCRIPTION
- e.g. when '2099-12-31T00:00:00.000Z' in my TZ (EST) the DateIso Formatter will transform this in 2099-12-30 instead of 2099-12-31 because it assumes that the TZ must be included