### PR TITLE
fix(filters): tree data presets caused regression in any grid w/presets

### DIFF
--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -366,10 +366,13 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
       }
 
       if (dataset.length > 0) {
-        if (!this._isDatasetInitialized && this.gridOptions.enableCheckboxSelector) {
-          this.loadRowSelectionPresetWhenExists();
+        if (!this._isDatasetInitialized) {
+          this.loadPresetsWhenDatasetInitialized();
+
+          if (this.gridOptions.enableCheckboxSelector) {
+            this.loadRowSelectionPresetWhenExists();
+          }
         }
-        this.loadPresetsWhenDatasetInitialized();
         this._isDatasetInitialized = true;
 
         // also update the hierarchical dataset

--- a/src/app/modules/angular-slickgrid/styles/_variables.scss
+++ b/src/app/modules/angular-slickgrid/styles/_variables.scss
@@ -538,7 +538,7 @@
  /* Compound Filters */
  $compound-filter-operator-select-font-family:   Consolas, "Lucida Console" !default; // use a monospace font so the operator descriptions are all aligned
  $compound-filter-operator-select-font-size:     14px !important !default;
- $compound-filter-operator-select-border:        1px solid #{lighten($primary-color, 15%)} !default;
+ $compound-filter-operator-select-border:        1px solid #{lighten($primary-color, 5%)} !default;
  $compound-filter-bgcolor:                       #ffffff !default;
  $compound-filter-operator-border-radius:        4px 0 0 4px !default;
  $compound-filter-border-radius:                 0 4px 4px 0 !default;

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^5.2.0",
+    "cypress": "^5.3.0",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",


### PR DESCRIPTION
- a regression was observer when using GridState/GridPresets with Local Storage, whenever clearing a Filter, it would put back the preset filter.