### PR TITLE
fix(exports): Excel Export custom width applies the width to next column

### DIFF
--- a/src/app/modules/angular-slickgrid/services/__tests__/export.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/export.service.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
+  Column,
   DelimiterType,
+  FieldType,
   FileType,
   Formatter,
   GridOption,
-  Column,
-  FieldType,
   SortDirectionNumber,
 } from '../../models';
 import { ExportService } from '../export.service';
@@ -322,28 +322,28 @@ describe('ExportService', () => {
 
       it(`should have the UserId escape with equal sign showing as prefix, to avoid Excel casting the value 1E06 to 1 exponential 6,
             when "exportCsvForceToKeepAsString" is enable in its column definition`, (done) => {
-        mockCollection = [{ id: 0, userId: '1E06', firstName: 'John', lastName: 'Z', position: 'SALES_REP', order: 10 }];
-        jest.spyOn(dataViewStub, 'getLength').mockReturnValue(mockCollection.length);
-        jest.spyOn(dataViewStub, 'getItem').mockReturnValue(null).mockReturnValueOnce(mockCollection[0]);
-        const spyOnAfter = jest.spyOn(service.onGridAfterExportToFile, 'next');
-        const spyUrlCreate = jest.spyOn(URL, 'createObjectURL');
-        const spyDownload = jest.spyOn(service, 'startDownloadFile');
+          mockCollection = [{ id: 0, userId: '1E06', firstName: 'John', lastName: 'Z', position: 'SALES_REP', order: 10 }];
+          jest.spyOn(dataViewStub, 'getLength').mockReturnValue(mockCollection.length);
+          jest.spyOn(dataViewStub, 'getItem').mockReturnValue(null).mockReturnValueOnce(mockCollection[0]);
+          const spyOnAfter = jest.spyOn(service.onGridAfterExportToFile, 'next');
+          const spyUrlCreate = jest.spyOn(URL, 'createObjectURL');
+          const spyDownload = jest.spyOn(service, 'startDownloadFile');
 
-        const optionExpectation = { filename: 'export.csv', format: 'csv', useUtf8WithBom: false };
-        const contentExpectation =
-          `"User Id","FirstName","LastName","Position","Order"
+          const optionExpectation = { filename: 'export.csv', format: 'csv', useUtf8WithBom: false };
+          const contentExpectation =
+            `"User Id","FirstName","LastName","Position","Order"
               ="1E06","John","Z","SALES_REP","<b>10</b>"`;
 
-        service.init(gridStub, dataViewStub);
-        service.exportToFile(mockExportCsvOptions);
+          service.init(gridStub, dataViewStub);
+          service.exportToFile(mockExportCsvOptions);
 
-        setTimeout(() => {
-          expect(spyOnAfter).toHaveBeenCalledWith(optionExpectation);
-          expect(spyUrlCreate).toHaveBeenCalledWith(mockCsvBlob);
-          expect(spyDownload).toHaveBeenCalledWith({ ...optionExpectation, content: removeMultipleSpaces(contentExpectation) });
-          done();
+          setTimeout(() => {
+            expect(spyOnAfter).toHaveBeenCalledWith(optionExpectation);
+            expect(spyUrlCreate).toHaveBeenCalledWith(mockCsvBlob);
+            expect(spyDownload).toHaveBeenCalledWith({ ...optionExpectation, content: removeMultipleSpaces(contentExpectation) });
+            done();
+          });
         });
-      });
 
       it(`should have the LastName in uppercase when "formatter" is defined but also has "exportCustomFormatter" which will be used`, (done) => {
         mockCollection = [{ id: 1, userId: '2B02', firstName: 'Jane', lastName: 'Doe', position: 'FINANCE_MANAGER', order: 1 }];

--- a/src/app/modules/angular-slickgrid/services/excelExport.service.ts
+++ b/src/app/modules/angular-slickgrid/services/excelExport.service.ts
@@ -273,7 +273,7 @@ export class ExcelExportService {
   private getColumnStyles(columns: Column[]): any[] {
     const grouping = this._dataView && this._dataView.getGrouping && this._dataView.getGrouping();
     const columnStyles = [];
-    if (grouping) {
+    if (Array.isArray(grouping) && grouping.length > 0) {
       columnStyles.push({
         bestFit: true,
         columnStyles: (this._gridOptions && this._gridOptions.excelExportOptions && this._gridOptions.excelExportOptions.customColumnWidth) || 10
@@ -374,7 +374,7 @@ export class ExcelExportService {
     // get grouped column titles and if found, we will add a "Group by" column at the first column index
     // if it's a CSV format, we'll escape the text in double quotes
     const grouping = this._dataView && this._dataView.getGrouping && this._dataView.getGrouping();
-    if (grouping && Array.isArray(grouping) && grouping.length > 0) {
+    if (Array.isArray(grouping) && grouping.length > 0) {
       this._hasGroupedItems = true;
       return groupByColumnHeader;
     } else {


### PR DESCRIPTION
- the custom width was not applied to the correct column, when user had a custom width on column 1 it was applied to column 2. The bug was that getGrouping() always return an array and we should check for its length instead (not just if it exist)