### PR TITLE
fix(pinning): reordering cols position freezing cols shouldn't affect

### DIFF
--- a/src/app/examples/grid-colspan.component.ts
+++ b/src/app/examples/grid-colspan.component.ts
@@ -54,7 +54,6 @@ export class GridColspanComponent implements OnInit {
     this.gridOptions1 = {
       enableAutoResize: false,
       enableCellNavigation: true,
-      enableColumnReorder: false,
       enableSorting: true,
       createPreHeaderPanel: true,
       showPreHeaderPanel: true,
@@ -79,7 +78,6 @@ export class GridColspanComponent implements OnInit {
 
     this.gridOptions2 = {
       enableCellNavigation: true,
-      enableColumnReorder: false,
       createPreHeaderPanel: true,
       showPreHeaderPanel: true,
       preHeaderPanelHeight: 25,

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
@@ -305,7 +305,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     component.gridId = 'grid1';
     component.columnDefinitions = [{ id: 'name', field: 'name' }];
     component.dataset = [];
-    component.gridOptions = { enableExcelExport: false, dataView: null } as GridOption;
+    component.gridOptions = { enableExcelExport: false, dataView: null } as unknown as GridOption;
     component.gridHeight = 600;
     component.gridWidth = 800;
   });
@@ -469,9 +469,9 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
 
         setTimeout(() => {
           expect(getColSpy).toHaveBeenCalled();
-          expect(component.columnDefinitions[0].editor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.collection).toEqual(mockCollection);
-          expect(component.columnDefinitions[0].internalColumnEditor.model).toEqual(Editors.text);
+          expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
+          expect(component.columnDefinitions[0].internalColumnEditor!.model).toEqual(Editors.text);
           done();
         });
       });
@@ -722,9 +722,9 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         component.ngAfterViewInit();
 
         setTimeout(() => {
-          expect(component.paginationOptions.pageSize).toBe(2);
-          expect(component.paginationOptions.pageNumber).toBe(expectedPageNumber);
-          expect(component.paginationOptions.totalItems).toBe(expectedTotalItems);
+          expect(component.paginationOptions!.pageSize).toBe(2);
+          expect(component.paginationOptions!.pageNumber).toBe(expectedPageNumber);
+          expect(component.paginationOptions!.totalItems).toBe(expectedTotalItems);
           expect(refreshSpy).toHaveBeenCalledWith(mockData);
           done();
         });
@@ -749,9 +749,9 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
 
         setTimeout(() => {
           expect(getPagingSpy).toHaveBeenCalled();
-          expect(component.paginationOptions.pageSize).toBe(10);
-          expect(component.paginationOptions.pageNumber).toBe(expectedPageNumber);
-          expect(component.paginationOptions.totalItems).toBe(expectedTotalItems);
+          expect(component.paginationOptions!.pageSize).toBe(10);
+          expect(component.paginationOptions!.pageNumber).toBe(expectedPageNumber);
+          expect(component.paginationOptions!.totalItems).toBe(expectedTotalItems);
           expect(refreshSpy).toHaveBeenCalledWith(mockData);
           done();
         });
@@ -781,55 +781,55 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         component.ngAfterViewInit();
 
         expect(spy).toHaveBeenCalled();
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       it('should execute the "internalPostProcess" callback method that was created by "createBackendApiInternalPostProcessCallback" with Pagination', () => {
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const spy = jest.spyOn(component, 'refreshGridData');
 
         component.ngAfterViewInit();
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { users: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { users: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
 
         expect(spy).toHaveBeenCalled();
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       it('should execute the "internalPostProcess" callback and expect totalItems to be updated in the PaginationService when "refreshGridData" is called on the 2nd time', () => {
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const refreshSpy = jest.spyOn(component, 'refreshGridData');
         const paginationSpy = jest.spyOn(paginationServiceStub, 'totalItems', 'set');
         const mockDataset = [{ firstName: 'John' }, { firstName: 'Jane' }];
 
         component.ngAfterViewInit();
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { users: { nodes: mockDataset, totalCount: mockDataset.length } } } as GraphqlPaginatedResult);
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { users: { nodes: mockDataset, totalCount: mockDataset.length } } } as GraphqlPaginatedResult);
         component.refreshGridData(mockDataset, 1);
         component.refreshGridData(mockDataset, 1);
 
         expect(refreshSpy).toHaveBeenCalledTimes(3);
         expect(paginationSpy).toHaveBeenCalledWith(2);
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       it('should execute the "internalPostProcess" callback method that was created by "createBackendApiInternalPostProcessCallback" without Pagination (when disabled)', () => {
         component.gridOptions.enablePagination = false;
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const spy = jest.spyOn(component, 'refreshGridData');
 
         component.ngAfterViewInit();
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { users: [{ firstName: 'John' }] } });
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { users: [{ firstName: 'John' }] } });
 
         expect(spy).toHaveBeenCalled();
