### PR TITLE
feat(perf): improve date sorting speed

### DIFF
--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateEuroFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateEuroFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateEuro Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-03 00:00:01';
-    const result = Formatters.dateEuro(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateEuro(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('03/05/2019');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -17,7 +17,7 @@ describe('the Date ISO Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-03 00:00:01';
-    const result = Formatters.dateIso(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateIso(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('2019-05-03');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeEuroAmPmFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeEuroAmPmFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeShortEuro Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-01 02:36:07';
-    const result = Formatters.dateTimeEuroAmPm(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeEuroAmPm(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('01/05/2019 02:36:07 am');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeEuroFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeEuroFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeEuro Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-01 02:36:07';
-    const result = Formatters.dateTimeEuro(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeEuro(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('01/05/2019 02:36:07');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeIsoAmPmFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeIsoAmPmFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeIsoAmPm Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-01 02:36:07';
-    const result = Formatters.dateTimeIsoAmPm(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeIsoAmPm(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('2019-05-01 02:36:07 am');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeIsoFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeIso Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-01 02:36:07';
-    const result = Formatters.dateTimeIso(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeIso(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('2019-05-01 02:36:07');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeShortEuroFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeShortEuroFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeShortEuro Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-01 02:36:07';
-    const result = Formatters.dateTimeShortEuro(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeShortEuro(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('01/05/2019 02:36');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeShortIsoFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeShortIsoFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeShortIso Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-01 02:36:07';
-    const result = Formatters.dateTimeShortIso(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeShortIso(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('2019-05-01 02:36');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeShortUsFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeShortUsFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeShortUs Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-03 02:36:07';
-    const result = Formatters.dateTimeShortUs(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeShortUs(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('05/03/2019 02:36');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeUsAmPmFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeUsAmPmFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeShortUs Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-03 02:36:07';
-    const result = Formatters.dateTimeUsAmPm(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeUsAmPm(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('05/03/2019 02:36:07 am');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeUsFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateTimeUsFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateTimeUs Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-03 02:36:07';
-    const result = Formatters.dateTimeUs(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateTimeUs(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('05/03/2019 02:36:07');
   });
 

--- a/src/app/modules/angular-slickgrid/formatters/__tests__/dateUsFormatter.spec.ts
+++ b/src/app/modules/angular-slickgrid/formatters/__tests__/dateUsFormatter.spec.ts
@@ -16,7 +16,7 @@ describe('the DateUs Formatter', () => {
 
   it('should provide a dateIso formatted input and return a formatted date value without time when valid date value is provided', () => {
     const value = '2019-05-03';
-    const result = Formatters.dateUs(0, 0, value, { input: 'dateIso' } as unknown as Column, {}, {});
+    const result = Formatters.dateUs(0, 0, value, { type: 'dateIso' } as unknown as Column, {}, {});
     expect(result).toBe('05/03/2019');
   });
 

--- a/src/app/modules/angular-slickgrid/sorters/dateUtilities.ts
+++ b/src/app/modules/angular-slickgrid/sorters/dateUtilities.ts
@@ -6,18 +6,18 @@ const moment = moment_; // patch to fix rollup "moment has no default export" is
 export function compareDates(value1: any, value2: any, sortDirection: number, sortColumn: Column, gridOptions: GridOption, format: string | moment_.MomentBuiltinFormat, strict?: boolean) {
   let diff = 0;
   const checkForUndefinedValues = sortColumn && sortColumn.valueCouldBeUndefined || gridOptions && gridOptions.cellValueCouldBeUndefined || false;
+  const date1 = moment(value1, format, strict);
+  const date2 = moment(value2, format, strict);
 
-  if (value1 === null || value1 === '' || (checkForUndefinedValues && value1 === undefined) || !moment(value1, format, strict).isValid()) {
+  if (value1 === null || value1 === '' || (checkForUndefinedValues && value1 === undefined) || !date1.isValid()) {
     diff = -1;
-  } else if (value2 === null || value2 === '' || (checkForUndefinedValues && value2 === undefined) || !moment(value2, format, strict).isValid()) {
+  } else if (value2 === null || value2 === '' || (checkForUndefinedValues && value2 === undefined) || !date2.isValid()) {
     diff = 1;
   } else {
-    const date1 = moment(value1, format, strict);
-    const date2 = moment(value2, format, strict);
-    diff = parseInt(date1.format('X'), 10) - parseInt(date2.format('X'), 10);
+    diff = date1.valueOf() < date2.valueOf() ? -1 : 1;
   }
 
-  return sortDirection * (diff === 0 ? 0 : (diff > 0 ? 1 : -1));
+  return sortDirection * diff;
 }
 
 /** From a FieldType, return the associated date Sorter */


### PR DESCRIPTION
Here's a quick perf date sorting test before & after code change with 50k rows and 8 columns
_note: the date are all in ISO format (yyyy-mm-dd), it might be even bigger differences with non-ISO format_

### BEFORE
#### 1st pass
sorting ASC: 2255.841064453125 ms
sorting DESC: 676.7099609375 ms
sorting ASC: 644.962646484375 ms
sorting DESC: 671.908935546875 ms

#### 2nd pass
sorting ASC: 1981.27978515625 ms
sorting DESC: 692.999755859375 ms
sorting ASC: 673.643798828125 ms
sorting DESC: 670.118896484375 ms

### AFTER

#### 1st pass
sorting ASC: 1059.22802734375 ms
sorting DESC: 126.10400390625 ms
sorting ASC: 336.77685546875 ms
sorting DESC: 143.007080078125 ms

#### 2nd pass
sorting ASC: 903.991943359375 ms
sorting DESC: 143.51708984375 ms
sorting ASC: 374.537109375 ms
sorting DESC: 117.73583984375 ms