### PR TITLE
feat(services): add 2x new methods hideColumnById or ..byIds

### DIFF
--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -176,10 +176,14 @@ export class GridRowMoveComponent implements OnInit, OnDestroy {
   }
 
   hideDurationColumnDynamically() {
-    const columnIndex = this.angularGrid.slickGrid.getColumns().findIndex(col => col.id === 'duration');
-    if (columnIndex >= 0) {
-      this.angularGrid.gridService.hideColumnByIndex(columnIndex);
-    }
+    // -- you can hide by one Id or multiple Ids:
+    // hideColumnById(id, options), hideColumnByIds([ids], options)
+    // you can also provide options, defaults are: { autoResizeColumns: true, triggerEvent: true, hideFromColumnPicker: false, hideFromGridMenu: false }
+
+    this.angularGrid.gridService.hideColumnById('duration');
+
+    // or with multiple Ids and extra options
+    // this.angularGrid.gridService.hideColumnByIds(['duration', 'finish'], { hideFromColumnPicker: true, hideFromGridMenu: false });
   }
 
   // Disable/Enable Filtering/Sorting functionalities

--- a/src/app/modules/angular-slickgrid/models/hideColumnOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/hideColumnOption.interface.ts
@@ -1,0 +1,13 @@
+export interface HideColumnOption {
+  /** Defaults to true, do we want to auto-reize the columns in the grid after hidding the column(s)? */
+  autoResizeColumns?: boolean;
+
+  /** Defaults to false, do we want to hide the column name from the column picker after hidding the column from the grid? */
+  hideFromColumnPicker?: boolean;
+
+  /** Defaults to false, do we want to hide the column name from the grid menu after hidding the column from the grid? */
+  hideFromGridMenu?: boolean;
+
+  /** Defaults to true, do we want to trigger an even "onHeaderMenuColumnsChanged" after hidding the column(s)? */
+  triggerEvent?: boolean;
+}

--- a/src/app/modules/angular-slickgrid/models/index.ts
+++ b/src/app/modules/angular-slickgrid/models/index.ts
@@ -96,6 +96,7 @@ export * from './headerButton.interface';
 export * from './headerButtonItem.interface';
 export * from './headerButtonOnCommandArgs.interface';
 export * from './headerMenu.interface';
+export * from './hideColumnOption.interface';
 export * from './htmlElementPosition.interface';
 export * from './jQueryUiSliderOption.interface';
 export * from './jQueryUiSliderResponse.interface';

