### PR TITLE
feat(state): add Pinning (frozen) to Grid State & Presets

### DIFF
--- a/src/app/examples/grid-state.component.ts
+++ b/src/app/examples/grid-state.component.ts
@@ -157,7 +157,11 @@ export class GridStateComponent implements OnInit, OnDestroy {
         hideForceFitButton: true
       },
       gridMenu: {
-        hideForceFitButton: true
+        hideForceFitButton: true,
+        hideClearFrozenColumnsCommand: false,
+      },
+      headerMenu: {
+        hideFreezeColumnsCommand: false,
       },
       enablePagination: true,
       pagination: {

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid-constructor.spec.ts
@@ -21,7 +21,7 @@ import {
   SortService,
   TreeDataService,
 } from '../../services';
-import { Column, CurrentFilter, CurrentSorter, GraphqlPaginatedResult, GraphqlServiceApi, GraphqlServiceOption, GridOption, GridState, GridStateChange, GridStateType, Pagination, ServicePagination } from '../../models';
+import { Column, CurrentFilter, CurrentPinning, CurrentSorter, GraphqlPaginatedResult, GraphqlServiceApi, GraphqlServiceOption, GridOption, GridState, GridStateChange, GridStateType, Pagination, ServicePagination } from '../../models';
 import { Filters } from '../../filters';
 import { Editors } from '../../editors';
 import * as utilities from '../../services/backend-utilities';
@@ -845,6 +845,15 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         component.gridOptions.presets = undefined;
 
         expect(backendSpy).toHaveBeenCalledWith(mockColumnFilter, false);
+      });
+
+      it('should override frozen grid options when "pinning" is defined in the "presets" property', () => {
+        const pinningMock = { frozenBottom: false, frozenColumn: -1, frozenRow: -1 } as CurrentPinning;
+
+        component.gridOptions.presets = { pinning: pinningMock };
+        component.ngAfterViewInit();
+
+        expect(component.gridOptions).toEqual({ ...component.gridOptions, ...pinningMock });
       });
 
       it('should call the "updateFilters" method when filters are defined in the "presets" property', () => {

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -849,6 +849,11 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
     this.sharedService.visibleColumns = this._columnDefinitions;
     this.extensionService.createExtensionsBeforeGridCreation(this._columnDefinitions, this.gridOptions);
 
+    // if user entered some Pinning/Frozen "presets", we need to apply them in the grid options
+    if (this.gridOptions.presets?.pinning) {
+      this.gridOptions = { ...this.gridOptions, ...this.gridOptions.presets.pinning };
+    }
+
     // build SlickGrid Grid, also user might optionally pass a custom dataview (e.g. remote model)
     this.grid = new Slick.Grid(`#${this.gridId}`, this.customDataView || this.dataView, this._columnDefinitions, this.gridOptions);
 

--- a/src/app/modules/angular-slickgrid/constants.ts
+++ b/src/app/modules/angular-slickgrid/constants.ts
@@ -8,7 +8,7 @@ export class Constants {
     TEXT_CLEAR_ALL_FILTERS: 'Clear all Filters',
     TEXT_CLEAR_ALL_GROUPING: 'Clear all Grouping',
     TEXT_CLEAR_ALL_SORTING: 'Clear all Sorting',
-    TEXT_CLEAR_FROZEN_COLUMNS: 'Clear Frozen Columns',
+    TEXT_CLEAR_PINNING: 'Unfreeze Columns/Rows',
     TEXT_COLLAPSE_ALL_GROUPS: 'Collapse all Groups',
     TEXT_CONTAINS: 'Contains',
     TEXT_COLUMNS: 'Columns',

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
@@ -5,7 +5,7 @@ import { GridOption } from '../../models/gridOption.interface';
 import { GridMenuExtension } from '../gridMenuExtension';
 import { ExtensionUtility } from '../extensionUtility';
 import { SharedService } from '../../services/shared.service';
-import { Column, DelimiterType, FileType } from '../../models';
+import { BackendServiceApi, Column, DelimiterType, FileType, GridMenu } from '../../models';
 import { ExcelExportService, ExportService, FilterService, SortService } from '../../services';
 
 declare const Slick: any;
@@ -138,7 +138,7 @@ describe('gridMenuExtension', () => {
         TITLE: 'Titre',
         CLEAR_ALL_FILTERS: 'Supprimer tous les filtres',
         CLEAR_ALL_SORTING: 'Supprimer tous les tris',
-        CLEAR_FROZEN_COLUMNS: 'Libérer les colonnes gelées',
+        CLEAR_PINNING: 'Dégeler les colonnes/rangées',
         EXPORT_TO_CSV: 'Exporter en format CSV',
         EXPORT_TO_EXCEL: 'Exporter vers Excel',
         EXPORT_TO_TAB_DELIMITED: 'Exporter en format texte (délimité par tabulation)',
@@ -176,7 +176,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should register the addon', () => {
-        const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onExtensionRegistered');
+        const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onExtensionRegistered');
 
         const instance = extension.register();
         const addonInstance = extension.getAddonInstance();
@@ -189,11 +189,11 @@ describe('gridMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onColumnsChanged" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onColumnsChanged');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onBeforeMenuShow');
-        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onMenuClose');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onBeforeMenuShow');
+        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
         const visibleColsSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
         const readjustSpy = jest.spyOn(extensionUtility, 'readjustFrozenColumnIndexWhenNeeded');
 
@@ -216,29 +216,29 @@ describe('gridMenuExtension', () => {
 
       it(`should call internal event handler subscribe and expect the "onColumnsChanged" option to be called
     and it should override "visibleColumns" when array passed as arguments is bigger than previous visible columns`, () => {
-          const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-          const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onColumnsChanged');
-          const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onAfterMenuShow');
-          const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onBeforeMenuShow');
-          const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onMenuClose');
-          const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
-          const visibleColsSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+        const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
+        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onBeforeMenuShow');
+        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
+        const visibleColsSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
 
-          const instance = extension.register();
-          instance.onColumnsChanged.notify({ columns: columnsMock, grid: gridStub }, new Slick.EventData(), gridStub);
+        const instance = extension.register();
+        instance.onColumnsChanged.notify({ columns: columnsMock, grid: gridStub }, new Slick.EventData(), gridStub);
 
-          expect(handlerSpy).toHaveBeenCalledTimes(5);
-          expect(handlerSpy).toHaveBeenCalledWith(
-            { notify: expect.anything(), subscribe: expect.anything(), unsubscribe: expect.anything(), },
-            expect.anything()
-          );
-          expect(onColumnSpy).toHaveBeenCalledWith(expect.anything(), { columns: columnsMock, grid: gridStub });
-          expect(onAfterSpy).not.toHaveBeenCalled();
-          expect(onBeforeSpy).not.toHaveBeenCalled();
-          expect(onCloseSpy).not.toHaveBeenCalled();
-          expect(onCommandSpy).not.toHaveBeenCalled();
-          expect(visibleColsSpy).toHaveBeenCalledWith(columnsMock);
-        });
+        expect(handlerSpy).toHaveBeenCalledTimes(5);
+        expect(handlerSpy).toHaveBeenCalledWith(
+          { notify: expect.anything(), subscribe: expect.anything(), unsubscribe: expect.anything(), },
+          expect.anything()
+        );
+        expect(onColumnSpy).toHaveBeenCalledWith(expect.anything(), { columns: columnsMock, grid: gridStub });
+        expect(onAfterSpy).not.toHaveBeenCalled();
+        expect(onBeforeSpy).not.toHaveBeenCalled();
+        expect(onCloseSpy).not.toHaveBeenCalled();
+        expect(onCommandSpy).not.toHaveBeenCalled();
+        expect(visibleColsSpy).toHaveBeenCalledWith(columnsMock);
+      });
 
       it('should call internal "onColumnsChanged" event and expect "readjustFrozenColumnIndexWhenNeeded" method to be called when the grid is detected to be a frozen grid', () => {
         gridOptionsMock.frozenColumn = 0;
@@ -258,11 +258,11 @@ describe('gridMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onBeforeMenuShow" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onColumnsChanged');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onBeforeMenuShow');
-        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onMenuClose');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onBeforeMenuShow');
+        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onBeforeMenuShow.notify({ grid: gridStub, menu: {} }, new Slick.EventData(), gridStub);
@@ -281,11 +281,11 @@ describe('gridMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onAfterMenuShow" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onColumnsChanged');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onBeforeMenuShow');
-        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onMenuClose');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onBeforeMenuShow');
+        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onAfterMenuShow.notify({ grid: gridStub, menu: {} }, new Slick.EventData(), gridStub);
@@ -304,11 +304,11 @@ describe('gridMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onMenuClose" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onColumnsChanged');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onBeforeMenuShow');
-        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onMenuClose');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onBeforeMenuShow');
+        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onMenuClose.notify({ grid: gridStub, menu: {} }, new Slick.EventData(), gridStub);
@@ -327,11 +327,11 @@ describe('gridMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onCommand" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onColumnsChanged');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onBeforeMenuShow');
-        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onMenuClose');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onBeforeMenuShow');
+        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'help' }, new Slick.EventData(), gridStub);
@@ -350,8 +350,8 @@ describe('gridMenuExtension', () => {
 
       it('should call "autosizeColumns" method when the "onMenuClose" event was triggered and the columns are different', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onColumnsChanged');
-        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onMenuClose');
+        const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
+        const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
         const autoSizeSpy = jest.spyOn(gridStub, 'autosizeColumns');
 
         const instance = extension.register();
@@ -381,16 +381,16 @@ describe('gridMenuExtension', () => {
 
       it('should expect an empty "customItems" array when both Filter & Sort are disabled', () => {
         extension.register();
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([]);
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
       });
 
-      it('should expect menu related to "Clear Frozen Columns"', () => {
+      it('should expect menu related to "Unfreeze Columns/Rows"', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, gridMenu: { hideClearFrozenColumnsCommand: false, } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { iconCssClass: 'fa fa-times', title: 'Libérer les colonnes gelées', disabled: false, command: 'clear-frozen-columns', positionOrder: 49 },
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { iconCssClass: 'fa fa-times', title: 'Dégeler les colonnes/rangées', disabled: false, command: 'clear-pinning', positionOrder: 52 },
         ]);
       });
 
@@ -399,10 +399,10 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
           { iconCssClass: 'fa fa-filter text-danger', title: 'Supprimer tous les filtres', disabled: false, command: 'clear-filter', positionOrder: 50 },
-          { iconCssClass: 'fa fa-random', title: 'Basculer la ligne des filtres', disabled: false, command: 'toggle-filter', positionOrder: 52 },
-          { iconCssClass: 'fa fa-refresh', title: 'Rafraîchir les données', disabled: false, command: 'refresh-dataset', positionOrder: 56 }
+          { iconCssClass: 'fa fa-random', title: 'Basculer la ligne des filtres', disabled: false, command: 'toggle-filter', positionOrder: 53 },
+          { iconCssClass: 'fa fa-refresh', title: 'Rafraîchir les données', disabled: false, command: 'refresh-dataset', positionOrder: 57 }
         ]);
       });
 
