### PR TITLE
fix(extensions): import jQuery mousewheel only with frozen, fixes #618

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
@@ -333,6 +333,16 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     expect(onAfterGridDestroyedSpy).toHaveBeenCalled();
   });
 
+  it('should load jQuery mousewheel when using a frozen grid', () => {
+    const loadSpy = jest.spyOn(component, 'loadJqueryMousewheelDynamically');
+    component.gridOptions.frozenRow = 3;
+
+    component.ngOnInit();
+    component.ngAfterViewInit();
+
+    expect(loadSpy).toHaveBeenCalled();
+  });
+
   describe('initialization method', () => {
     describe('columns definitions changed', () => {
       it('should expect "translateColumnHeaders" being called when "enableTranslate" is set', () => {

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -2,7 +2,6 @@
 // only import the necessary core lib, each will be imported on demand when enabled (via require)
 import 'jquery-ui-dist/jquery-ui';
 import 'slickgrid/lib/jquery.event.drag-2.3.0';
-import 'slickgrid/lib/jquery.mousewheel';
 import 'slickgrid/slick.core';
 import 'slickgrid/slick.grid';
 import 'slickgrid/slick.dataview';
@@ -77,6 +76,7 @@ import { RowSelectionExtension } from '../extensions/rowSelectionExtension';
 // using external non-typed js libraries
 declare const Slick: any;
 declare const $: any;
+declare function require(name: string);
 
 const slickgridEventPrefix = 'sg';
 
@@ -254,8 +254,13 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
   }
 
   ngOnInit(): void {
-    this.onBeforeGridCreate.emit(true);
+    if (this.gridOptions && this.gridOptions.frozenRow >= 0) {
+      // load jQuery mousewheel only when using a frozen grid (this will make the mousewheel work on any side of the frozen container).
+      // DO NOT USE with Row Detail
+      require('slickgrid/lib/jquery.mousewheel');
+    }
 
+    this.onBeforeGridCreate.emit(true);
     if (this.gridOptions && !this.gridOptions.enableAutoResize && (this._fixedHeight || this._fixedWidth)) {
       this.gridHeightString = `${this._fixedHeight}px`;
       this.gridWidthString = `${this._fixedWidth}px`;

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -255,9 +255,7 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
 
   ngOnInit(): void {
     if (this.gridOptions && this.gridOptions.frozenRow >= 0) {
-      // load jQuery mousewheel only when using a frozen grid (this will make the mousewheel work on any side of the frozen container).
-      // DO NOT USE with Row Detail
-      require('slickgrid/lib/jquery.mousewheel');
+      this.loadJqueryMousewheelDynamically();
     }
 
     this.onBeforeGridCreate.emit(true);
@@ -335,6 +333,12 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
         };
       }
     }
+  }
+
+  loadJqueryMousewheelDynamically() {
+    // load jQuery mousewheel only when using a frozen grid (this will make the mousewheel work on any side of the frozen container).
+    // DO NOT USE with Row Detail
+    require('slickgrid/lib/jquery.mousewheel');
   }
 
   /**


### PR DESCRIPTION
- when jQuery mousewheel is imported, SlickGrid attaches a scroll handler which prevent scrolling to work as normal, this however should only be used with frozen grids since it creates other issues like seen in Row Detail were it doesn't behave correctly
- NOTE that this is more of a patch and a SlickGrid grid option flag would be better to handle that, possibly create a flag in future SlickGrid version
- fixes #618