### PR TITLE
fix(interfaces): column types in GridStateChange

### DIFF
--- a/src/app/modules/angular-slickgrid/models/gridStateChange.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridStateChange.interface.ts
@@ -1,10 +1,10 @@
-import { Column, CurrentFilter, CurrentPagination, CurrentRowSelection, CurrentSorter, GridState, GridStateType } from './index';
+import { CurrentColumn, CurrentFilter, CurrentPagination, CurrentRowSelection, CurrentSorter, GridState, GridStateType } from './index';
 
 export interface GridStateChange {
   /** Last Grid State Change that was triggered (only 1 type of change at a time) */
   change?: {
     /** Grid State change, the values of the new change */
-    newValues: Column[] | CurrentFilter[] | CurrentSorter[] | CurrentPagination | CurrentRowSelection;
+    newValues: CurrentColumn[] | CurrentFilter[] | CurrentSorter[] | CurrentPagination | CurrentRowSelection;
 
     /** The Grid State Type of change that was made (filter/sorter/...) */
     type: GridStateType;


### PR DESCRIPTION
Both the service and the tests use the CurrentColumn type
for the event GridStateType.column