### PR TITLE
fix(editors): add saveOutputType to finally have proper save format

### DIFF
--- a/src/app/examples/grid-editor.component.ts
+++ b/src/app/examples/grid-editor.component.ts
@@ -272,7 +272,9 @@ export class GridEditorComponent implements OnInit {
         filter: { model: Filters.compoundDate },
         formatter: Formatters.dateIso,
         exportWithFormatter: true,
-        type: FieldType.date,
+        type: FieldType.date,              // dataset cell input format
+        // outputType: FieldType.dateUs,   // date picker format
+        saveOutputType: FieldType.dateUtc, // save output date formattype: FieldType.date,
         editor: {
           model: Editors.date,
           // override any of the Flatpickr options through "editorOptions"

--- a/src/app/modules/angular-slickgrid/models/column.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/column.interface.ts
@@ -169,8 +169,17 @@ export interface Column<T = any> {
   /** an event that can be used for triggering an action after a cell click */
   onCellClick?: (e: KeyboardEvent | MouseEvent, args: OnEventArgs) => void;
 
-  /** column output type */
+  /**
+   * Column output type(e.g.Date Picker, the output format that we will see in the picker)
+   * NOTE: this is only currently used by the Editors / Filters with a Date Picker
+   */
   outputType?: FieldType;
+
+  /**
+   * Column Editor save format type (e.g. which date format to use when saving after choosing a date from the Date Editor picker)
+   * NOTE: this is only currently used by the Date Editor (date picker)
+   */
+  saveOutputType?: FieldType;
 
   /** if you want to pass custom paramaters to your Formatter/Editor or anything else */
   params?: any | any[];


### PR DESCRIPTION
- we now have 3 available types to use with the Date Editors formatting
1. `type` (data input format),
2. `outputType` (picker display format)
3. `saveOutputType` (save format)