### PR TITLE
fix(select): make a collection array copy to avoid change by ref

### DIFF
--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -6,7 +6,6 @@ import {
   FieldType,
   Filters,
   Formatters,
-  GraphqlResult,
   GraphqlPaginatedResult,
   GraphqlService,
   GraphqlServiceApi,
@@ -199,7 +198,7 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
         // onInit: (query) => this.getCustomerApiCall(query)
         preProcess: () => this.displaySpinner(true),
         process: (query) => this.getCustomerApiCall(query),
-        postProcess: (result: GraphqlResult | GraphqlPaginatedResult) => {
+        postProcess: (result: GraphqlPaginatedResult) => {
           this.metrics = result.metrics;
           this.displaySpinner(false);
         }
@@ -220,12 +219,11 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Calling your GraphQL backend server should always return a Promise or Observable of type GraphqlPaginatedResult (or GraphqlResult)
-   *
+   * Calling your GraphQL backend server should always return a Promise or Observable of type GraphqlPaginatedResult (or GraphqlResult without Pagination)
    * @param query
-   * @return Promise<GraphqlPaginatedResult> | Observable<GraphqlPaginatedResult>
+   * @return Promise<GraphqlPaginatedResult> | Observable<GraphqlResult>
    */
-  getCustomerApiCall(query: string): Promise<GraphqlResult | GraphqlPaginatedResult> {
+  getCustomerApiCall(query: string): Promise<GraphqlPaginatedResult> {
     // in your case, you will call your WebAPI function (wich needs to return a Promise)
     // for the demo purpose, we will call a mock WebAPI function
     const mockedResult = {

--- a/src/app/modules/angular-slickgrid/editors/selectEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/selectEditor.ts
@@ -518,8 +518,7 @@ export class SelectEditor implements Editor {
       throw new Error('The "collection" passed to the Select Editor is not a valid array.');
     }
 
-    // make a copy of the collection so that SelectFilter doesn't impact SelectEditor and vice versa
-    // (this could happen when calling "addBlankEntry" or "addCustomFirstEntry")
+    // make a copy of the collection so that we don't impact SelectFilter, this could happen when calling "addBlankEntry" or "addCustomFirstEntry"
     const collection = [...inputCollection];
 
     // user can optionally add a blank entry at the beginning of the collection

--- a/src/app/modules/angular-slickgrid/editors/selectEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/selectEditor.ts
@@ -196,7 +196,7 @@ export class SelectEditor implements Editor {
     const isIncludingPrefixSuffix = this.collectionOptions && this.collectionOptions.includePrefixSuffixToSelectedValues || false;
 
     return this.collection
-      .filter(c => elmValue.indexOf(c.hasOwnProperty(this.valueName) && c[this.valueName].toString()) !== -1)
+      .filter(c => elmValue.indexOf(c.hasOwnProperty(this.valueName) && c[this.valueName] !== null && c[this.valueName].toString()) !== -1)
       .map(c => {
         const labelText = c[this.valueName];
         let prefixText = c[this.labelPrefixName] || '';
@@ -237,7 +237,7 @@ export class SelectEditor implements Editor {
     // collection of label/value pair
     const separatorBetweenLabels = this.collectionOptions && this.collectionOptions.separatorBetweenTextLabels || '';
     const isIncludingPrefixSuffix = this.collectionOptions && this.collectionOptions.includePrefixSuffixToSelectedValues || false;
-    const itemFound = findOrDefault(this.collection, (c: any) => c.hasOwnProperty(this.valueName) && c[this.valueName].toString() === elmValue);
+    const itemFound = findOrDefault(this.collection, (c: any) => c.hasOwnProperty(this.valueName) && c[this.valueName] !== null && c[this.valueName].toString() === elmValue);
 
     // is the field a complex object, "address.streetNumber"
     const fieldName = this.columnDef && this.columnDef.field;
@@ -509,14 +509,18 @@ export class SelectEditor implements Editor {
     return outputCollection;
   }
 
-  protected renderDomElement(collection: any[]) {
-    if (!Array.isArray(collection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
+  protected renderDomElement(inputCollection: any[]) {
+    if (!Array.isArray(inputCollection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty;
-      collection = getDescendantProperty(collection, collectionInsideObjectProperty);
+      inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
     }
-    if (!Array.isArray(collection)) {
+    if (!Array.isArray(inputCollection)) {
       throw new Error('The "collection" passed to the Select Editor is not a valid array.');
     }
+
+    // make a copy of the collection so that SelectFilter doesn't impact SelectEditor and vice versa
+    // (this could happen when calling "addBlankEntry" or "addCustomFirstEntry")
+    const collection = [...inputCollection];
 
     // user can optionally add a blank entry at the beginning of the collection
     if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.labelName] !== '') {
@@ -560,7 +564,9 @@ export class SelectEditor implements Editor {
         let prefixText = option[this.labelPrefixName] || '';
         let suffixText = option[this.labelSuffixName] || '';
         let optionLabel = option[this.optionLabel] || '';
-        optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+        if (optionLabel && optionLabel.toString) {
+          optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+        }
 
         // also translate prefix/suffix if enableTranslateLabel is true and text is a string
         prefixText = (this.enableTranslateLabel && prefixText && typeof prefixText === 'string') ? this._translate.instant(prefixText || ' ') : prefixText;

--- a/src/app/modules/angular-slickgrid/editors/selectEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/selectEditor.ts
@@ -519,7 +519,10 @@ export class SelectEditor implements Editor {
     }
 
     // make a copy of the collection so that we don't impact SelectFilter, this could happen when calling "addBlankEntry" or "addCustomFirstEntry"
-    const collection = [...inputCollection];
+    let collection: any[] = [];
+    if (inputCollection.length > 0) {
+      collection = [...inputCollection];
+    }
 
     // user can optionally add a blank entry at the beginning of the collection
     if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.labelName] !== '') {

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -298,18 +298,14 @@ export class SelectFilter implements Filter {
     this.renderDomElement(collection);
   }
 
-  protected renderDomElement(inputCollection) {
-    if (!Array.isArray(inputCollection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
+  protected renderDomElement(collection: any[]) {
+    if (!Array.isArray(collection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty;
-      inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
+      collection = getDescendantProperty(collection, collectionInsideObjectProperty);
     }
-    if (!Array.isArray(inputCollection)) {
+    if (!Array.isArray(collection)) {
       throw new Error('The "collection" passed to the Select Filter is not a valid array.');
     }
-
-    // make a copy of the collection so that SelectFilter doesn't impact SelectEditor and vice versa
-    // (this could happen when calling "addBlankEntry" or "addCustomFirstEntry")
-    const collection = [...inputCollection];
 
     // make sure however that it wasn't added more than once
     if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.labelName] !== '') {

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -298,13 +298,19 @@ export class SelectFilter implements Filter {
     this.renderDomElement(collection);
   }
 
-  protected renderDomElement(collection: any[]) {
-    if (!Array.isArray(collection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
+  protected renderDomElement(inputCollection: any[]) {
+    if (!Array.isArray(inputCollection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty;
-      collection = getDescendantProperty(collection, collectionInsideObjectProperty);
+      inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
     }
-    if (!Array.isArray(collection)) {
+    if (!Array.isArray(inputCollection)) {
       throw new Error('The "collection" passed to the Select Filter is not a valid array.');
+    }
+
+    // make a copy of the collection so that we don't impact SelectEditor, this could happen when calling "addBlankEntry" or "addCustomFirstEntry"
+    let collection: any[] = [];
+    if (inputCollection.length > 0) {
+      collection = [...inputCollection];
     }
 
     // make sure however that it wasn't added more than once

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -298,14 +298,18 @@ export class SelectFilter implements Filter {
     this.renderDomElement(collection);
   }
 
-  protected renderDomElement(collection) {
-    if (!Array.isArray(collection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
+  protected renderDomElement(inputCollection) {
+    if (!Array.isArray(inputCollection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty;
-      collection = getDescendantProperty(collection, collectionInsideObjectProperty);
+      inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
     }
-    if (!Array.isArray(collection)) {
+    if (!Array.isArray(inputCollection)) {
       throw new Error('The "collection" passed to the Select Filter is not a valid array.');
     }
+
+    // make a copy of the collection so that SelectFilter doesn't impact SelectEditor and vice versa
+    // (this could happen when calling "addBlankEntry" or "addCustomFirstEntry")
+    const collection = [...inputCollection];
 
     // make sure however that it wasn't added more than once
     if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.labelName] !== '') {
@@ -360,7 +364,9 @@ export class SelectFilter implements Filter {
           let prefixText = option[this.labelPrefixName] || '';
           let suffixText = option[this.labelSuffixName] || '';
           let optionLabel = option.hasOwnProperty(this.optionLabel) ? option[this.optionLabel] : '';
-          optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+          if (optionLabel && optionLabel.toString) {
+            optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+          }
 
           // also translate prefix/suffix if enableTranslateLabel is true and text is a string
           prefixText = (this.enableTranslateLabel && isEnableTranslate && prefixText && typeof prefixText === 'string') ? this.translate && this.translate.currentLang && this.translate.instant(prefixText || ' ') : prefixText;


### PR DESCRIPTION
- when using "addBlankEntry" or "addCustomFirstEntry", the SelectFilter was affecting SelectEditor (and vice versa) because the collection was used by ref, so to fix this we can just do a copy of the collection before dealing with it