### PR TITLE
feat(filters): display operator into input text filter from Grid Presets

### DIFF
--- a/src/app/modules/angular-slickgrid/filters/__tests__/inputFilter.spec.ts
+++ b/src/app/modules/angular-slickgrid/filters/__tests__/inputFilter.spec.ts
@@ -23,7 +23,7 @@ describe('InputFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: InputFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: any;
   let mockColumn: Column;
 
   beforeEach(() => {
@@ -47,7 +47,7 @@ describe('InputFilter', () => {
   });
 
   it('should throw an error when trying to call init without any arguments', () => {
-    expect(() => filter.init(null)).toThrowError('[Angular-SlickGrid] A filter must always have an "init()" with valid arguments.');
+    expect(() => filter.init(null as any)).toThrowError('[Angular-SlickGrid] A filter must always have an "init()" with valid arguments.');
   });
 
   it('should initialize the filter', () => {
@@ -61,101 +61,143 @@ describe('InputFilter', () => {
 
   it('should have a placeholder when defined in its column definition', () => {
     const testValue = 'test placeholder';
-    mockColumn.filter.placeholder = testValue;
+    mockColumn.filter!.placeholder = testValue;
 
     filter.init(filterArguments);
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+    const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
     expect(filterElm.placeholder).toBe(testValue);
   });
 
-  it('should call "setValues" and expect that value to be in the callback when triggered', () => {
-    const spyCallback = jest.spyOn(filterArguments, 'callback');
+  describe('setValues method', () => {
+    it('should call "setValues" and expect that value to be in the callback when triggered', () => {
+      const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments);
-    filter.setValues('abc');
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+      filter.init(filterArguments);
+      filter.setValues('abc');
+      const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
-    filterElm.focus();
-    filterElm.dispatchEvent(new (window.window as any).Event('input', { keyCode: 97, bubbles: true, cancelable: true }));
-    const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
+      filterElm.focus();
+      filterElm.dispatchEvent(new (window.window as any).Event('input', { keyCode: 97, bubbles: true, cancelable: true }));
+      const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
-    expect(filterFilledElms.length).toBe(1);
-    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '', searchTerms: ['abc'], shouldTriggerQuery: true });
-  });
+      expect(filterFilledElms.length).toBe(1);
+      expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '', searchTerms: ['abc'], shouldTriggerQuery: true });
+    });
 
-  it('should call "setValues" and expect that value to be in the callback when triggered by ENTER key', () => {
-    const spyCallback = jest.spyOn(filterArguments, 'callback');
+    it('should call "setValues" and expect that value to be in the callback when triggered by ENTER key', () => {
+      const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments);
-    filter.setValues('abc');
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+      filter.init(filterArguments);
+      filter.setValues('abc');
+      const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
-    filterElm.focus();
-    const event = new (window.window as any).Event('keyup', { bubbles: true, cancelable: true });
-    event.key = 'Enter';
-    filterElm.dispatchEvent(event);
-    const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
+      filterElm.focus();
+      const event = new (window.window as any).Event('keyup', { bubbles: true, cancelable: true });
+      event.key = 'Enter';
+      filterElm.dispatchEvent(event);
+      const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
-    expect(filterFilledElms.length).toBe(1);
-    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '', searchTerms: ['abc'], shouldTriggerQuery: true });
-  });
+      expect(filterFilledElms.length).toBe(1);
+      expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '', searchTerms: ['abc'], shouldTriggerQuery: true });
+    });
 
-  it('should call "setValues" and expect that value NOT to be in the callback when triggered by a keyup event that is NOT the ENTER key', () => {
-    const spyCallback = jest.spyOn(filterArguments, 'callback');
+    it('should call "setValues" and expect that value NOT to be in the callback when triggered by a keyup event that is NOT the ENTER key', () => {
+      const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments);
-    filter.setValues('abc');
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+      filter.init(filterArguments);
+      filter.setValues('abc');
+      const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
-    filterElm.focus();
-    const event = new (window.window as any).Event('keyup', { bubbles: true, cancelable: true });
-    event.key = 'a';
-    filterElm.dispatchEvent(event);
-    const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
+      filterElm.focus();
+      const event = new (window.window as any).Event('keyup', { bubbles: true, cancelable: true });
+      event.key = 'a';
+      filterElm.dispatchEvent(event);
+      const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
-    expect(filterFilledElms.length).toBe(0);
-    expect(spyCallback).not.toHaveBeenCalled();
-  });
+      expect(filterFilledElms.length).toBe(0);
+      expect(spyCallback).not.toHaveBeenCalled();
+    });
 
-  it('should call "setValues" an operator and with extra spaces at the beginning of the searchTerms and trim value when "enableFilterTrimWhiteSpace" is enabled in grid options', () => {
-    gridOptionMock.enableFilterTrimWhiteSpace = true;
-    const spyCallback = jest.spyOn(filterArguments, 'callback');
+    it('should call "setValues" an operator and with extra spaces at the beginning of the searchTerms and trim value when "enableFilterTrimWhiteSpace" is enabled in grid options', () => {
+      gridOptionMock.enableFilterTrimWhiteSpace = true;
+      const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments);
-    filter.setValues('    abc ', 'EQ');
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+      filter.init(filterArguments);
+      filter.setValues('    abc ', 'EQ');
+      const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
-    filterElm.focus();
-    filterElm.dispatchEvent(new (window.window as any).Event('input', { keyCode: 97, bubbles: true, cancelable: true }));
-    const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
+      filterElm.focus();
+      filterElm.dispatchEvent(new (window.window as any).Event('input', { keyCode: 97, bubbles: true, cancelable: true }));
+      const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
-    expect(filterFilledElms.length).toBe(1);
-    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: 'EQ', searchTerms: ['abc'], shouldTriggerQuery: true });
-  });
+      expect(filterFilledElms.length).toBe(1);
+      expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: 'EQ', searchTerms: ['abc'], shouldTriggerQuery: true });
+    });
 
