### PR TITLE
fix(styling): Compound Filter Operator dropdown too wide in BS4

### DIFF
--- a/src/app/modules/angular-slickgrid/styles/_variables.scss
+++ b/src/app/modules/angular-slickgrid/styles/_variables.scss
@@ -539,6 +539,7 @@
  $compound-filter-operator-select-font-family:   Consolas, "Lucida Console" !default; // use a monospace font so the operator descriptions are all aligned
  $compound-filter-operator-select-font-size:     14px !important !default;
  $compound-filter-operator-select-border:        1px solid #{lighten($primary-color, 5%)} !default;
+ $compound-filter-operator-select-width:         25px !default;
  $compound-filter-bgcolor:                       #ffffff !default;
  $compound-filter-operator-border-radius:        4px 0 0 4px !default;
  $compound-filter-border-radius:                 0 4px 4px 0 !default;

--- a/src/app/modules/angular-slickgrid/styles/slick-plugins.scss
+++ b/src/app/modules/angular-slickgrid/styles/slick-plugins.scss
@@ -714,6 +714,7 @@
     font-family: $compound-filter-operator-select-font-family;
     font-size: $compound-filter-operator-select-font-size;
     border: $compound-filter-operator-select-border;
+    width: $compound-filter-operator-select-width;
 
     &.form-control {
       cursor: pointer;


### PR DESCRIPTION
- it seems that we need to fix a max width so that it won't go over in BS4