### PR TITLE
refactor: use http-server instead of webpack to run Cypress E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,11 @@ jobs:
           name: Upload Jest coverage to Codecov
           command: bash <(curl -s https://codecov.io/bash)
       - run:
-          name: Start Dev WebServer
-          command: yarn start
+          name: Website Prod Build (GitHub demo site)
+          command: yarn run build:demo
+      - run:
+          name: Run Web Server
+          command: yarn run serve:demo
           background: true
       - restore_cache:
           name: Restoring Cache for Cypress
@@ -49,6 +52,3 @@ jobs:
           command: |
             cd test/cypress
             yarn cypress:ci
-      - run:
-          name: Build Demo Site
-          command: yarn run ng:build

--- a/angular.json
+++ b/angular.json
@@ -11,7 +11,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist-demo",
+            "outputPath": "docs",
             "index": "src/index.html",
             "main": "src/main.ts",
             "tsConfig": "src/tsconfig.app.json",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "ng:build": "ng build",
     "start": "ng serve --port 4300 --open",
     "prebuild": "npm-run-all delete:dist",
     "build": "npm run packagr",
@@ -67,7 +66,9 @@
     "presass:watch:salesforce": "cross-env npm run sass-build-task:scss-compile:salesforce",
     "sass:watch:salesforce": "cross-env npm run sass-build-task:scss-compile:salesforce -- -watch",
     "sass:watch": "run-p sass:watch:bootstrap sass:watch:material sass:watch:salesforce sass:copy:watch",
-    "sass:copy:watch": "nodemon --ext scss --watch src/app/modules/angular-slickgrid/styles/*.scss --exec \"npm run sass:copy\""
+    "sass:copy:watch": "nodemon --ext scss --watch src/app/modules/angular-slickgrid/styles/*.scss --exec \"npm run sass:copy\"",
+    "build:demo": "ng build --configuration=production",
+    "serve:demo": "http-server ./docs -p 4300 -a localhost"
   },
   "author": "Ghislain B.",
   "repository": {
@@ -155,6 +156,7 @@
     "gulp-bump": "^3.2.0",
     "gulp-sass": "^4.1.0",
     "gulp-yuidoc": "^0.1.2",
+    "http-server": "^0.12.3",
     "jest": "^24.9.0",
     "jest-extended": "^0.11.5",
     "jest-junit": "^6.4.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -69,7 +69,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes), TranslateModule],
+  imports: [RouterModule.forRoot(routes, { useHash: true }), TranslateModule],
   exports: [RouterModule, TranslateModule],
 })
 export class AppRoutingRoutingModule { }

--- a/test/cypress/cypress.json
+++ b/test/cypress/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:4300",
-  "baseExampleUrl": "http://localhost:4300",
+  "baseExampleUrl": "http://localhost:4300/#",
   "video": false,
   "viewportWidth": 1200,
   "viewportHeight": 950,

--- a/test/cypress/integration/example01.spec.js
+++ b/test/cypress/integration/example01.spec.js
@@ -4,7 +4,7 @@ describe('Example 1 - Basic Grids', () => {
   const fullTitles = ['Title', 'Duration (days)', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseUrl')}`);
+    cy.visit(`${Cypress.config('baseExampleUrl')}`);
     cy.get('h2').should('contain', 'Example 1: Basic Grids');
   });
 

--- a/test/cypress/integration/example07.spec.js
+++ b/test/cypress/integration/example07.spec.js
@@ -11,7 +11,7 @@ describe('Example 7 - Header Button Plugin', () => {
   });
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseUrl')}/headerbutton`);
+    cy.visit(`${Cypress.config('baseExampleUrl')}/headerbutton`);
     cy.get('h2').should('contain', 'Example 7: Header Button Plugin');
   });
 

--- a/test/cypress/integration/example08.spec.js
+++ b/test/cypress/integration/example08.spec.js
@@ -11,7 +11,7 @@ describe('Example 8 - Header Menu Plugin', () => {
   });
 
   it('should display Example title', () => {
-    cy.visit(`${Cypress.config('baseUrl')}/headermenu`);
+    cy.visit(`${Cypress.config('baseExampleUrl')}/headermenu`);
     cy.get('h2').should('contain', 'Example 8: Header Menu Plugin');
   });
 

--- a/test/cypress/integration/home.spec.js
+++ b/test/cypress/integration/home.spec.js
@@ -2,7 +2,7 @@
 
 describe('Home Page', () => {
   it('should display Home Page', () => {
-    cy.visit('http://localhost:4300/home');
+    cy.visit(`${Cypress.config('baseExampleUrl')}/home`);
 
     cy.get('h2').should(($h2) => {
       expect($h2, 'text content').to.have.text('Angular-Slickgrid - Demo Site');


### PR DESCRIPTION
- run a Prod build and then use http-server to serve Cypress E2E tests