### PR TITLE
chore(build): use dequal/lite to help legacy browsers

### DIFF
--- a/src/app/modules/angular-slickgrid/editors/selectEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/selectEditor.ts
@@ -1,5 +1,5 @@
 import { TranslateService } from '@ngx-translate/core';
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 import { Subscription } from 'rxjs';
 import * as DOMPurify_ from 'dompurify';
 const DOMPurify = DOMPurify_; // patch to fix rollup to work

--- a/src/app/modules/angular-slickgrid/services/filter.service.ts
+++ b/src/app/modules/angular-slickgrid/services/filter.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 import { isObservable, Subject } from 'rxjs';
 
 import {

--- a/src/app/modules/angular-slickgrid/services/gridState.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridState.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 import { Subject, Subscription } from 'rxjs';
 
 import {

--- a/src/app/modules/angular-slickgrid/services/pagination.service.ts
+++ b/src/app/modules/angular-slickgrid/services/pagination.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { dequal } from 'dequal';
+import { dequal } from 'dequal/lite';
 import { Subscription, isObservable, Subject } from 'rxjs';
 
 import { BackendServiceApi, CurrentPagination, GraphqlResult, GraphqlPaginatedResult, GridOption, Pagination, ServicePagination } from '../models';


### PR DESCRIPTION
- dequal/lite is a bit smaller and since we don't need to compare against Set/Map/Symbol, we can use, it even seems to be a bit faster
- this might help in supporting legacy browser like IE11