@@ -411,7 +411,7 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
           { iconCssClass: 'fa fa-filter text-danger', title: 'Supprimer tous les filtres', disabled: false, command: 'clear-filter', positionOrder: 50 }
         ]);
       });
@@ -421,8 +421,8 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { iconCssClass: 'fa fa-random', title: 'Basculer la ligne des filtres', disabled: false, command: 'toggle-filter', positionOrder: 52 },
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { iconCssClass: 'fa fa-random', title: 'Basculer la ligne des filtres', disabled: false, command: 'toggle-filter', positionOrder: 53 },
         ]);
       });
 
@@ -431,8 +431,8 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { iconCssClass: 'fa fa-refresh', title: 'Rafraîchir les données', disabled: false, command: 'refresh-dataset', positionOrder: 56 }
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { iconCssClass: 'fa fa-refresh', title: 'Rafraîchir les données', disabled: false, command: 'refresh-dataset', positionOrder: 57 }
         ]);
       });
 
@@ -441,8 +441,8 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { iconCssClass: 'fa fa-random', title: 'Basculer la ligne de pré-en-tête', disabled: false, command: 'toggle-preheader', positionOrder: 52 }
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { iconCssClass: 'fa fa-random', title: 'Basculer la ligne de pré-en-tête', disabled: false, command: 'toggle-preheader', positionOrder: 53 }
         ]);
       });
 