-        expect(component.gridOptions.backendServiceApi.internalPostProcess).toEqual(expect.any(Function));
+        expect(component.gridOptions.backendServiceApi!.internalPostProcess).toEqual(expect.any(Function));
       });
 
       xit('should execute the "internalPostProcess" callback method but return an empty dataset when dataset name does not match "getDatasetName"', () => {
         component.gridOptions.enablePagination = true;
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'getDatasetName').mockReturnValue('users');
+        jest.spyOn(component.gridOptions.backendServiceApi!.service, 'getDatasetName').mockReturnValue('users');
         const spy = jest.spyOn(component, 'refreshGridData');
 
         component.ngAfterViewInit();
-        component.gridOptions.backendServiceApi.internalPostProcess({ data: { notUsers: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
+        component.gridOptions.backendServiceApi!.internalPostProcess!({ data: { notUsers: { nodes: [{ firstName: 'John' }], totalCount: 2 } } } as GraphqlPaginatedResult);
 
         expect(spy).not.toHaveBeenCalled();
         expect(component.dataset).toEqual([]);
@@ -902,10 +902,10 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 }
         };
         const promise = new Promise((resolve) => setTimeout(() => resolve(processResult), 1));
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(promise);
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi, 'process').mockReturnValue(promise);
+        jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        (component.gridOptions as any).backendServiceApi.service.options = { executeProcessCommandOnInit: true };
         component.ngAfterViewInit();
 
         expect(processSpy).toHaveBeenCalled();
@@ -923,10 +923,10 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           data: { users: { nodes: [] }, pageInfo: { hasNextPage: true }, totalCount: 0 },
           metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 }
         };
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(of(processResult));
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi, 'process').mockReturnValue(of(processResult));
+        jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        (component.gridOptions as any).backendServiceApi.service.options = { executeProcessCommandOnInit: true };
         component.ngAfterViewInit();
 
         expect(processSpy).toHaveBeenCalled();
@@ -944,10 +944,10 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           data: { users: [] },
           metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 }
         };
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(of(processResult));
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi, 'process').mockReturnValue(of(processResult));
+        jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        (component.gridOptions as any).backendServiceApi.service.options = { executeProcessCommandOnInit: true };
         component.ngAfterViewInit();
 
         expect(processSpy).toHaveBeenCalled();
@@ -962,10 +962,10 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         const mockError = { error: '404' };
         const query = `query { users (first:20,offset:0) { totalCount, nodes { id,name,gender,company } } }`;
         const promise = new Promise((resolve, reject) => setTimeout(() => reject(mockError), 1));
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(promise);
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi, 'process').mockReturnValue(promise);
+        jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        (component.gridOptions as any).backendServiceApi.service.options = { executeProcessCommandOnInit: true };
         component.ngAfterViewInit();
 
         expect(processSpy).toHaveBeenCalled();
