### PR TITLE
fix(backend): OData/GraphQL pagination should display warning on empty

### DIFF
--- a/src/app/examples/grid-odata.component.html
+++ b/src/app/examples/grid-odata.component.html
@@ -31,16 +31,16 @@
       <span data-test="radioVersion">
         <label class="radio-inline control-label" for="radio2">
           <input type="radio" name="inlineRadioOptions" data-test="version2" id="radio2" checked [value]="2"
-            (change)="setOdataVersion(2)"> 2
+                 (change)="setOdataVersion(2)"> 2
         </label>
         <label class="radio-inline control-label" for="radio4">
           <input type="radio" name="inlineRadioOptions" data-test="version4" id="radio4" [value]="4"
-            (change)="setOdataVersion(4)"> 4
+                 (change)="setOdataVersion(4)"> 4
         </label>
       </span>
       <label class="checkbox-inline control-label" for="enableCount" style="margin-left: 20px">
         <input type="checkbox" id="enableCount" data-test="enable-count" [checked]="isCountEnabled"
-          (click)="changeCountEnableFlag()">
+               (click)="changeCountEnableFlag()">
         <span style="font-weight: bold">Enable Count</span> (add to OData query)
       </label>
     </div>
@@ -55,8 +55,12 @@
     </button>
   </div>
 
-  <angular-slickgrid gridId="grid5" [columnDefinitions]="columnDefinitions" [gridOptions]="gridOptions"
-    [dataset]="dataset" (onGridStateChanged)="gridStateChanged($event)"
-    (onAngularGridCreated)="angularGridReady($event)">
+  <angular-slickgrid gridId="grid5"
+                     [columnDefinitions]="columnDefinitions"
+                     [gridOptions]="gridOptions"
+                     [paginationOptions]="paginationOptions"
+                     [dataset]="dataset"
+                     (onGridStateChanged)="gridStateChanged($event)"
+                     (onAngularGridCreated)="angularGridReady($event)">
   </angular-slickgrid>
 </div>

--- a/src/app/examples/grid-odata.component.ts
+++ b/src/app/examples/grid-odata.component.ts
@@ -12,6 +12,7 @@ import {
   OdataOption,
   OdataServiceApi,
   OperatorType,
+  Pagination,
 } from './../modules/angular-slickgrid';
 
 const defaultPageSize = 20;
@@ -43,6 +44,7 @@ export class GridOdataComponent implements OnInit {
   gridOptions: GridOption;
   dataset = [];
   metrics: Metrics;
+  paginationOptions: Pagination;
 
   isCountEnabled = true;
   odataVersion = 2;
@@ -139,11 +141,10 @@ export class GridOdataComponent implements OnInit {
     if (this.isCountEnabled) {
       countPropName = (this.odataVersion === 4) ? '@odata.count' : 'odata.count';
     }
-    this.gridOptions.pagination.totalItems = data[countPropName];
+    this.paginationOptions = { ...this.gridOptions.pagination, totalItems: data[countPropName] };
     if (this.metrics) {
       this.metrics.totalItemCount = data[countPropName];
     }
-    this.gridOptions = Object.assign({}, this.gridOptions);
 
     // once pagination totalItems is filled, we can update the dataset
     this.dataset = data['items'];

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
@@ -126,6 +126,7 @@ const paginationServiceStub = {
   totalItems: 0,
   init: jest.fn(),
   dispose: jest.fn(),
+  updateTotalItems: jest.fn(),
   onPaginationVisibilityChanged: new Subject<boolean>(),
   onPaginationChanged: new Subject<ServicePagination>(),
 } as unknown as PaginationService;
@@ -1247,6 +1248,29 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
       beforeEach(() => {
         jest.clearAllMocks();
         component.destroy();
+      });
+
+      it('should merge paginationOptions when some already exist', () => {
+        const mockPagination = { pageSize: 2, pageSizes: [] };
+        const paginationSrvSpy = jest.spyOn(paginationServiceStub, 'updateTotalItems');
+
+        component.ngAfterViewInit();
+        component.paginationOptions = mockPagination;
+
+        expect(component.paginationOptions).toEqual({ ...mockPagination, totalItems: 0 });
+        expect(paginationSrvSpy).toHaveBeenCalledWith(0, true);
+      });
+
+      it('should set brand new paginationOptions when none previously exist', () => {
+        const mockPagination = { pageSize: 2, pageSizes: [], totalItems: 1 };
+        const paginationSrvSpy = jest.spyOn(paginationServiceStub, 'updateTotalItems');
+
+        component.ngAfterViewInit();
+        component.paginationOptions = undefined;
+        component.paginationOptions = mockPagination;
+
+        expect(component.paginationOptions).toEqual(mockPagination);
+        expect(paginationSrvSpy).toHaveBeenNthCalledWith(2, 1, true);
       });
 
       it('should call trigger a gridStage change event when pagination change is triggered', () => {

--- a/src/app/modules/angular-slickgrid/services/pagination.service.ts
+++ b/src/app/modules/angular-slickgrid/services/pagination.service.ts
@@ -95,9 +95,7 @@ export class PaginationService {
     if (this._isLocalGrid && this.dataView) {
       this._eventHandler.subscribe(this.dataView.onPagingInfoChanged, (e, pagingInfo) => {
         if (this._totalItems !== pagingInfo.totalRows) {
-          this._totalItems = pagingInfo.totalRows;
-          this._paginationOptions.totalItems = this._totalItems;
-          this.refreshPagination(false, false);
+          this.updateTotalItems(pagingInfo.totalRows);
         }
       });
       dataView.setRefreshHints({ isFilterUnchanged: true });
@@ -366,6 +364,14 @@ export class PaginationService {
   // --
   // private functions
   // --------------------
+
+  updateTotalItems(totalItems: number, triggerChangedEvent = false) {
+    this._totalItems = totalItems;
+    if (this._paginationOptions) {
+      this._paginationOptions.totalItems = totalItems;
+      this.refreshPagination(false, triggerChangedEvent);
+    }
+  }
 
   /**
    * When item is added or removed, we will refresh the numbers on the pagination however we won't trigger a backend change

--- a/test/cypress/integration/example05.spec.js
+++ b/test/cypress/integration/example05.spec.js
@@ -516,6 +516,9 @@ describe('Example 5 - OData Grid', () => {
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('.slick-empty-data-warning:visible')
+        .contains('No data to display.');
     });
 
     it('should display page 0 of 0 but hide pagination from/to numbers when filtered data "xy" returns an empty dataset', () => {
@@ -553,6 +556,10 @@ describe('Example 5 - OData Grid', () => {
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('.slick-empty-data-warning')
+        .contains('No data to display.')
+        .should('not.be.visible');
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(2);


### PR DESCRIPTION
- add a new paginationOptions getter/setter to avoid incomplete gridOptions passed by the OData result callback, merging the gridOptions was incomplete because it was only merging with the local gridOptions instead of the local+global gridOptions
- basically we won't be able to see the Empty Dataset Warning with OData unless we modified the code and use the new setter. Keeping the old code will still work but just won't display the warning when dataset is empty