@@ -450,7 +450,7 @@ describe('gridMenuExtension', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, showPreHeaderPanel: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideTogglePreHeaderCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([]);
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
       });
 
       it('should have the "clear-sorting" menu command when "enableSorting" is set', () => {
@@ -458,7 +458,7 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
           { iconCssClass: 'fa fa-unsorted text-danger', title: 'Supprimer tous les tris', disabled: false, command: 'clear-sorting', positionOrder: 51 }
         ]);
       });
@@ -467,7 +467,7 @@ describe('gridMenuExtension', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableSorting: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideClearAllSortingCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([]);
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
       });
 
       it('should have the "export-csv" menu command when "enableExport" is set', () => {
@@ -475,8 +475,8 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { iconCssClass: 'fa fa-download', title: 'Exporter en format CSV', disabled: false, command: 'export-csv', positionOrder: 53 }
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { iconCssClass: 'fa fa-download', title: 'Exporter en format CSV', disabled: false, command: 'export-csv', positionOrder: 54 }
         ]);
       });
 
@@ -484,7 +484,7 @@ describe('gridMenuExtension', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([]);
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
       });
 
       it('should have the "export-excel" menu command when "enableExport" is set', () => {
@@ -492,8 +492,8 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { iconCssClass: 'fa fa-file-excel-o text-success', title: 'Exporter vers Excel', disabled: false, command: 'export-excel', positionOrder: 54 }
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { iconCssClass: 'fa fa-file-excel-o text-success', title: 'Exporter vers Excel', disabled: false, command: 'export-excel', positionOrder: 55 }
         ]);
       });
 
@@ -502,8 +502,8 @@ describe('gridMenuExtension', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { iconCssClass: 'fa fa-download', title: 'Exporter en format texte (délimité par tabulation)', disabled: false, command: 'export-text-delimited', positionOrder: 55 }
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { iconCssClass: 'fa fa-download', title: 'Exporter en format texte (délimité par tabulation)', disabled: false, command: 'export-text-delimited', positionOrder: 56 }
         ]);
       });
 
@@ -511,7 +511,7 @@ describe('gridMenuExtension', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([]);
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
       });
     });
 
@@ -556,9 +556,9 @@ describe('gridMenuExtension', () => {
 
       it('should have user grid menu custom items', () => {
         extension.register();
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { command: 'export-csv', disabled: false, iconCssClass: 'fa fa-download', positionOrder: 53, title: 'Exporter en format CSV' },
-          // { command: 'export-excel', disabled: false, iconCssClass: 'fa fa-file-excel-o text-success', positionOrder: 54, title: 'Exporter vers Excel' },
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { command: 'export-csv', disabled: false, iconCssClass: 'fa fa-download', positionOrder: 54, title: 'Exporter en format CSV' },
+          // { command: 'export-excel', disabled: false, iconCssClass: 'fa fa-file-excel-o text-success', positionOrder: 55, title: 'Exporter vers Excel' },
           { command: 'help', disabled: false, iconCssClass: 'fa fa-question-circle', positionOrder: 99, title: 'Aide', titleKey: 'HELP' },
         ]);
       });