@@ -979,10 +979,10 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
       it('should throw an error when the process method on initialization when "executeProcessCommandOnInit" is set as a backend service options from an Observable', (done) => {
         const mockError = { error: '404' };
         const query = `query { users (first:20,offset:0) { totalCount, nodes { id,name,gender,company } } }`;
-        const processSpy = jest.spyOn(component.gridOptions.backendServiceApi, 'process').mockReturnValue(throwError(mockError));
-        jest.spyOn(component.gridOptions.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn((component.gridOptions as any).backendServiceApi, 'process').mockReturnValue(throwError(mockError));
+        jest.spyOn((component.gridOptions as any).backendServiceApi.service, 'buildQuery').mockReturnValue(query);
 
-        component.gridOptions.backendServiceApi.service.options = { executeProcessCommandOnInit: true };
+        (component.gridOptions as any).backendServiceApi.service.options = { executeProcessCommandOnInit: true };
         component.ngAfterViewInit();
 
         expect(processSpy).toHaveBeenCalled();
@@ -1492,7 +1492,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
 
         component.gridOptions.enableRowSelection = true;
         component.gridOptions.enablePagination = true;
-        component.gridOptions.backendServiceApi = null;
+        (component.gridOptions as any).backendServiceApi = null;
         component.gridOptions.presets = { rowSelection: { dataContextIds: selectedGridRows } };
         component.dataset = mockData;
         component.ngAfterViewInit();
@@ -1511,7 +1511,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
 
       it('should change "showPagination" flag when "onPaginationVisibilityChanged" from the Pagination Service is triggered', (done) => {
         component.gridOptions.enablePagination = true;
-        component.gridOptions.backendServiceApi = null;
+        (component.gridOptions as any).backendServiceApi = null;
         component.ngAfterViewInit();
         paginationServiceStub.onPaginationVisibilityChanged.next({ visible: false });
         setTimeout(() => {

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -194,8 +194,8 @@ describe('App Component', () => {
     component.gridId = 'grid1';
 
     fixture.detectChanges();
-    const gridPaneElm = document.querySelector<HTMLDivElement>('.gridPane');
-    const gridContainerElm = document.querySelector<HTMLDivElement>('.slickgrid-container');
+    const gridPaneElm = document.querySelector('.gridPane') as HTMLDivElement;
+    const gridContainerElm = document.querySelector('.slickgrid-container') as HTMLDivElement;
 
     expect(gridPaneElm.id).toBe('slickGridContainer-grid1');
     expect(gridContainerElm.id).toBe('grid1');
@@ -209,8 +209,8 @@ describe('App Component', () => {
     component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file' } } as GridOption;
     component.dataset = mockFlatDataset;
     fixture.detectChanges();
-    const gridPaneElm = document.querySelector<HTMLDivElement>('.gridPane');
-    const gridContainerElm = document.querySelector<HTMLDivElement>('.slickgrid-container');
+    const gridPaneElm = document.querySelector('.gridPane') as HTMLDivElement;
+    const gridContainerElm = document.querySelector('.slickgrid-container') as HTMLDivElement;
 
     expect(gridPaneElm.id).toBe('slickGridContainer-grid1');
     expect(gridContainerElm.id).toBe('grid1');
@@ -227,8 +227,8 @@ describe('App Component', () => {
     component.gridWidth = 800;
 
     fixture.detectChanges();
-    const gridPaneElm = document.querySelector<HTMLDivElement>('.gridPane');
-    const gridContainerElm = document.querySelector<HTMLDivElement>('.slickgrid-container');
+    const gridPaneElm = document.querySelector('.gridPane') as HTMLDivElement;
+    const gridContainerElm = document.querySelector('.slickgrid-container') as HTMLDivElement;
 
     expect(component.gridHeightString).toBe('600px');
     expect(component.gridWidthString).toBe('800px');
@@ -237,7 +237,7 @@ describe('App Component', () => {
   });
 
   it('should throw an error when the "enableAutoResize" is disabled and no "grid-height" is provided', () => {
-    component.gridHeight = null;
+    (component as any).gridHeight = null;
     component.gridOptions = { enableAutoResize: false };
 
     expect(() => fixture.detectChanges()).toThrowError('[Angular-Slickgrid] requires a "grid-height" or the "enableAutoResize"');
@@ -267,5 +267,17 @@ describe('App Component', () => {
       expect(dispatchCustomSpy).toHaveBeenCalledWith('sgOnRowsChanged', expect.any(Object));
       done();
     }, 10);
+  });
+
+  it('should update "visibleColumns" in the Shared Service when "onColumnsReordered" event is triggered', () => {
+    const sharedHasColumnsReorderedSpy = jest.spyOn(SharedService.prototype, 'hasColumnsReordered', 'set');
+    const sharedVisibleColumnsSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+    const newVisibleColumns = [{ id: 'lastName', field: 'lastName' }, { id: 'fristName', field: 'fristName' }];
+
+    fixture.detectChanges();
+    component.grid.onColumnsReordered.notify({ impactedColumns: newVisibleColumns });
+
+    expect(sharedHasColumnsReorderedSpy).toHaveBeenCalledWith(true);
+    expect(sharedVisibleColumnsSpy).toHaveBeenCalledWith(newVisibleColumns);
   });
 });

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -659,6 +659,12 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
           }
         }
       });
+
+      // when column are reordered, we need to update the visibleColumn array
+      this._eventHandler.subscribe(grid.onColumnsReordered, (e: any, args: { impactedColumns: Column[]; grid: any; }) => {
+        this.sharedService.hasColumnsReordered = true;
+        this.sharedService.visibleColumns = args.impactedColumns;
+      });
     }
 
     // does the user have a colspan callback?

--- a/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
@@ -348,8 +348,8 @@ export class HeaderMenuExtension implements Extension {
           this.sharedService.frozenVisibleColumnId = args.column.id;
 
           // to freeze columns, we need to take only the visible columns and we also need to use setColumns() when some of them are hidden
-          // to make sure that we only use the visible columns, not doing this would show back some of the hidden columns
-          if (Array.isArray(visibleColumns) && Array.isArray(this.sharedService.allColumns) && visibleColumns.length !== this.sharedService.allColumns.length) {
+          // to make sure that we only use the visible columns, not doing this will have the undesired effect of showing back some of the hidden columns
+          if (this.sharedService.hasColumnsReordered || (Array.isArray(this.sharedService.allColumns) && visibleColumns.length !== this.sharedService.allColumns.length)) {
             this.sharedService.grid.setColumns(visibleColumns);
           }
           break;

--- a/src/app/modules/angular-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
@@ -48,6 +48,7 @@ const gridStub = {
   invalidate: jest.fn(),
   onColumnsResized: new Slick.Event(),
   onColumnsReordered: new Slick.Event(),
+  onRendered: new Slick.Event(),
   onSetOptions: new Slick.Event(),
   onSort: new Slick.Event(),
   render: jest.fn(),
@@ -143,7 +144,7 @@ describe('GroupingAndColspanService', () => {
   });
 
   it('should not call the "renderPreHeaderRowGroupingTitles" when there are no grid options', () => {
-    gridStub.getOptions = undefined;
+    (gridStub as any).getOptions = undefined;
     const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
     service.init(gridStub, dataViewStub);
     expect(spy).not.toHaveBeenCalled();
@@ -166,7 +167,7 @@ describe('GroupingAndColspanService', () => {
 
     it('should call the "renderPreHeaderRowGroupingTitles" on initial load even when there are no column definitions', () => {
       const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
-      gridStub.getColumns = undefined;
+      (gridStub as any).getColumns = undefined;
 
       service.init(gridStub, dataViewStub);
       jest.runAllTimers(); // fast-forward timer
@@ -181,6 +182,18 @@ describe('GroupingAndColspanService', () => {
 
       service.init(gridStub, dataViewStub);
       gridStub.onSort.notify({ impactedColumns: mockColumns }, new Slick.EventData(), gridStub);
+      jest.runAllTimers(); // fast-forward timer
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 50);
+    });
+
+    it('should call the "renderPreHeaderRowGroupingTitles" after triggering a grid "onRendered"', () => {
+      const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
+
+      service.init(gridStub, dataViewStub);
+      gridStub.onRendered.notify({ startRow: 0, endRow: 10, grid: gridStub }, new Slick.EventData(), gridStub);
       jest.runAllTimers(); // fast-forward timer
 
       expect(spy).toHaveBeenCalledTimes(2);

--- a/src/app/modules/angular-slickgrid/services/__tests__/shared.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/shared.service.spec.ts
@@ -207,6 +207,16 @@ describe('Shared Service', () => {
     expect(service.frozenVisibleColumnId).toEqual('field1');
   });
 
+  it('should call "hasColumnsReordered" GETTER and expect a boolean value to be returned', () => {
+    const flag = service.hasColumnsReordered;
+    expect(flag).toEqual(false);
+  });
+
+  it('should call "hasColumnsReordered" GETTER and SETTER expect same value to be returned', () => {
+    service.hasColumnsReordered = true;
+    expect(service.hasColumnsReordered).toEqual(true);
+  });
+
   it('should call "visibleColumns" GETTER and return all columns', () => {
     const spy = jest.spyOn(service, 'visibleColumns', 'get').mockReturnValue(mockColumns);
 

--- a/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
+++ b/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
@@ -48,6 +48,7 @@ export class GroupingAndColspanService {
       if (this._gridOptions.createPreHeaderPanel) {
         // on all following events, call the
         this._eventHandler.subscribe(grid.onSort, () => this.renderPreHeaderRowGroupingTitles());
+        this._eventHandler.subscribe(grid.onRendered, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(grid.onColumnsResized, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(grid.onColumnsReordered, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(dataView.onRowCountChanged, () => this.renderPreHeaderRowGroupingTitles());

--- a/src/app/modules/angular-slickgrid/services/shared.service.ts
+++ b/src/app/modules/angular-slickgrid/services/shared.service.ts
@@ -8,6 +8,7 @@ export class SharedService {
   private _groupItemMetadataProvider: any;
   private _grid: any;
   private _gridOptions!: GridOption;
+  private _hasColumnsReordered = false;
   private _currentPagination: CurrentPagination | undefined;
   private _hideHeaderRowAfterPageLoad = false;
   private _visibleColumns: Column[] = [];
@@ -58,6 +59,15 @@ export class SharedService {
   /** Getter to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward */
   set frozenVisibleColumnId(columnId: string | number | undefined) {
     this._frozenVisibleColumnId = columnId;
+  }
+
+  /** Setter to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward */
+  get hasColumnsReordered(): boolean {
+    return this._hasColumnsReordered;
+  }
+  /** Getter to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward */
+  set hasColumnsReordered(isColumnReordered: boolean) {
+    this._hasColumnsReordered = isColumnReordered;
   }
 
   /** Getter for SlickGrid Grid object */


### PR DESCRIPTION
- the steps to reproduce the issue was to create a grid with `frozenColumn` in the grid options, then change column position (cols reordering) and finally open header menu and freeze any of the column and the bug was that it was going back to original positions while it should keep new positions and just add new freeze column

![XMqeZnN](https://i.imgur.com/XMqeZnN.gif)