-  it('should call "setValues" with extra spaces at the beginning of the searchTerms and trim value when "enableTrimWhiteSpace" is enabled in the column filter', () => {
-    gridOptionMock.enableFilterTrimWhiteSpace = false;
-    mockColumn.filter.enableTrimWhiteSpace = true;
-    const spyCallback = jest.spyOn(filterArguments, 'callback');
+    it('should call "setValues" with extra spaces at the beginning of the searchTerms and trim value when "enableTrimWhiteSpace" is enabled in the column filter', () => {
+      gridOptionMock.enableFilterTrimWhiteSpace = false;
+      mockColumn.filter!.enableTrimWhiteSpace = true;
+      const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments);
-    filter.setValues('    abc ');
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+      filter.init(filterArguments);
+      filter.setValues('    abc ');
+      const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
-    filterElm.focus();
-    filterElm.dispatchEvent(new (window.window as any).Event('input', { keyCode: 97, bubbles: true, cancelable: true }));
-    const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
+      filterElm.focus();
+      filterElm.dispatchEvent(new (window.window as any).Event('input', { keyCode: 97, bubbles: true, cancelable: true }));
+      const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
-    expect(filterFilledElms.length).toBe(1);
-    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '', searchTerms: ['abc'], shouldTriggerQuery: true });
+      expect(filterFilledElms.length).toBe(1);
+      expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '', searchTerms: ['abc'], shouldTriggerQuery: true });
+    });
+
+    it('should call "setValues" and include an operator and expect the operator to show up in the output search string shown in the filter input text value', () => {
+      filter.init(filterArguments);
+
+      filter.setValues('abc', '<>');
+      expect(filter.getValue()).toBe('<>abc');
+
+      filter.setValues('abc', '!=');
+      expect(filter.getValue()).toBe('!=abc');
+
+      filter.setValues('abc', '=');
+      expect(filter.getValue()).toBe('=abc');
+
+      filter.setValues('abc', '==');
+      expect(filter.getValue()).toBe('==abc');
+
+      filter.setValues(123, '<');
+      expect(filter.getValue()).toBe('<123');
+
+      filter.setValues(123, '<=');
+      expect(filter.getValue()).toBe('<=123');
+
+      filter.setValues(123, '>');
+      expect(filter.getValue()).toBe('>123');
+
+      filter.setValues(123, '>=');
+      expect(filter.getValue()).toBe('>=123');
+
+      filter.setValues('abc', 'EndsWith');
+      expect(filter.getValue()).toBe('*abc');
+
+      filter.setValues('abc', '*z');
+      expect(filter.getValue()).toBe('*abc');
+
+      filter.setValues('abc', 'StartsWith');
+      expect(filter.getValue()).toBe('abc*');
+
+      filter.setValues('abc', 'a*');
+      expect(filter.getValue()).toBe('abc*');
+    });
   });
 
   it('should trigger the callback method when user types something in the input', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filter.init(filterArguments);
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+    const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
     filterElm.focus();
     filterElm.value = 'a';
@@ -168,7 +210,7 @@ describe('InputFilter', () => {
     filterArguments.searchTerms = ['xyz'];
 
     filter.init(filterArguments);
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+    const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
 
     expect(filterElm.value).toBe('xyz');
   });
@@ -177,7 +219,7 @@ describe('InputFilter', () => {
     filterArguments.searchTerms = [''];
 
     filter.init(filterArguments);
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+    const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
     expect(filterElm.value).toBe('');
@@ -190,7 +232,7 @@ describe('InputFilter', () => {
 
     filter.init(filterArguments);
     filter.clear();
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+    const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
     expect(filterElm.value).toBe('');
@@ -204,7 +246,7 @@ describe('InputFilter', () => {
 
     filter.init(filterArguments);
     filter.clear(false);
-    const filterElm = divContainer.querySelector<HTMLInputElement>('input.filter-duration');
+    const filterElm = divContainer.querySelector('input.filter-duration') as HTMLInputElement;
     const filterFilledElms = divContainer.querySelectorAll<HTMLInputElement>('input.filter-duration.filled');
 
 

--- a/src/app/modules/angular-slickgrid/services/filter.service.ts
+++ b/src/app/modules/angular-slickgrid/services/filter.service.ts
@@ -925,7 +925,7 @@ export class FilterService {
         // when hiding/showing (with Column Picker or Grid Menu), it will try to re-create yet again the filters (since SlickGrid does a re-render)
         // we need to also set again the values in the DOM elements if the values were set by a searchTerm(s)
         if (searchTerms && newFilter.setValues) {
-          newFilter.setValues(searchTerms);
+          newFilter.setValues(searchTerms, operator);
         }
       }
     }


### PR DESCRIPTION
- a use case that we have with the text InputFilter is that if have a filter that includes an operator inside the search text (e.g.: ">=55") and we save the Grid State in Local Storage or anything else and then we reload them as Grid Presets, the operator won't be showing up (it would only show "55" while keeping the Operator hidden but still in play) that is because the FilterService is doing the split (this is an Operator and these are the SearchTerm) and the Grid State only keeps the split, so in that case this PR adds an extra step that if we're using the `setValues()` method, then we're probably using a Grid Preset or an UpdateFilters and we should display the operator as part of the final displayed search string inside the input value