--- a/src/app/modules/angular-slickgrid/services/__tests__/grid.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/grid.service.spec.ts
@@ -1225,13 +1225,13 @@ describe('Grid Service', () => {
       const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
       const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
       jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
-      const getVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
       const setColsSpy = jest.spyOn(gridStub, 'setColumns');
       const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
 
       service.hideColumnByIndex(1);
 
-      expect(getVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(rxColChangedSpy).toHaveBeenCalledWith(mockWithoutColumns);
     });
@@ -1240,13 +1240,13 @@ describe('Grid Service', () => {
       const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
       const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
       jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
-      const getVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
       const setColsSpy = jest.spyOn(gridStub, 'setColumns');
       const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
 
       service.hideColumnByIndex(1, false);
 
-      expect(getVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(rxColChangedSpy).not.toHaveBeenCalled();
     });
@@ -1268,13 +1268,13 @@ describe('Grid Service', () => {
       const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
       const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
       jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
-      const getVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
       const setColsSpy = jest.spyOn(gridStub, 'setColumns');
       const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
 
       service.hideColumnByIndex(1);
 
-      expect(getVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(rxColChangedSpy).toHaveBeenCalledWith(mockWithoutColumns);
     });
@@ -1283,15 +1283,170 @@ describe('Grid Service', () => {
       const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
       const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
       jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
-      const getVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
       const setColsSpy = jest.spyOn(gridStub, 'setColumns');
       const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
 
       service.hideColumnByIndex(1, false);
 
-      expect(getVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
       expect(rxColChangedSpy).not.toHaveBeenLastCalledWith(mockWithoutColumns);
+    });
+  });
+
+  describe('hideColumnById method', () => {
+    it('should return -1 when the column id is not found in the list of loaded column definitions', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+
+      const output = service.hideColumnById('xyz');
+
+      expect(output).toBe(-1);
+    });
+
+    it('should set new columns minus the column to hide and it should keep new set as the new "visibleColumns"', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
+      const setColsSpy = jest.spyOn(gridStub, 'setColumns');
+      const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
+
+      const output = service.hideColumnById('field2');
+
+      expect(output).toBe(1);
+      expect(autoSizeSpy).toHaveBeenCalled();
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(rxColChangedSpy).toHaveBeenCalledWith(mockWithoutColumns);
+    });
+
+    it('should set new columns minus the column to hide but without triggering an event when set to False', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
+      const setColsSpy = jest.spyOn(gridStub, 'setColumns');
+      const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
+
+      service.hideColumnById('field2', { triggerEvent: false });
+
+      expect(autoSizeSpy).toHaveBeenCalled();
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(rxColChangedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should set new columns minus the column to hide but without resize the columns when "autoResizeColumns" is set to False', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
+      const setColsSpy = jest.spyOn(gridStub, 'setColumns');
+      const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
+
+      service.hideColumnById('field2', { autoResizeColumns: false });
+
+      expect(autoSizeSpy).not.toHaveBeenCalled();
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(rxColChangedSpy).toHaveBeenCalled();
+    });
+
+    it('should set new columns minus the column to hide AND also hide the column from the column picker when "hideFromColumnPicker" is set to False', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(mockColumns);
+      const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
+      const setColsSpy = jest.spyOn(gridStub, 'setColumns');
+
+      service.hideColumnById('field2', { hideFromColumnPicker: true });
+
+      expect(autoSizeSpy).toHaveBeenCalled();
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(mockColumns).toEqual([{ id: 'field1', width: 100 }, { id: 'field2', width: 150, excludeFromColumnPicker: true }, { id: 'field3', field: 'field3' }]);
+      expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
+    });
+
+    it('should set new columns minus the column to hide AND also hide the column from the column picker when "hideFromColumnPicker" is set to False', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      const mockWithoutColumns = [{ id: 'field1', width: 100 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const setVisibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+      jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(mockColumns);
+      const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
+      const setColsSpy = jest.spyOn(gridStub, 'setColumns');
+
+      service.hideColumnById('field2', { autoResizeColumns: false, hideFromGridMenu: true });
+
+      expect(autoSizeSpy).not.toHaveBeenCalled();
+      expect(setVisibleSpy).toHaveBeenCalledWith(mockWithoutColumns);
+      expect(mockColumns).toEqual([{ id: 'field1', width: 100 }, { id: 'field2', width: 150, excludeFromGridMenu: true }, { id: 'field3', field: 'field3' }]);
+      expect(setColsSpy).toHaveBeenCalledWith(mockWithoutColumns);
+    });
+  });
+
+  describe('hideColumnByIds method', () => {
+    it('should loop through the Ids provided and call hideColumnById on each of them with same options', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
+      const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
+      const hideByIdSpy = jest.spyOn(service, 'hideColumnById');
+
+      service.hideColumnByIds(['field2', 'field3']);
+
+      expect(hideByIdSpy).toHaveBeenCalledTimes(2);
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(1, 'field2', { autoResizeColumns: false, hideFromColumnPicker: false, hideFromGridMenu: false, triggerEvent: false });
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(2, 'field3', { autoResizeColumns: false, hideFromColumnPicker: false, hideFromGridMenu: false, triggerEvent: false });
+      expect(autoSizeSpy).toHaveBeenCalled();
+      expect(rxColChangedSpy).toHaveBeenCalledWith(expect.toBeArray());
+    });
+
+    it('should loop through the Ids provided and call hideColumnById on each of them with same options BUT not auto size columns neither trigger when both are disabled', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
+      const rxColChangedSpy = jest.spyOn(service.onColumnsChanged, 'next');
+      const hideByIdSpy = jest.spyOn(service, 'hideColumnById');
+
+      service.hideColumnByIds(['field2', 'field3'], { autoResizeColumns: false, triggerEvent: false });
+
+      expect(hideByIdSpy).toHaveBeenCalledTimes(2);
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(1, 'field2', { autoResizeColumns: false, hideFromColumnPicker: false, hideFromGridMenu: false, triggerEvent: false });
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(2, 'field3', { autoResizeColumns: false, hideFromColumnPicker: false, hideFromGridMenu: false, triggerEvent: false });
+      expect(autoSizeSpy).not.toHaveBeenCalled();
+      expect(rxColChangedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should loop through the Ids provided and call hideColumnById on each of them with same options and hide from column picker when "hideFromColumnPicker" is enabled', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const hideByIdSpy = jest.spyOn(service, 'hideColumnById');
+
+      service.hideColumnByIds(['field2', 'field3'], { hideFromColumnPicker: true });
+
+      expect(hideByIdSpy).toHaveBeenCalledTimes(2);
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(1, 'field2', { autoResizeColumns: false, hideFromColumnPicker: true, hideFromGridMenu: false, triggerEvent: false });
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(2, 'field3', { autoResizeColumns: false, hideFromColumnPicker: true, hideFromGridMenu: false, triggerEvent: false });
+    });
+
+    it('should loop through the Ids provided and call hideColumnById on each of them with same options and hide from column picker when "hideFromColumnPicker" is enabled', () => {
+      const mockColumns = [{ id: 'field1', width: 100 }, { id: 'field2', width: 150 }, { id: 'field3', field: 'field3' }] as Column[];
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
+      const hideByIdSpy = jest.spyOn(service, 'hideColumnById');
+
+      service.hideColumnByIds(['field2', 'field3'], { hideFromGridMenu: true });
+
+      expect(hideByIdSpy).toHaveBeenCalledTimes(2);
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(1, 'field2', { autoResizeColumns: false, hideFromColumnPicker: false, hideFromGridMenu: true, triggerEvent: false });
+      expect(hideByIdSpy).toHaveBeenNthCalledWith(2, 'field3', { autoResizeColumns: false, hideFromColumnPicker: false, hideFromGridMenu: true, triggerEvent: false });
     });
   });
 