@@ -566,8 +566,8 @@ describe('gridMenuExtension', () => {
       it('should have same user grid menu custom items even when grid menu extension is registered multiple times', () => {
         extension.register();
         extension.register();
-        expect(SharedService.prototype.gridOptions.gridMenu.customItems).toEqual([
-          { command: 'export-csv', disabled: false, iconCssClass: 'fa fa-download', positionOrder: 53, title: 'Exporter en format CSV' },
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([
+          { command: 'export-csv', disabled: false, iconCssClass: 'fa fa-download', positionOrder: 54, title: 'Exporter en format CSV' },
           { command: 'help', disabled: false, iconCssClass: 'fa fa-question-circle', positionOrder: 99, title: 'Aide', titleKey: 'HELP' },
         ]);
       });
@@ -591,11 +591,11 @@ describe('gridMenuExtension', () => {
           data: { users: { nodes: [] }, pageInfo: { hasNextPage: true }, totalCount: 0 },
           metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 }
         };
-        const preSpy = jest.spyOn(gridOptionsMock.backendServiceApi, 'preProcess');
-        const postSpy = jest.spyOn(gridOptionsMock.backendServiceApi, 'postProcess');
+        const preSpy = jest.spyOn(gridOptionsMock.backendServiceApi as BackendServiceApi, 'preProcess');
+        const postSpy = jest.spyOn(gridOptionsMock.backendServiceApi as BackendServiceApi, 'postProcess');
         const promise = new Promise((resolve) => setTimeout(() => resolve(processResult), 1));
-        const processSpy = jest.spyOn(gridOptionsMock.backendServiceApi, 'process').mockReturnValue(promise);
-        jest.spyOn(gridOptionsMock.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+        const processSpy = jest.spyOn(gridOptionsMock.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(promise);
+        jest.spyOn((gridOptionsMock.backendServiceApi as BackendServiceApi).service, 'buildQuery').mockReturnValue(query);
         extension.refreshBackendDataset({ enableAddRow: true });
         expect(preSpy).toHaveBeenCalled();
         expect(processSpy).toHaveBeenCalled();
@@ -613,25 +613,25 @@ describe('gridMenuExtension', () => {
         mockGridMenuAddon.onCommand = new Slick.Event();
       });
 
-      it('should call "clearFrozenColumns" when the command triggered is "clear-frozen-columns"', () => {
+      it('should call "clearFrozenColumns" when the command triggered is "clear-pinning"', () => {
         const setOptionsSpy = jest.spyOn(gridStub, 'setOptions');
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
         jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
         jest.spyOn(SharedService.prototype, 'visibleColumns', 'get').mockReturnValue(columnsMock.slice(0, 1));
 
         const instance = extension.register();
-        instance.onCommand.notify({ grid: gridStub, command: 'clear-frozen-columns' }, new Slick.EventData(), gridStub);
+        instance.onCommand.notify({ grid: gridStub, command: 'clear-pinning' }, new Slick.EventData(), gridStub);
 
         expect(onCommandSpy).toHaveBeenCalled();
         expect(setColumnsSpy).toHaveBeenCalled();
-        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: -1, enableMouseWheelScrollHandler: false });
+        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: -1, frozenRow: -1, frozenBottom: false, enableMouseWheelScrollHandler: false });
       });
 
       it('should call "clearFilters" and dataview refresh when the command triggered is "clear-filter"', () => {
         const filterSpy = jest.spyOn(filterServiceStub, 'clearFilters');
         const refreshSpy = jest.spyOn(SharedService.prototype.dataView, 'refresh');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'clear-filter' }, new Slick.EventData(), gridStub);
@@ -644,7 +644,7 @@ describe('gridMenuExtension', () => {
       it('should call "clearSorting" and dataview refresh when the command triggered is "clear-sorting"', () => {
         const sortSpy = jest.spyOn(sortServiceStub, 'clearSorting');
         const refreshSpy = jest.spyOn(SharedService.prototype.dataView, 'refresh');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'clear-sorting' }, new Slick.EventData(), gridStub);
@@ -656,7 +656,7 @@ describe('gridMenuExtension', () => {
 
       it('should call "exportToExcel" when the command triggered is "export-excel"', () => {
         const excelExportSpy = jest.spyOn(excelExportServiceStub, 'exportToExcel');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'export-excel' }, new Slick.EventData(), gridStub);
@@ -667,7 +667,7 @@ describe('gridMenuExtension', () => {
 
       it('should call "exportToFile" with CSV set when the command triggered is "export-csv"', () => {
         const exportSpy = jest.spyOn(exportServiceStub, 'exportToFile');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'export-csv' }, new Slick.EventData(), gridStub);
@@ -681,7 +681,7 @@ describe('gridMenuExtension', () => {
 
       it('should call "exportToFile" with CSV set when the command triggered is "export-text-delimited"', () => {
         const exportSpy = jest.spyOn(exportServiceStub, 'exportToFile');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'export-text-delimited' }, new Slick.EventData(), gridStub);
@@ -696,7 +696,7 @@ describe('gridMenuExtension', () => {
       it('should call the grid "setHeaderRowVisibility" method when the command triggered is "toggle-filter"', () => {
         gridOptionsMock.showHeaderRow = false;
         const gridSpy = jest.spyOn(SharedService.prototype.grid, 'setHeaderRowVisibility');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
         const setColumnSpy = jest.spyOn(SharedService.prototype.grid, 'setColumns');
 
         const instance = extension.register();
@@ -717,7 +717,7 @@ describe('gridMenuExtension', () => {
       it('should call the grid "setTopPanelVisibility" method when the command triggered is "toggle-toppanel"', () => {
         gridOptionsMock.showTopPanel = false;
         const gridSpy = jest.spyOn(SharedService.prototype.grid, 'setTopPanelVisibility');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'toggle-toppanel' }, new Slick.EventData(), gridStub);
@@ -735,7 +735,7 @@ describe('gridMenuExtension', () => {
       it('should call the grid "setPreHeaderPanelVisibility" method when the command triggered is "toggle-preheader"', () => {
         gridOptionsMock.showPreHeaderPanel = false;
         const gridSpy = jest.spyOn(SharedService.prototype.grid, 'setPreHeaderPanelVisibility');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'toggle-preheader' }, new Slick.EventData(), gridStub);
@@ -752,7 +752,7 @@ describe('gridMenuExtension', () => {
 
       it('should call "refreshBackendDataset" method when the command triggered is "refresh-dataset"', () => {
         const refreshSpy = jest.spyOn(extension, 'refreshBackendDataset');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'refresh-dataset' }, new Slick.EventData(), gridStub);
@@ -774,9 +774,9 @@ describe('gridMenuExtension', () => {
         expect(utilitySpy).toHaveBeenCalled();
         expect(translateSpy).toHaveBeenCalled();
         expect(updateColsSpy).toHaveBeenCalledWith(SharedService.prototype.gridOptions.gridMenu);
-        expect(SharedService.prototype.gridOptions.gridMenu.columnTitle).toBe('Colonnes');
-        expect(SharedService.prototype.gridOptions.gridMenu.forceFitTitle).toBe('Ajustement forcé des colonnes');
-        expect(SharedService.prototype.gridOptions.gridMenu.syncResizeTitle).toBe('Redimension synchrone');
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).columnTitle).toBe('Colonnes');
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).forceFitTitle).toBe('Ajustement forcé des colonnes');
+        expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).syncResizeTitle).toBe('Redimension synchrone');
         expect(columnsMock).toEqual([
           { id: 'field1', field: 'field1', width: 100, name: 'Titre', nameKey: 'TITLE' },
           { id: 'field2', field: 'field2', width: 75 }
@@ -789,7 +789,7 @@ describe('gridMenuExtension', () => {
         const instance = extension.register();
 
         const showSpy = jest.spyOn(instance, 'showGridMenu');
-        extension.showGridMenu(null);
+        extension.showGridMenu(null as any);
 
         expect(showSpy).toHaveBeenCalled();
       });
@@ -798,7 +798,7 @@ describe('gridMenuExtension', () => {
 
   describe('without ngx-translate', () => {
     beforeEach(() => {
-      translate = null;
+      translate = null as any;
       extension = new GridMenuExtension({} as ExcelExportService, {} as ExportService, {} as ExtensionUtility, {} as FilterService, { gridOptions: { enableTranslate: true } } as SharedService, {} as SortService, translate);
     });
 

--- a/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
@@ -216,17 +216,17 @@ export class GridMenuExtension implements Extension {
     const gridOptions = this.sharedService.gridOptions;
     const translationPrefix = getTranslationPrefix(gridOptions);
 
-    // show grid menu: Clear Frozen Columns
+    // show grid menu: Unfreeze Columns/Rows
     if (this.sharedService.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideClearFrozenColumnsCommand) {
-      const commandName = 'clear-frozen-columns';
+      const commandName = 'clear-pinning';
       if (!originalCustomItems.find(item => item !== 'divider' && item.hasOwnProperty('command') && item.command === commandName)) {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconClearFrozenColumnsCommand || 'fa fa-times',
-            title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}CLEAR_FROZEN_COLUMNS`) : this._locales && this._locales.TEXT_CLEAR_FROZEN_COLUMNS,
+            title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}CLEAR_PINNING`) : this._locales && this._locales.TEXT_CLEAR_PINNING,
             disabled: false,
             command: commandName,
-            positionOrder: 49
+            positionOrder: 52
           }
         );
       }
@@ -259,7 +259,7 @@ export class GridMenuExtension implements Extension {
               title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}TOGGLE_FILTER_ROW`) : this._locales && this._locales.TEXT_TOGGLE_FILTER_ROW,
               disabled: false,
               command: commandName,
-              positionOrder: 52
+              positionOrder: 53
             }
           );
         }
@@ -275,7 +275,7 @@ export class GridMenuExtension implements Extension {
               title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}REFRESH_DATASET`) : this._locales && this._locales.TEXT_REFRESH_DATASET,
               disabled: false,
               command: commandName,
-              positionOrder: 56
+              positionOrder: 57
             }
           );
         }
@@ -293,7 +293,7 @@ export class GridMenuExtension implements Extension {
               title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}TOGGLE_PRE_HEADER_ROW`) : this._locales && this._locales.TEXT_TOGGLE_PRE_HEADER_ROW,
               disabled: false,
               command: commandName,
-              positionOrder: 52
+              positionOrder: 53
             }
           );
         }
@@ -328,7 +328,7 @@ export class GridMenuExtension implements Extension {
             title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}EXPORT_TO_CSV`) : this._locales && this._locales.TEXT_EXPORT_TO_CSV,
             disabled: false,
             command: commandName,
-            positionOrder: 53
+            positionOrder: 54
           }
         );
       }
@@ -344,7 +344,7 @@ export class GridMenuExtension implements Extension {
             title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}EXPORT_TO_EXCEL`) : this._locales && this._locales.TEXT_EXPORT_TO_EXCEL,
             disabled: false,
             command: commandName,
-            positionOrder: 54
+            positionOrder: 55
           }
         );
       }
@@ -360,7 +360,7 @@ export class GridMenuExtension implements Extension {
             title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}EXPORT_TO_TAB_DELIMITED`) : this._locales && this._locales.TEXT_EXPORT_TO_TAB_DELIMITED,
             disabled: false,
             command: commandName,
-            positionOrder: 55
+            positionOrder: 56
           }
         );
       }
@@ -383,14 +383,24 @@ export class GridMenuExtension implements Extension {
   private executeGridMenuInternalCustomCommands(e: Event, args: GridMenuItem) {
     if (args && args.command) {
       switch (args.command) {
-        case 'clear-frozen-columns':
+        case 'clear-pinning':
           const visibleColumns = [...this.sharedService.visibleColumns];
-          this.sharedService.grid.setOptions({ frozenColumn: -1, enableMouseWheelScrollHandler: false });
+          const newGridOptions = { frozenColumn: -1, frozenRow: -1, frozenBottom: false, enableMouseWheelScrollHandler: false };
+          this.sharedService.grid.setOptions(newGridOptions);
+          this.sharedService.gridOptions.frozenColumn = newGridOptions.frozenColumn;
+          this.sharedService.gridOptions.frozenRow = newGridOptions.frozenRow;
+          this.sharedService.gridOptions.frozenBottom = newGridOptions.frozenBottom;
+          this.sharedService.gridOptions.enableMouseWheelScrollHandler = newGridOptions.enableMouseWheelScrollHandler;
 
           // SlickGrid seems to be somehow resetting the columns to their original positions,
           // so let's re-fix them to the position we kept as reference
           if (Array.isArray(visibleColumns)) {
             this.sharedService.grid.setColumns(visibleColumns);
+          }
+
+          // we also need to autosize columns if the option is enabled
+          if (this.sharedService.gridOptions.enableAutoSizeColumns) {
+            this.sharedService.grid.autosizeColumns();
           }
           break;
         case 'clear-filter':

--- a/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
@@ -344,13 +344,21 @@ export class HeaderMenuExtension implements Extension {
         case 'freeze-columns':
           const visibleColumns = [...this.sharedService.visibleColumns];
           const columnPosition = visibleColumns.findIndex((col) => col.id === args.column.id);
-          this.sharedService.grid.setOptions({ frozenColumn: columnPosition, enableMouseWheelScrollHandler: true } as GridOption);
+          const newGridOptions = { frozenColumn: columnPosition, enableMouseWheelScrollHandler: true };
+          this.sharedService.grid.setOptions(newGridOptions);
+          this.sharedService.gridOptions.frozenColumn = newGridOptions.frozenColumn;
+          this.sharedService.gridOptions.enableMouseWheelScrollHandler = newGridOptions.enableMouseWheelScrollHandler;
           this.sharedService.frozenVisibleColumnId = args.column.id;
 
           // to freeze columns, we need to take only the visible columns and we also need to use setColumns() when some of them are hidden
           // to make sure that we only use the visible columns, not doing this will have the undesired effect of showing back some of the hidden columns
           if (this.sharedService.hasColumnsReordered || (Array.isArray(this.sharedService.allColumns) && visibleColumns.length !== this.sharedService.allColumns.length)) {
             this.sharedService.grid.setColumns(visibleColumns);
+          }
+
+          // we also need to autosize columns if the option is enabled
+          if (this.sharedService.gridOptions.enableAutoSizeColumns) {
+            this.sharedService.grid.autosizeColumns();
           }
           break;
         case 'sort-asc':

--- a/src/app/modules/angular-slickgrid/models/currentPinning.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/currentPinning.interface.ts
@@ -1,0 +1,10 @@
+export interface CurrentPinning {
+  /** Defaults to false, do we want to freeze (pin) the bottom portion instead of the top */
+  frozenBottom?: boolean;
+
+  /** Number of column index(es) to freeze (pin) in the grid */
+  frozenColumn?: number;
+
+  /** Number of row index(es) to freeze (pin) in the grid */
+  frozenRow?: number;
+}

--- a/src/app/modules/angular-slickgrid/models/gridMenu.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridMenu.interface.ts
@@ -37,7 +37,7 @@ export interface GridMenu {
   /** Defaults to false, which will hide the "Clear all Sorting" command in the Grid Menu (Grid Option "enableSorting: true" has to be enabled) */
   hideClearAllSortingCommand?: boolean;
 
-  /** Defaults to true, which will hide the "Clear Frozen Columns" command in the Grid Menu */
+  /** Defaults to true, which will hide the "Unfreeze Columns/Rows" command in the Grid Menu */
   hideClearFrozenColumnsCommand?: boolean;
 
   /** Defaults to false, which will hide the "Export to CSV" command in the Grid Menu (Grid Option "enableExport: true" has to be enabled) */
@@ -73,7 +73,7 @@ export interface GridMenu {
   /** icon for the "Clear all Sorting" command */
   iconClearAllSortingCommand?: string;
 
-  /** icon for the "Clear Frozen Columns" command */
+  /** icon for the "Unfreeze Columns/Rows" command */
   iconClearFrozenColumnsCommand?: string;
 
   /** icon for the "Export to CSV" command */

--- a/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
@@ -333,10 +333,10 @@ export interface GridOption {
   /** Defaults to false, do we want to freeze (pin) the bottom portion instead of the top */
   frozenBottom?: boolean;
 
-  /** Number of column(s) to freeze (pin) in the grid */
+  /** Number of column index(es) to freeze (pin) in the grid */
   frozenColumn?: number;
 
-  /** Number of row(s) to freeze (pin) in the grid */
+  /** Number of row index(es) to freeze (pin) in the grid */
   frozenRow?: number;
 
   /** Defaults to false, which leads to have row with full width */

--- a/src/app/modules/angular-slickgrid/models/gridState.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridState.interface.ts
@@ -1,4 +1,4 @@
-import { CurrentColumn, CurrentFilter, CurrentPagination, CurrentRowSelection, CurrentSorter } from './index';
+import { CurrentColumn, CurrentFilter, CurrentPagination, CurrentPinning, CurrentRowSelection, CurrentSorter } from './index';
 
 export interface GridState {
   /** Columns (and their state: visibility/position) that are currently applied in the grid */
@@ -12,6 +12,9 @@ export interface GridState {
 
   /** Pagination (and it's state, pageNumber, pageSize) that are currently applied in the grid */
   pagination?: CurrentPagination | null;
+
+  /** Pinning (frozen) column & row position */
+  pinning?: CurrentPinning;
 
   /** Row Selections (by their dataContext IDs and/or grid row indexes) */
   rowSelection?: CurrentRowSelection | null;

--- a/src/app/modules/angular-slickgrid/models/gridStateChange.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridStateChange.interface.ts
@@ -1,10 +1,10 @@
-import { CurrentColumn, CurrentFilter, CurrentPagination, CurrentRowSelection, CurrentSorter, GridState, GridStateType } from './index';
+import { CurrentColumn, CurrentFilter, CurrentPagination, CurrentPinning, CurrentRowSelection, CurrentSorter, GridState, GridStateType } from './index';
 
 export interface GridStateChange {
   /** Last Grid State Change that was triggered (only 1 type of change at a time) */
   change?: {
     /** Grid State change, the values of the new change */
-    newValues: CurrentColumn[] | CurrentFilter[] | CurrentSorter[] | CurrentPagination | CurrentRowSelection;
+    newValues: CurrentColumn[] | CurrentFilter[] | CurrentSorter[] | CurrentPagination | CurrentPinning | CurrentRowSelection;
 
     /** The Grid State Type of change that was made (filter/sorter/...) */
     type: GridStateType;

--- a/src/app/modules/angular-slickgrid/models/gridStateType.enum.ts
+++ b/src/app/modules/angular-slickgrid/models/gridStateType.enum.ts
@@ -2,6 +2,7 @@ export enum GridStateType {
   columns = 'columns',
   filter = 'filter',
   pagination = 'pagination',
+  pinning = 'pinning',
   sorter = 'sorter',
   rowSelection = 'rowSelection',
 }

--- a/src/app/modules/angular-slickgrid/models/index.ts
+++ b/src/app/modules/angular-slickgrid/models/index.ts
@@ -28,6 +28,7 @@ export * from './contextMenu.interface';
 export * from './currentColumn.interface';
 export * from './currentFilter.interface';
 export * from './currentPagination.interface';
+export * from './currentPinning.interface';
 export * from './currentRowSelection.interface';
 export * from './currentSorter.interface';
 export * from './customFooterOption.interface';

--- a/src/app/modules/angular-slickgrid/models/locale.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/locale.interface.ts
@@ -17,8 +17,8 @@ export interface Locale {
   /** Text "Clear all Sorting" shown in Header Menu */
   TEXT_CLEAR_ALL_SORTING: string;
 
-  /** Text "Clear Frozen Columns" shown in Grid Menu */
-  TEXT_CLEAR_FROZEN_COLUMNS: string;
+  /** Text "Unfreeze Columns/Rows" shown in Grid Menu */
+  TEXT_CLEAR_PINNING: string;
 
   /** Text "Columns" title displayed in the Column Picker & Grid Menu (when enabled) */
   TEXT_COLUMNS: string;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -4,7 +4,7 @@
   "CLEAR_ALL_FILTERS": "Clear all Filters",
   "CLEAR_ALL_GROUPING": "Clear all Grouping",
   "CLEAR_ALL_SORTING": "Clear all Sorting",
-  "CLEAR_FROZEN_COLUMNS": "Clear Frozen Columns",
+  "CLEAR_PINNING": "Unfreeze Columns/Rows",
   "COLLAPSE_ALL_GROUPS": "Collapse all Groups",
   "COLUMNS": "Columns",
   "COMMANDS": "Commands",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -4,7 +4,7 @@
   "CLEAR_ALL_FILTERS": "Supprimer tous les filtres",
   "CLEAR_ALL_GROUPING": "Supprimer tous les groupes",
   "CLEAR_ALL_SORTING": "Supprimer tous les tris",
-  "CLEAR_FROZEN_COLUMNS": "Libérer les colonnes gelées",
+  "CLEAR_PINNING": "Dégeler les colonnes/rangées",
   "COLLAPSE_ALL_GROUPS": "Réduire tous les groupes",
   "COLUMNS": "Colonnes",
   "COMMANDS": "Commandes",

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -5,7 +5,7 @@ function removeExtraSpaces(textS) {
 }
 
 describe('Example 15 - Column Span & Header Grouping', () => {
-  // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after clear frozen columns
+  // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
   const fullPreTitles = ['', 'Common Factor', 'Period', 'Analysis'];
   const fullTitles = ['#', 'Title', 'Duration', 'Start', 'Finish', '% Complete', 'Effort Driven'];
 
@@ -105,12 +105,12 @@ describe('Example 15 - Column Span & Header Grouping', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
-  it('should click on the Grid Menu command "Clear Frozen Columns" to switch to a regular grid without frozen columns and expect 7 columns on the left container', () => {
+  it('should click on the Grid Menu command "Unfreeze Columns/Rows" to switch to a regular grid without frozen columns and expect 7 columns on the left container', () => {
     cy.get('#grid2')
       .find('button.slick-gridmenu-button')
       .click({ force: true });
 
-    cy.contains('Clear Frozen Columns')
+    cy.contains('Unfreeze Columns/Rows')
       .click({ force: true });
 
     cy.get('#grid2').find('[style="top:0px"]').should('have.length', 1);

--- a/test/cypress/integration/example16.spec.js
+++ b/test/cypress/integration/example16.spec.js
@@ -416,6 +416,23 @@ describe('Example 16: Grid State & Presets using Local Storage', () => {
       .each(($child, index) => expect($child.find('.slick-column-name').text()).to.eq(expectedTitles[index]));
   });
 
+  it('should be able to freeze "Description" column', () => {
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(1)')
+      .trigger('mouseover')
+      .children('.slick-header-menubutton')
+      .should('be.hidden')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu')
+      .should('be.visible')
+      .children('.slick-header-menuitem:nth-child(1)')
+      .children('.slick-header-menucontent')
+      .should('contain', 'Geler les colonnes')
+      .click();
+  });
+
   it('should reload the page', () => {
     cy.reload().wait(50);
   });
@@ -478,5 +495,11 @@ describe('Example 16: Grid State & Presets using Local Storage', () => {
         console.log($child)
         expect($child.attr('class')).to.contain('selected');
       });
+  });
+
+  it('should have a persisted frozen column after "Description" and a grid with 4 containers on page load with 2 columns on the left and 3 columns on the right', () => {
+    cy.get('[style="top:0px"]').should('have.length', 2);
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 2);
+    cy.get('.grid-canvas-right > [style="top:0px"]').children().should('have.length', 3);
   });
 });

--- a/test/cypress/integration/example16.spec.js
+++ b/test/cypress/integration/example16.spec.js
@@ -178,7 +178,7 @@ describe('Example 16: Grid State & Presets using Local Storage', () => {
 
     cy.get('.slick-header-menu')
       .should('be.visible')
-      .children('.slick-header-menuitem:nth-child(2)')
+      .children('.slick-header-menuitem:nth-child(4)')
       .children('.slick-header-menucontent')
       .should('contain', 'Sort Descending')
       .click();
@@ -405,7 +405,7 @@ describe('Example 16: Grid State & Presets using Local Storage', () => {
 
     cy.get('.slick-header-menu')
       .should('be.visible')
-      .children('.slick-header-menuitem:nth-child(6)')
+      .children('.slick-header-menuitem:nth-child(8)')
       .children('.slick-header-menucontent')
       .should('contain', 'Cacher la colonne')
       .click();

--- a/test/cypress/integration/example20.spec.js
+++ b/test/cypress/integration/example20.spec.js
@@ -5,7 +5,7 @@ function removeExtraSpaces(textS) {
 }
 
 describe('Example 20 - Frozen Grid', () => {
-  // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after clear frozen columns
+  // NOTE:  everywhere there's a * 2 is because we have a top+bottom (frozen rows) containers even after Unfreeze Columns/Rows
 
   const fullTitles = ['#', 'Title', '% Complete', 'Start', 'Finish', 'Cost | Duration', 'Effort Driven', 'Title 1', 'Title 2', 'Title 3', 'Title 4'];
 
@@ -207,16 +207,16 @@ describe('Example 20 - Frozen Grid', () => {
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
-  it('should click on the Grid Menu command "Clear Frozen Columns" to switch to a regular grid without frozen columns and expect 7 columns on the left container', () => {
+  it('should click on the Grid Menu command "Unfreeze Columns/Rows" to switch to a regular grid without frozen columns and expect 7 columns on the left container', () => {
     cy.get('#grid20')
       .find('button.slick-gridmenu-button')
       .click({ force: true });
 
-    cy.contains('Clear Frozen Columns')
+    cy.contains('Unfreeze Columns/Rows')
       .click({ force: true });
 
-    cy.get('[style="top:0px"]').should('have.length', 1 * 2);
-    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 11 * 2);
+    cy.get('[style="top:0px"]').should('have.length', 1);
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 11);
 
     cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(0)').should('contain', '0');
     cy.get('.grid-canvas-left > [style="top:0px"] > .slick-cell:nth(1)').should('contain', 'Task 0');

--- a/test/translateServiceStub.ts
+++ b/test/translateServiceStub.ts
@@ -16,7 +16,7 @@ export class TranslateServiceStub {
       case 'CLEAR_ALL_GROUPING': output = this.currentLang === 'en' ? 'Clear all Grouping' : 'Supprimer tous les groupes'; break;
       case 'CLEAR_ALL_FILTERS': output = this.currentLang === 'en' ? 'Clear all Filters' : 'Supprimer tous les filtres'; break;
       case 'CLEAR_ALL_SORTING': output = this.currentLang === 'en' ? 'Clear all Sorting' : 'Supprimer tous les tris'; break;
-      case 'CLEAR_FROZEN_COLUMNS': output = this.currentLang === 'en' ? 'Clear Frozen Columns' : 'Libérer les colonnes gelées'; break;
+      case 'CLEAR_PINNING': output = this.currentLang === 'en' ? 'Unfreeze Columns/Rows' : 'Dégeler les colonnes/rangées'; break;
       case 'COLUMNS': output = this.currentLang === 'en' ? 'Columns' : 'Colonnes'; break;
       case 'COMMANDS': output = this.currentLang === 'en' ? 'Commands' : 'Commandes'; break;
       case 'COLLAPSE_ALL_GROUPS': output = this.currentLang === 'en' ? 'Collapse all Groups' : 'Réduire tous les groupes'; break;


### PR DESCRIPTION
#### TODOs
- [x] get Pinning from Grid State
- [x] use Pinning from grid options `presets`
- [x] add `clearPinning` and `setPinning`
- [x] add Cypress E2E tests to
  - [x] save Grid State & expect Grid Presets to reload the Pinning/Freezing
- [x] rename grid menu to "Unfreeze Columns/Rows" and in French "Dégeler les colonnes/rangées"