--- a/src/app/modules/angular-slickgrid/services/grid.service.ts
+++ b/src/app/modules/angular-slickgrid/services/grid.service.ts
@@ -8,6 +8,7 @@ import {
   GridServiceDeleteOption,
   GridServiceInsertOption,
   GridServiceUpdateOption,
+  HideColumnOption,
   OnEventArgs
 } from './../models/index';
 import { ExtensionService } from './extension.service';
@@ -20,9 +21,11 @@ import { arrayRemoveItemByIndex } from './utilities';
 // using external non-typed js libraries
 declare const Slick: any;
 let highlightTimerEnd: any;
+
 const GridServiceDeleteOptionDefaults: GridServiceDeleteOption = { triggerEvent: true };
 const GridServiceInsertOptionDefaults: GridServiceInsertOption = { highlightRow: true, position: 'top', resortGrid: false, selectRow: false, triggerEvent: true };
 const GridServiceUpdateOptionDefaults: GridServiceUpdateOption = { highlightRow: true, selectRow: false, scrollRowIntoView: false, triggerEvent: true };
+const HideColumnOptionDefaults: HideColumnOption = { autoResizeColumns: true, triggerEvent: true, hideFromColumnPicker: false, hideFromGridMenu: false };
 
 @Injectable()
 export class GridService {
@@ -141,9 +144,10 @@ export class GridService {
   }
 
   /**
-   * Hide a Column from the Grid (the column will just become hidden and will still show up in columnPicker/gridMenu)
-   * @param column
-   */
+     * @deprecated Hide a Column from the Grid (the column will just become hidden and will still show up in columnPicker/gridMenu)
+     * @see hideColumnById
+     * @param column
+     */
   hideColumn(column: Column) {
     if (this._grid && this._grid.getColumns && this._grid.setColumns && this._grid.getColumnIndex) {
       const columnIndex = this._grid.getColumnIndex(column.id);
@@ -154,7 +158,8 @@ export class GridService {
   }
 
   /**
-   * Hide a Column from the Grid by its column definition index (the column will just become hidden and will still show up in columnPicker/gridMenu)
+   * @deprecated Hide a Column from the Grid by its column definition index (the column will just become hidden and will still show up in columnPicker/gridMenu)
+   * @see hideColumnById Please use "hideColumnById(id)" or "hideColumnByIds([ids])" instead since it has a lot more options
    * @param columnIndex - column definition index
    * @param triggerEvent - do we want to trigger an event (onHeaderMenuColumnsChanged) when column becomes hidden? Defaults to true.
    */
@@ -166,6 +171,71 @@ export class GridService {
       this._grid.setColumns(visibleColumns);
       if (triggerEvent) {
         this.onColumnsChanged.next(visibleColumns);
+      }
+    }
+  }
+
+  /**
+   * Hide a Column from the Grid by its column definition id, the column will just become hidden and will still show up in columnPicker/gridMenu
+   * @param {string | number} columnId - column definition id
+   * @param {boolean} triggerEvent - do we want to trigger an event (onHeaderMenuColumnsChanged) when column becomes hidden? Defaults to true.
+   * @return {number} columnIndex - column index position when found or -1
+   */
+  hideColumnById(columnId: string | number, options?: HideColumnOption): number {
+    options = { ...HideColumnOptionDefaults, ...options };
+    if (this._grid && this._grid.getColumns && this._grid.setColumns) {
+      const currentColumns = this._grid.getColumns();
+      const colIndexFound = currentColumns.findIndex(col => col.id === columnId);
+
+      if (colIndexFound >= 0) {
+        const visibleColumns = arrayRemoveItemByIndex<Column>(currentColumns, colIndexFound);
+        this.sharedService.visibleColumns = visibleColumns;
+        this._grid.setColumns(visibleColumns);
+
+        const columnIndexFromAllColumns = this.sharedService.allColumns.findIndex(col => col.id === columnId);
+        if (columnIndexFromAllColumns) {
+          if (options && options.hideFromColumnPicker) {
+            this.sharedService.allColumns[columnIndexFromAllColumns].excludeFromColumnPicker = true;
+          }
+          if (options && options.hideFromGridMenu) {
+            this.sharedService.allColumns[columnIndexFromAllColumns].excludeFromGridMenu = true;
+          }
+        }
+
+        // do we want to auto-resize the columns in the grid after hidding some? most often yes
+        if (options && options.autoResizeColumns) {
+          this._grid.autosizeColumns();
+        }
+
+        // do we want to trigger an event after hidding
+        if (options && options.triggerEvent) {
+          this.onColumnsChanged.next(visibleColumns);
+        }
+        return colIndexFound;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Hide a Column from the Grid by its column definition id(s), the column will just become hidden and will still show up in columnPicker/gridMenu
+   * @param {Array<string | number>} columnIds - column definition ids, can be a single string and an array of strings
+   * @param {boolean} triggerEvent - do we want to trigger an event (onHeaderMenuColumnsChanged) when column becomes hidden? Defaults to true.
+   */
+  hideColumnByIds(columnIds: Array<string | number>, options?: HideColumnOption) {
+    options = { ...HideColumnOptionDefaults, ...options };
+    if (Array.isArray(columnIds)) {
+      for (const columnId of columnIds) {
+        // hide each column by its id but wait after the for loop to auto resize columns in the grid
+        this.hideColumnById(columnId, { ...options, triggerEvent: false, autoResizeColumns: false });
+      }
+      // do we want to auto-resize the columns in the grid after hidding some? most often yes
+      if (options && options.autoResizeColumns) {
+        this._grid.autosizeColumns();
+      }
+      // do we want to trigger an event after hidding
+      if (options && options.triggerEvent) {
+        this.onColumnsChanged.next(this.sharedService.visibleColumns);
       }
     }
   }


### PR DESCRIPTION
- deprecated previous methods (hideColumn, hideColumnByIndex) since the new methods offer more values with extra options to resize and/or hide from pickers