### PR TITLE
feat(resize): add column resize by cell content

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "jquery-ui-dist": "^1.12.1",
     "moment-mini": "^2.24.0",
     "rxjs": "^6.6.7",
-    "slickgrid": "^2.4.33",
+    "slickgrid": "^2.4.34",
     "text-encoding-utf-8": "^1.0.2"
   },
   "peerDependencies": {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -20,6 +20,7 @@ import { GridMenuComponent } from './examples/grid-menu.component';
 import { GridOdataComponent } from './examples/grid-odata.component';
 import { GridRangeComponent } from './examples/grid-range.component';
 import { GridRemoteComponent } from './examples/grid-remote.component';
+import { GridResizeByContentComponent } from './examples/grid-resize-by-content.component';
 import { GridRowDetailComponent } from './examples/grid-rowdetail.component';
 import { GridRowMoveComponent } from './examples/grid-rowmove.component';
 import { GridRowSelectionComponent } from './examples/grid-rowselection.component';
@@ -58,6 +59,7 @@ const routes: Routes = [
   { path: 'odata', component: GridOdataComponent },
   { path: 'range', component: GridRangeComponent },
   { path: 'remote', component: GridRemoteComponent },
+  { path: 'resize-by-content', component: GridResizeByContentComponent },
   { path: 'rowdetail', component: GridRowDetailComponent },
   { path: 'rowmove', component: GridRowMoveComponent },
   { path: 'selection', component: GridRowSelectionComponent },

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -128,6 +128,11 @@
             29- Tree Data (Hierarchical)
           </a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" routerLinkActive="active" [routerLink]="['/resize-by-content']">
+            30- Resize by Cell Content
+          </a>
+        </li>
       </ul>
     </section>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { GridMenuComponent } from './examples/grid-menu.component';
 import { GridOdataComponent } from './examples/grid-odata.component';
 import { GridRangeComponent } from './examples/grid-range.component';
 import { GridRemoteComponent } from './examples/grid-remote.component';
+import { GridResizeByContentComponent } from './examples/grid-resize-by-content.component';
 import { GridRowDetailComponent } from './examples/grid-rowdetail.component';
 import { GridRowMoveComponent } from './examples/grid-rowmove.component';
 import { GridRowSelectionComponent } from './examples/grid-rowselection.component';
@@ -110,6 +111,7 @@ export function appInitializerFactory(translate: TranslateService, injector: Inj
     GridOdataComponent,
     GridRangeComponent,
     GridRemoteComponent,
+    GridResizeByContentComponent,
     GridRowDetailComponent,
     GridRowMoveComponent,
     GridRowSelectionComponent,

--- a/src/app/examples/grid-resize-by-content.component.html
+++ b/src/app/examples/grid-resize-by-content.component.html
@@ -11,16 +11,16 @@
   </h2>
   <div class="subtitle" [innerHTML]="subTitle"></div>
 
+  <h4 class="ml-3">Container Width (950px)</h4>
   <div class="row">
-    <h4 class="ml-3">Container Width (950px)</h4>
 
     <div class="ml-2 mb-2 mr-2">
       <div class="btn-group btn-group-sm" role="group" aria-label="Basic Editing Commands">
-        <button class="btn btn-outline-secondary btn-sm" data-test="set-dynamic-filter"
+        <button class="btn btn-outline-secondary btn-sm" data-text="autosize-columns-btn"
                 (click)="handleDefaultResizeColumns()">
           <i class="fa fa-expand"></i> (default resize) by "autosizeColumns"
         </button>
-        <button class="btn btn-outline-secondary btn-sm" data-test="set-dynamic-sorting"
+        <button class="btn btn-outline-secondary btn-sm" data-text="resize-by-content-btn"
                 (click)="handleNewResizeColumns()">
           <i class="fa fa-expand"></i> Resize by Cell Content
         </button>

--- a/src/app/examples/grid-resize-by-content.component.html
+++ b/src/app/examples/grid-resize-by-content.component.html
@@ -1,0 +1,56 @@
+<div class="container-fluid">
+  <h2>
+    {{title}}
+    <span class="float-right">
+      <a style="font-size: 18px"
+         target="_blank"
+         href="https://github.com/ghiscoding/Angular-Slickgrid/blob/master/src/app/examples/grid-resize-by-content.component.ts">
+        <span class="fa fa-link"></span> code
+      </a>
+    </span>
+  </h2>
+  <div class="subtitle" [innerHTML]="subTitle"></div>
+
+  <div class="row">
+    <h4 class="ml-3">Container Width (950px)</h4>
+
+    <div class="ml-2 mb-2 mr-2">
+      <div class="btn-group btn-group-sm" role="group" aria-label="Basic Editing Commands">
+        <button class="btn btn-outline-secondary btn-sm" data-test="set-dynamic-filter"
+                (click)="handleDefaultResizeColumns()">
+          <i class="fa fa-expand"></i> (default resize) by "autosizeColumns"
+        </button>
+        <button class="btn btn-outline-secondary btn-sm" data-test="set-dynamic-sorting"
+                (click)="handleNewResizeColumns()">
+          <i class="fa fa-expand"></i> Resize by Cell Content
+        </button>
+      </div>
+    </div>
+
+    <div class="mb-2">
+      <div class="btn-group btn-group-sm" role="group" aria-label="Basic Editing Commands">
+        <button type="button" class="btn btn-outline-secondary" data-test="toggle-readonly-btn"
+                (click)="toggleGridEditReadonly()">
+          <i class="fa fa-table"></i> Toggle Edit/Readonly Grid
+        </button>
+        <button type="button" class="btn btn-outline-secondary" data-test="undo-last-edit-btn"
+                (click)="undoLastEdit()">
+          <i class="fa fa-undo"></i> Undo Last Edit
+        </button>
+        <button type="button" class="btn btn-outline-secondary" data-test="save-all-btn"
+                (click)="saveAll()">
+          <i class="fa fa-save"></i> Save All
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div id="smaller-container" style="width: 950px">
+    <angular-slickgrid gridId="grid30"
+                       [columnDefinitions]="columnDefinitions"
+                       [gridOptions]="gridOptions"
+                       [dataset]="dataset"
+                       (onAngularGridCreated)="angularGridReady($event)">
+    </angular-slickgrid>
+  </div>
+</div>

--- a/src/app/examples/grid-resize-by-content.component.scss
+++ b/src/app/examples/grid-resize-by-content.component.scss
@@ -1,0 +1,19 @@
+$button-border-color: #ababab !default;
+
+.editable-field {
+  background-color: rgba(227, 240, 251, 0.569) !important;
+}
+.unsaved-editable-field {
+  background-color: #fbfdd1 !important;
+}
+.button-style {
+  cursor: pointer;
+  background-color: white;
+  border: 1px solid #{$button-border-color};
+  border-radius: 2px;
+  justify-content: center;
+  text-align: center;
+  &:hover {
+    border-color: darken($button-border-color, 10%);
+  }
+}

--- a/src/app/examples/grid-resize-by-content.component.ts
+++ b/src/app/examples/grid-resize-by-content.component.ts
@@ -1,0 +1,786 @@
+import { Component, OnInit, Injectable, ViewEncapsulation } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { AngularGridInstance, Column, GridOption, Filters, Formatter, LongTextEditorOption, FieldType, Editors, Formatters, AutocompleteOption, EditCommand, formatNumber, Sorters } from '../modules/angular-slickgrid';
+
+const URL_COUNTRIES_COLLECTION = 'assets/data/countries.json';
+declare const Slick: any;
+
+/**
+ * Check if the current item (cell) is editable or not
+ * @param {*} dataContext - item data context object
+ * @param {*} columnDef - column definition
+ * @param {*} grid - slickgrid grid object
+ * @returns {boolean} isEditable
+ */
+function checkItemIsEditable(dataContext: any, columnDef: Column, grid: any) {
+  const gridOptions = grid && grid.getOptions && grid.getOptions();
+  const hasEditor = columnDef.editor;
+  const isGridEditable = gridOptions.editable;
+  let isEditable = !!(isGridEditable && hasEditor);
+
+  if (dataContext && columnDef && gridOptions && gridOptions.editable) {
+    switch (columnDef.id) {
+      case 'finish':
+        isEditable = !!dataContext?.completed;
+        break;
+    }
+  }
+  return isEditable;
+}
+
+const customEditableInputFormatter: Formatter = (_row, _cell, value, columnDef, _dataContext, grid) => {
+  const gridOptions = grid && grid.getOptions && grid.getOptions();
+  const isEditableLine = gridOptions.editable && columnDef.editor;
+  value = (value === null || value === undefined) ? '' : value;
+  return isEditableLine ? { text: value, addClasses: 'editable-field', toolTip: 'Click to Edit' } : value;
+};
+
+// you can create custom validator to pass to an inline editor
+const myCustomTitleValidator = (value: any, args: any) => {
+  if ((value === null || value === undefined || !value.length) && (args.compositeEditorOptions && args.compositeEditorOptions.modalType === 'create' || args.compositeEditorOptions.modalType === 'edit')) {
+    // we will only check if the field is supplied when it's an inline editing OR a composite editor of type create/edit
+    return { valid: false, msg: 'This is a required field.' };
+  } else if (!/^(task\s\d+)*$/i.test(value)) {
+    return { valid: false, msg: 'Your title is invalid, it must start with "Task" followed by a number.' };
+  }
+  return { valid: true, msg: '' };
+};
+
+@Component({
+  templateUrl: './grid-resize-by-content.component.html',
+  styleUrls: ['./grid-resize-by-content.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+@Injectable()
+export class GridResizeByContentComponent implements OnInit {
+  title = 'Example 30: Columns Resize by Content';
+  subTitle = `The grid below uses the optional resize by cell content (with a fixed 950px for demo purposes), you can click on the 2 buttons to see the difference. The "autosizeColumns" is really the default option used by SlickGrid-Universal, the resize by cell content is optional because it requires to read the first thousand rows and do extra width calculation.`;
+
+  angularGrid!: AngularGridInstance;
+  gridOptions!: GridOption;
+  columnDefinitions: Column[] = [];
+  dataset: any[] = [];
+  editQueue: any[] = [];
+  editedItems: any = {};
+  isGridEditable = true;
+  isCompositeDisabled = false;
+  isMassSelectionDisabled = true;
+  complexityLevelList = [
+    { value: 0, label: 'Very Simple' },
+    { value: 1, label: 'Simple' },
+    { value: 2, label: 'Straightforward' },
+    { value: 3, label: 'Complex' },
+    { value: 4, label: 'Very Complex' },
+  ];
+
+  constructor(private http: HttpClient) { }
+
+  angularGridReady(angularGrid: AngularGridInstance) {
+    this.angularGrid = angularGrid;
+  }
+
+  ngOnInit(): void {
+    this.defineGrid();
+    this.dataset = this.loadData(5000);
+  }
+
+  // Grid2 definition
+  defineGrid() {
+    this.columnDefinitions = [
+      {
+        id: 'title', name: 'Title', field: 'title', sortable: true, type: FieldType.string, minWidth: 65,
+        // you can adjust the resize calculation via multiple options
+        resizeExtraWidthPadding: 4,
+        resizeCharWidthInPx: 7.6,
+        resizeCalcWidthRatio: 1,
+        resizeMaxWidthThreshold: 200,
+        filterable: true, columnGroup: 'Common Factor',
+        filter: { model: Filters.compoundInputText },
+        formatter: Formatters.multiple, params: { formatters: [Formatters.uppercase, Formatters.bold] },
+        editor: {
+          model: Editors.longText, required: true, alwaysSaveOnEnterKey: true,
+          maxLength: 12,
+          editorOptions: {
+            cols: 45,
+            rows: 6,
+            buttonTexts: {
+              cancel: 'Close',
+              save: 'Done'
+            }
+          } as LongTextEditorOption,
+          validator: myCustomTitleValidator,
+        },
+      },
+      {
+        id: 'duration', name: 'Duration', field: 'duration', sortable: true, filterable: true, minWidth: 65,
+        type: FieldType.number, columnGroup: 'Common Factor',
+        formatter: (_row, _cell, value) => {
+          if (value === null || value === undefined || value === '') {
+            return '';
+          }
+          return value > 1 ? `${value} days` : `${value} day`;
+        },
+        editor: { model: Editors.float, decimal: 2, valueStep: 1, minValue: 0, maxValue: 10000, alwaysSaveOnEnterKey: true, required: true },
+      },
+      {
+        id: 'cost', name: 'Cost', field: 'cost', minWidth: 65,
+        sortable: true, filterable: true, type: FieldType.number, columnGroup: 'Analysis',
+        filter: { model: Filters.compoundInputNumber },
+        formatter: Formatters.dollar,
+      },
+      {
+        id: 'percentComplete', name: '% Complete', field: 'percentComplete', minWidth: 100,
+        type: FieldType.number,
+        sortable: true, filterable: true, columnGroup: 'Analysis',
+        filter: { model: Filters.compoundSlider, operator: '>=' },
+        editor: {
+          model: Editors.slider,
+          minValue: 0, maxValue: 100,
+        },
+      },
+      {
+        id: 'complexity', name: 'Complexity', field: 'complexity',
+        resizeCalcWidthRatio: 0.82, // default calc ratio is 1 or 0.95 for field type of string
+        sortable: true, filterable: true, columnGroup: 'Analysis',
+        formatter: (_row, _cell, value) => this.complexityLevelList[value].label,
+        exportCustomFormatter: (_row, _cell, value) => this.complexityLevelList[value].label,
+        filter: {
+          model: Filters.multipleSelect,
+          collection: this.complexityLevelList
+        },
+        editor: {
+          model: Editors.singleSelect,
+          collection: this.complexityLevelList,
+        },
+      },
+      {
+        id: 'start', name: 'Start', field: 'start', sortable: true,
+        formatter: Formatters.dateUs, columnGroup: 'Period',
+        exportCustomFormatter: Formatters.dateUs,
+        type: FieldType.date, outputType: FieldType.dateUs, saveOutputType: FieldType.dateUtc,
+        filterable: true, filter: { model: Filters.compoundDate },
+        editor: { model: Editors.date, params: { hideClearButton: false } },
+      },
+      {
+        id: 'completed', name: 'Completed', field: 'completed', width: 80, minWidth: 75, maxWidth: 100,
+        sortable: true, filterable: true, columnGroup: 'Period',
+        formatter: Formatters.multiple,
+        params: { formatters: [Formatters.checkmark, Formatters.center] },
+        exportWithFormatter: false,
+        filter: {
+          collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }],
+          model: Filters.singleSelect
+        },
+        editor: { model: Editors.checkbox, },
+        // editor: { model: Editors.singleSelect, collection: [{ value: true, label: 'Yes' }, { value: false, label: 'No' }], },
+      },
+      {
+        id: 'finish', name: 'Finish', field: 'finish', sortable: true,
+        formatter: Formatters.dateUs, columnGroup: 'Period',
+        type: FieldType.date, outputType: FieldType.dateUs, saveOutputType: FieldType.dateUtc,
+        filterable: true, filter: { model: Filters.compoundDate },
+        exportCustomFormatter: Formatters.dateUs,
+        editor: {
+          model: Editors.date,
+          editorOptions: { minDate: 'today' },
+          validator: (value, args) => {
+            const dataContext = args && args.item;
+            if (dataContext && (dataContext.completed && !value)) {
+              return { valid: false, msg: 'You must provide a "Finish" date when "Completed" is checked.' };
+            }
+            return { valid: true, msg: '' };
+          }
+        },
+      },
+      {
+        id: 'product', name: 'Product', field: 'product',
+        filterable: true, columnGroup: 'Item',
+        minWidth: 100,
+        resizeCharWidthInPx: 8,
+        exportWithFormatter: true,
+        dataKey: 'id',
+        labelKey: 'itemName',
+        formatter: Formatters.complexObject,
+        exportCustomFormatter: Formatters.complex, // without the Editing cell Formatter
+        type: FieldType.object,
+        sorter: Sorters.objectString,
+        editor: {
+          model: Editors.autoComplete,
+          alwaysSaveOnEnterKey: true,
+
+          // example with a Remote API call
+          editorOptions: {
+            minLength: 1,
+            source: (request, response) => {
+              // const items = require('c://TEMP/items.json');
+              const products = this.mockProducts();
+              response(products.filter(product => product.itemName.toLowerCase().includes(request.term.toLowerCase())));
+            },
+            renderItem: {
+              // layout: 'twoRows',
+              // templateCallback: (item: any) => this.renderItemCallbackWith2Rows(item),
+
+              layout: 'fourCorners',
+              templateCallback: (item: any) => this.renderItemCallbackWith4Corners(item),
+            },
+          } as AutocompleteOption,
+        },
+        filter: {
+          model: Filters.inputText,
+          // placeholder: '&#128269; search city',
+          type: FieldType.string,
+          queryField: 'product.itemName',
+        }
+      },
+      {
+        id: 'origin', name: 'Country of Origin', field: 'origin',
+        formatter: Formatters.complexObject, columnGroup: 'Item',
+        exportCustomFormatter: Formatters.complex, // without the Editing cell Formatter
+        dataKey: 'code',
+        labelKey: 'name',
+        type: FieldType.object,
+        sorter: Sorters.objectString,
+        filterable: true,
+        sortable: true,
+        minWidth: 100,
+        editor: {
+          model: Editors.autoComplete,
+          customStructure: { label: 'name', value: 'code' },
+          collectionAsync: this.http.get(URL_COUNTRIES_COLLECTION),
+        },
+        filter: {
+          model: Filters.inputText,
+          type: FieldType.string,
+          queryField: 'origin.name',
+        }
+      },
+      {
+        id: 'action', name: 'Action', field: 'action', width: 70, minWidth: 70, maxWidth: 70,
+        excludeFromExport: true,
+        formatter: () => `<div class="button-style margin-auto" style="width: 35px;"><span class="fa fa-chevron-down text-primary"></span></div>`,
+        cellMenu: {
+          hideCloseButton: false,
+          width: 175,
+          commandTitle: 'Commands',
+          commandItems: [
+            {
+              command: 'help',
+              title: 'Help!',
+              iconCssClass: 'fa fa-question-circle',
+              positionOrder: 66,
+              action: () => alert('Please Help!'),
+            },
+            'divider',
+            {
+              command: 'delete-row', title: 'Delete Row', positionOrder: 64,
+              iconCssClass: 'fa fa-times color-danger', cssClass: 'red', textCssClass: 'text-italic color-danger-light',
+              // only show command to 'Delete Row' when the task is not completed
+              itemVisibilityOverride: (args) => {
+                return !args.dataContext?.completed;
+              },
+              action: (_event, args) => {
+                const dataContext = args.dataContext;
+                const row = args?.row ?? 0;
+                if (confirm(`Do you really want to delete row (${row + 1}) with "${dataContext.title}"`)) {
+                  this.angularGrid.gridService.deleteItemById(dataContext.id);
+                }
+              }
+            },
+          ],
+        }
+      },
+    ];
+
+    this.gridOptions = {
+      editable: true,
+      autoAddCustomEditorFormatter: customEditableInputFormatter,
+      enableCellNavigation: true,
+      autoEdit: true,
+      autoCommitEdit: true,
+      autoResize: {
+        containerId: 'smaller-container',
+        sidePadding: 10
+      },
+      enableAutoResize: true,
+
+      // resizing by cell content is opt-in
+      // we first need to disable the 2 default flags to autoFit/autosize
+      autoFitColumnsOnFirstLoad: false,
+      enableAutoSizeColumns: false,
+      // then enable resize by content with these 2 flags
+      autosizeColumnsByCellContentOnFirstLoad: true,
+      enableAutoResizeColumnsByCellContent: true,
+
+      // optional resize calculation options
+      resizeDefaultRatioForStringType: 0.92,
+      resizeFormatterPaddingWidthInPx: 8, // optional editor formatter padding for resize calculation
+
+      enableExcelExport: true,
+      excelExportOptions: {
+        exportWithFormatter: false
+      },
+      enableFiltering: true,
+      enableRowSelection: true,
+      enableCheckboxSelector: true,
+      checkboxSelector: {
+        hideInFilterHeaderRow: false,
+        hideInColumnTitleRow: true,
+      },
+      rowSelectionOptions: {
+        // True (Single Selection), False (Multiple Selections)
+        selectActiveRow: false
+      },
+      createPreHeaderPanel: true,
+      showPreHeaderPanel: true,
+      preHeaderPanelHeight: 28,
+      rowHeight: 33,
+      headerRowHeight: 35,
+      editCommandHandler: (item, column, editCommand) => {
+        // composite editors values are saved as array, so let's convert to array in any case and we'll loop through these values
+        const prevSerializedValues = Array.isArray(editCommand.prevSerializedValue) ? editCommand.prevSerializedValue : [editCommand.prevSerializedValue];
+        const serializedValues = Array.isArray(editCommand.serializedValue) ? editCommand.serializedValue : [editCommand.serializedValue];
+        const editorColumns = this.columnDefinitions.filter((col) => col.editor !== undefined);
+
+        const modifiedColumns: Column[] = [];
+        prevSerializedValues.forEach((_val, index) => {
+          const prevSerializedValue = prevSerializedValues[index];
+          const serializedValue = serializedValues[index];
+
+          if (prevSerializedValue !== serializedValue) {
+            const finalColumn = Array.isArray(editCommand.prevSerializedValue) ? editorColumns[index] : column;
+            this.editedItems[this.gridOptions.datasetIdPropertyName || 'id'] = item; // keep items by their row indexes, if the row got edited twice then we'll keep only the last change
+            this.angularGrid.slickGrid.invalidate();
+            editCommand.execute();
+
+            this.renderUnsavedCellStyling(item, finalColumn, editCommand);
+            modifiedColumns.push(finalColumn);
+          }
+        });
+
+        // queued editor only keeps 1 item object even when it's a composite editor,
+        // so we'll push only 1 change at the end but with all columns modified
+        // this way we can undo the entire row change (for example if user changes 3 field in the editor modal, then doing a undo last change will undo all 3 in 1 shot)
+        this.editQueue.push({ item, columns: modifiedColumns, editCommand });
+      },
+      // when using the cellMenu, you can change some of the default options and all use some of the callback methods
+      enableCellMenu: true,
+    };
+  }
+
+  loadData(count: number) {
+    // mock data
+    const tmpArray: any[] = [];
+    for (let i = 0; i < count; i++) {
+      const randomItemId = Math.floor(Math.random() * this.mockProducts().length);
+      const randomYear = 2000 + Math.floor(Math.random() * 10);
+      const randomFinishYear = (new Date().getFullYear()) + Math.floor(Math.random() * 10); // use only years not lower than 3 years ago
+      const randomMonth = Math.floor(Math.random() * 11);
+      const randomDay = Math.floor((Math.random() * 29));
+      const randomTime = Math.floor((Math.random() * 59));
+      const randomFinish = new Date(randomFinishYear, (randomMonth + 1), randomDay, randomTime, randomTime, randomTime);
+      const randomPercentComplete = Math.floor(Math.random() * 100) + 15; // make it over 15 for E2E testing purposes
+      const percentCompletion = randomPercentComplete > 100 ? (i > 5 ? 100 : 88) : randomPercentComplete; // don't use 100 unless it's over index 5, for E2E testing purposes
+      const isCompleted = percentCompletion === 100;
+
+      tmpArray[i] = {
+        id: i,
+        title: 'Task ' + i,
+        duration: Math.floor(Math.random() * 100) + 10,
+        percentComplete: percentCompletion,
+        analysis: {
+          percentComplete: percentCompletion,
+        },
+        complexity: i % 3 ? 0 : 2,
+        start: new Date(randomYear, randomMonth, randomDay, randomDay, randomTime, randomTime, randomTime),
+        finish: (isCompleted || (i % 3 === 0 && (randomFinish > new Date() && i > 3)) ? (isCompleted ? new Date() : randomFinish) : ''), // make sure the random date is earlier than today and it's index is bigger than 3
+        cost: (i % 33 === 0) ? null : Math.round(Math.random() * 10000) / 100,
+        completed: (isCompleted || (i % 3 === 0 && (randomFinish > new Date() && i > 3))),
+        product: { id: this.mockProducts()[randomItemId]?.id, itemName: this.mockProducts()[randomItemId]?.itemName, },
+        origin: (i % 2) ? { code: 'CA', name: 'Canada' } : { code: 'US', name: 'United States' },
+      };
+
+      if (!(i % 8)) {
+        delete tmpArray[i].finish; // also test with undefined properties
+        delete tmpArray[i].percentComplete; // also test with undefined properties
+      }
+    }
+    return tmpArray;
+  }
+
+  handleValidationError(_e: Event, args: any) {
+    if (args.validationResults) {
+      let errorMsg = args.validationResults.msg || '';
+      if (args.editor && (args.editor instanceof Slick.CompositeEditor)) {
+        if (args.validationResults.errors) {
+          errorMsg += '\n';
+          for (const error of args.validationResults.errors) {
+            const columnName = error.editor.args.column.name;
+            errorMsg += `${columnName.toUpperCase()}: ${error.msg}`;
+          }
+        }
+        console.log(errorMsg);
+      }
+    } else {
+      alert(args.validationResults.msg);
+    }
+    return false;
+  }
+
+  handleItemDeleted(_e: Event, args: any) {
+    console.log('item deleted with id:', args.itemId);
+  }
+
+  handleOnBeforeEditCell(e: Event, args: any) {
+    const { column, item, grid } = args;
+
+    if (column && item) {
+      if (!checkItemIsEditable(item, column, grid)) {
+        // event.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    }
+    return false;
+  }
+
+  handleOnCellChange(_e: Event, args: any) {
+    const dataContext = args?.item;
+
+    // when the field "completed" changes to false, we also need to blank out the "finish" date
+    if (dataContext && !dataContext.completed) {
+      dataContext.finish = null;
+      this.angularGrid.gridService.updateItem(dataContext);
+    }
+  }
+
+  handlePaginationChanged() {
+    this.removeAllUnsavedStylingFromCell();
+    this.renderUnsavedStylingOnAllVisibleCells();
+  }
+
+  handleDefaultResizeColumns() {
+    // just for demo purposes, set it back to its original width
+    const columns = this.angularGrid.slickGrid.getColumns() as Column[];
+    columns.forEach(col => col.width = col.originalWidth);
+    this.angularGrid.slickGrid.setColumns(columns);
+    this.angularGrid.slickGrid.autosizeColumns();
+  }
+
+  handleNewResizeColumns() {
+    this.angularGrid.resizerService.resizeColumnsByCellContent(true);
+  }
+
+  toggleGridEditReadonly() {
+    // first need undo all edits
+    this.undoAllEdits();
+
+    // then change a single grid options to make the grid non-editable (readonly)
+    this.isGridEditable = !this.isGridEditable;
+    this.isCompositeDisabled = !this.isGridEditable;
+    if (!this.isGridEditable) {
+      this.isMassSelectionDisabled = true;
+    }
+    // dynamically change SlickGrid editable grid option
+    this.angularGrid.slickGrid.setOptions({ editable: this.isGridEditable });
+  }
+
+  removeUnsavedStylingFromCell(_item: any, column: Column, row: number) {
+    // remove unsaved css class from that cell
+    this.angularGrid.slickGrid.removeCellCssStyles(`unsaved_highlight_${[column.id]}${row}`);
+  }
+
+  removeAllUnsavedStylingFromCell() {
+    for (const lastEdit of this.editQueue) {
+      const lastEditCommand = lastEdit?.editCommand;
+      if (lastEditCommand) {
+        // remove unsaved css class from that cell
+        for (const lastEditColumn of lastEdit.columns) {
+          this.removeUnsavedStylingFromCell(lastEdit.item, lastEditColumn, lastEditCommand.row);
+        }
+      }
+    }
+  }
+
+  renderUnsavedStylingOnAllVisibleCells() {
+    for (const lastEdit of this.editQueue) {
+      if (lastEdit) {
+        const { item, columns, editCommand } = lastEdit;
+        if (Array.isArray(columns)) {
+          columns.forEach((col) => {
+            this.renderUnsavedCellStyling(item, col, editCommand);
+          });
+        }
+      }
+    }
+  }
+
+  renderUnsavedCellStyling(item: any, column: Column, editCommand: EditCommand) {
+    if (editCommand && item && column) {
+      const row = this.angularGrid.dataView.getRowByItem(item) as number;
+      if (row >= 0) {
+        const hash = { [row]: { [column.id]: 'unsaved-editable-field' } };
+        this.angularGrid.slickGrid.setCellCssStyles(`unsaved_highlight_${[column.id]}${row}`, hash);
+      }
+    }
+  }
+
+
+  saveAll() {
+    // Edit Queue (array increases every time a cell is changed, regardless of item object)
+    console.log(this.editQueue);
+
+    // Edit Items only keeps the merged data (an object with row index as the row properties)
+    // if you change 2 different cells on 2 different cells then this editedItems will only contain 1 property
+    // example: editedItems = { 0: { title: task 0, duration: 50, ... }}
+    // ...means that row index 0 got changed and the final merged object is { title: task 0, duration: 50, ... }
+    console.log(this.editedItems);
+    // console.log(`We changed ${Object.keys(this.editedItems).length} rows`);
+
+    // since we saved, we can now remove all the unsaved color styling and reset our array/object
+    this.removeAllUnsavedStylingFromCell();
+    this.editQueue = [];
+    this.editedItems = {};
+  }
+
+  undoLastEdit(showLastEditor = false) {
+    const lastEdit = this.editQueue.pop();
+    const lastEditCommand = lastEdit?.editCommand;
+    if (lastEdit && lastEditCommand && Slick.GlobalEditorLock.cancelCurrentEdit()) {
+      lastEditCommand.undo();
+
+      // remove unsaved css class from that cell
+      for (const lastEditColumn of lastEdit.columns) {
+        this.removeUnsavedStylingFromCell(lastEdit.item, lastEditColumn, lastEditCommand.row);
+      }
+      this.angularGrid.slickGrid.invalidate();
+
+
+      // optionally open the last cell editor associated
+      if (showLastEditor) {
+        this.angularGrid?.slickGrid.gotoCell(lastEditCommand.row, lastEditCommand.cell, false);
+      }
+    }
+  }
+
+  undoAllEdits() {
+    for (const lastEdit of this.editQueue) {
+      const lastEditCommand = lastEdit?.editCommand;
+      if (lastEditCommand && Slick.GlobalEditorLock.cancelCurrentEdit()) {
+        lastEditCommand.undo();
+
+        // remove unsaved css class from that cell
+        for (const lastEditColumn of lastEdit.columns) {
+          this.removeUnsavedStylingFromCell(lastEdit.item, lastEditColumn, lastEditCommand.row);
+        }
+      }
+    }
+    this.angularGrid.slickGrid.invalidate(); // re-render the grid only after every cells got rolled back
+    this.editQueue = [];
+  }
+
+  mockProducts() {
+    return [
+      {
+        id: 0,
+        itemName: 'Sleek Metal Computer',
+        itemNameTranslated: 'some fantastic sleek metal computer description',
+        listPrice: 2100.23,
+        itemTypeName: 'I',
+        image: 'http://i.stack.imgur.com/pC1Tv.jpg',
+        icon: `mdi ${this.getRandomIcon(0)}`,
+      },
+      {
+        id: 1,
+        itemName: 'Tasty Granite Table',
+        itemNameTranslated: 'an extremely huge and heavy table',
+        listPrice: 3200.12,
+        itemTypeName: 'I',
+        image: 'https://i.imgur.com/Fnm7j6h.jpg',
+        icon: `mdi ${this.getRandomIcon(1)}`,
+      },
+      {
+        id: 2,
+        itemName: 'Awesome Wooden Mouse',
+        itemNameTranslated: 'super old mouse',
+        listPrice: 15.00,
+        itemTypeName: 'I',
+        image: 'https://i.imgur.com/RaVJuLr.jpg',
+        icon: `mdi ${this.getRandomIcon(2)}`,
+      },
+      {
+        id: 3,
+        itemName: 'Gorgeous Fresh Shirt',
+        itemNameTranslated: 'what a gorgeous shirt seriously',
+        listPrice: 25.76,
+        itemTypeName: 'I',
+        image: 'http://i.stack.imgur.com/pC1Tv.jpg',
+        icon: `mdi ${this.getRandomIcon(3)}`,
+      },
+      {
+        id: 4,
+        itemName: 'Refined Cotton Table',
+        itemNameTranslated: 'super light table that will fall apart amazingly fast',
+        listPrice: 13.35,
+        itemTypeName: 'I',
+        image: 'https://i.imgur.com/Fnm7j6h.jpg',
+        icon: `mdi ${this.getRandomIcon(4)}`,
+      },
+      {
+        id: 5,
+        itemName: 'Intelligent Wooden Pizza',
+        itemNameTranslated: 'wood not included',
+        listPrice: 23.33,
+        itemTypeName: 'I',
+        image: 'https://i.imgur.com/RaVJuLr.jpg',
+        icon: `mdi ${this.getRandomIcon(5)}`,
+      },
+      {
+        id: 6,
+        itemName: 'Licensed Cotton Chips',
+        itemNameTranslated: 'not sure what that is',
+        listPrice: 71.21,
+        itemTypeName: 'I',
+        image: 'http://i.stack.imgur.com/pC1Tv.jpg',
+        icon: `mdi ${this.getRandomIcon(6)}`,
+      },
+      {
+        id: 7,
+        itemName: 'Ergonomic Rubber Soap',
+        itemNameTranslated: `so good you'll want to use it every night`,
+        listPrice: 2.43,
+        itemTypeName: 'I',
+        image: 'https://i.imgur.com/Fnm7j6h.jpg',
+        icon: `mdi ${this.getRandomIcon(7)}`,
+      },
+      {
+        id: 8,
+        itemName: 'Handcrafted Steel Car',
+        itemNameTranslated: `aka tesla truck`,
+        listPrice: 31288.39,
+        itemTypeName: 'I',
+        image: 'https://i.imgur.com/RaVJuLr.jpg',
+        icon: `mdi ${this.getRandomIcon(8)}`,
+      },
+    ];
+  }
+
+  /** List of icons that are supported in this lib Material Design Icons */
+  getRandomIcon(iconIndex?: number) {
+    const icons = [
+      'fa-500px',
+      'fa-address-book',
+      'fa-address-book-o',
+      'fa-address-card',
+      'fa-address-card-o',
+      'fa-adjust',
+      'fa-adn',
+      'fa-align-center',
+      'fa-align-justify',
+      'fa-align-left',
+      'fa-align-right',
+      'fa-amazon',
+      'fa-ambulance',
+      'fa-american-sign-language-interpreting',
+      'fa-anchor',
+      'fa-android',
+      'fa-angellist',
+      'fa-angle-double-down',
+      'fa-angle-double-left',
+      'fa-angle-double-right',
+      'fa-angle-double-up',
+      'fa-angle-down',
+      'fa-angle-left',
+      'fa-angle-right',
+      'fa-angle-up',
+      'fa-apple',
+      'fa-archive',
+      'fa-area-chart',
+      'fa-arrow-circle-down',
+      'fa-arrow-circle-left',
+      'fa-arrow-circle-o-down',
+      'fa-arrow-circle-o-left',
+      'fa-arrow-circle-o-right',
+      'fa-arrow-circle-o-up',
+      'fa-arrow-circle-right',
+      'fa-arrow-circle-up',
+      'fa-arrow-down',
+      'fa-arrow-left',
+      'fa-arrow-right',
+      'fa-arrow-up',
+      'fa-arrows',
+      'fa-arrows-alt',
+      'fa-arrows-h',
+      'fa-arrows-v',
+      'fa-assistive-listening-systems',
+      'fa-asterisk',
+      'fa-at',
+      'fa-audio-description',
+      'fa-backward',
+      'fa-balance-scale',
+      'fa-ban',
+      'fa-bandcamp',
+      'fa-bank (alias)',
+      'fa-bar-chart',
+      'fa-barcode',
+      'fa-bars',
+      'fa-bath',
+      'fa-battery-empty',
+      'fa-battery-full',
+      'fa-battery-half',
+      'fa-battery-quarter',
+      'fa-battery-three-quarters',
+      'fa-bed',
+      'fa-beer',
+      'fa-behance',
+      'fa-behance-square',
+      'fa-bell',
+      'fa-bell-o',
+      'fa-bell-slash',
+      'fa-bell-slash-o',
+      'fa-bicycle',
+      'fa-binoculars',
+      'fa-birthday-cake',
+      'fa-bitbucket',
+      'fa-bitbucket-square',
+    ];
+    const randomNumber = Math.floor((Math.random() * icons.length - 1));
+    return icons[iconIndex ?? randomNumber];
+  }
+
+  renderItemCallbackWith2Rows(item: any): string {
+    return `<div class="autocomplete-container-list">
+      <div class="autocomplete-left">
+        <!--<img src="http://i.stack.imgur.com/pC1Tv.jpg" width="50" />-->
+        <span class="fa ${item.icon}"></span>
+      </div>
+      <div>
+        <span class="autocomplete-top-left">
+          <span class="mdfai ${item.itemTypeName === 'I' ? 'fa-info-circle' : 'fa-copy'}"></span>
+          ${item.itemName}
+        </span>
+      <div>
+    </div>
+    <div>
+      <div class="autocomplete-bottom-left">${item.itemNameTranslated}</div>
+    </div>`;
+  }
+
+  renderItemCallbackWith4Corners(item: any): string {
+    return `<div class="autocomplete-container-list">
+          <div class="autocomplete-left">
+            <!--<img src="http://i.stack.imgur.com/pC1Tv.jpg" width="50" />-->
+            <span class="fa ${item.icon}"></span>
+          </div>
+          <div>
+            <span class="autocomplete-top-left">
+              <span class="fa ${item.itemTypeName === 'I' ? 'fa-info-circle' : 'fa-copy'}"></span>
+              ${item.itemName}
+            </span>
+            <span class="autocomplete-top-right">${formatNumber(item.listPrice, 2, 2, false, '$')}</span>
+          <div>
+        </div>
+        <div>
+          <div class="autocomplete-bottom-left">${item.itemNameTranslated}</div>
+          <span class="autocomplete-bottom-right">Type: <b>${item.itemTypeName === 'I' ? 'Item' : item.itemTypeName === 'C' ? 'PdCat' : 'Cat'}</b></span>
+        </div>`;
+  }
+}

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -99,6 +99,14 @@ const filterServiceStub = {
   onFilterChanged: new Subject<CurrentFilter[]>(),
 } as unknown as FilterService;
 
+const resizerServiceStub = {
+  init: jest.fn(),
+  dispose: jest.fn(),
+  bindAutoResizeDataGrid: jest.fn(),
+  resizeGrid: jest.fn(),
+  resizeColumnsByCellContent: jest.fn(),
+} as unknown as ResizerService;
+
 const sortServiceStub = {
   bindBackendOnSort: jest.fn(),
   bindLocalOnSort: jest.fn(),
@@ -136,7 +144,6 @@ describe('App Component', () => {
         GridEventService,
         GridStateService,
         PaginationService,
-        ResizerService,
         SharedService,
         TranslateService,
         AutoTooltipExtension,
@@ -161,6 +168,7 @@ describe('App Component', () => {
         { provide: ExtensionService, useValue: extensionServiceStub },
         { provide: ExtensionUtility, useValue: extensionUtilityStub },
         { provide: GroupingAndColspanService, useValue: groupingAndColspanServiceStub },
+        { provide: ResizerService, useValue: resizerServiceStub },
         { provide: SortService, useValue: sortServiceStub },
         { provide: TreeDataService, useValue: treeDataServiceStub },
       ],
@@ -279,5 +287,23 @@ describe('App Component', () => {
 
     expect(sharedHasColumnsReorderedSpy).toHaveBeenCalledWith(true);
     expect(sharedVisibleColumnsSpy).toHaveBeenCalledWith(newVisibleColumns);
+  });
+
+  describe('resizeColumnsByCellContent method', () => {
+    it('should call "resizeColumnsByCellContent" when the DataView "onSetItemsCalled" event is triggered and "enableAutoResizeColumnsByCellContent" is set', (done) => {
+      const resizeContentSpy = jest.spyOn(resizerServiceStub, 'resizeColumnsByCellContent');
+      const mockDataset = [{ id: 1, firstName: 'John' }, { id: 2, firstName: 'Jane' }];
+
+      component.gridId = 'grid1';
+      component.gridOptions = { enablePagination: false, showCustomFooter: true, autoFitColumnsOnFirstLoad: false, enableAutoSizeColumns: false, enableAutoResizeColumnsByCellContent: true } as GridOption;
+      component.dataset = mockDataset;
+      fixture.detectChanges();
+      component.dataView.onSetItemsCalled.notify({ idProperty: 'id', itemCount: 1 });
+
+      setTimeout(() => {
+        expect(resizeContentSpy).toHaveBeenCalledWith(true);
+        done();
+      }, 10);
+    });
   });
 });

--- a/src/app/modules/angular-slickgrid/components/__tests__/slick-vanilla-utilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/slick-vanilla-utilities.spec.ts
@@ -1,0 +1,36 @@
+import { Column, Editors, Formatter, Formatters } from '@slickgrid-universal/common';
+import { autoAddEditorFormatterToColumnsWithEditor } from '../slick-vanilla-utilities';
+
+
+describe('Slick-Vanilla-Grid-Bundle / Utilies', () => {
+  describe('autoAddEditorFormatterToColumnsWithEditor', () => {
+    let columnDefinitions: Column[];
+    const customEditableInputFormatter: Formatter = (_row, _cell, value, columnDef) => {
+      const isEditableLine = !!columnDef.editor;
+      value = (value === null || value === undefined) ? '' : value;
+      return isEditableLine ? `<div class="editing-field">${value}</div>` : value;
+    };
+
+    beforeEach(() => {
+      columnDefinitions = [
+        { id: 'firstName', field: 'firstName', editor: { model: Editors.text } },
+        { id: 'lastName', field: 'lastName', editor: { model: Editors.text }, formatter: Formatters.multiple, params: { formatters: [Formatters.italic, Formatters.bold] } },
+        { id: 'age', field: 'age', type: 'number', formatter: Formatters.multiple },
+        { id: 'address', field: 'address.street', editor: { model: Editors.longText }, formatter: Formatters.complexObject },
+        { id: 'zip', field: 'address.zip', type: 'number', formatter: Formatters.complexObject },
+      ];
+    });
+
+    it('should have custom editor formatter with correct structure', () => {
+      autoAddEditorFormatterToColumnsWithEditor(columnDefinitions, customEditableInputFormatter);
+
+      expect(columnDefinitions).toEqual([
+        { id: 'firstName', field: 'firstName', editor: { model: Editors.text }, formatter: customEditableInputFormatter },
+        { id: 'lastName', field: 'lastName', editor: { model: Editors.text }, formatter: Formatters.multiple, params: { formatters: [Formatters.italic, Formatters.bold, customEditableInputFormatter] } },
+        { id: 'age', field: 'age', type: 'number', formatter: Formatters.multiple },
+        { id: 'address', field: 'address.street', editor: { model: Editors.longText }, formatter: Formatters.multiple, params: { formatters: [Formatters.complexObject, customEditableInputFormatter] } },
+        { id: 'zip', field: 'address.zip', type: 'number', formatter: Formatters.complexObject },
+      ]);
+    });
+  });
+});

--- a/src/app/modules/angular-slickgrid/components/__tests__/slick-vanilla-utilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/slick-vanilla-utilities.spec.ts
@@ -1,4 +1,6 @@
-import { Column, Editors, Formatter, Formatters } from '@slickgrid-universal/common';
+import { Editors } from '../../editors/editors.index';
+import { Formatters } from '../../formatters/formatters.index';
+import { Column, FieldType, Formatter } from '../../models/index';
 import { autoAddEditorFormatterToColumnsWithEditor } from '../slick-vanilla-utilities';
 
 
@@ -15,9 +17,9 @@ describe('Slick-Vanilla-Grid-Bundle / Utilies', () => {
       columnDefinitions = [
         { id: 'firstName', field: 'firstName', editor: { model: Editors.text } },
         { id: 'lastName', field: 'lastName', editor: { model: Editors.text }, formatter: Formatters.multiple, params: { formatters: [Formatters.italic, Formatters.bold] } },
-        { id: 'age', field: 'age', type: 'number', formatter: Formatters.multiple },
+        { id: 'age', field: 'age', type: FieldType.number, formatter: Formatters.multiple },
         { id: 'address', field: 'address.street', editor: { model: Editors.longText }, formatter: Formatters.complexObject },
-        { id: 'zip', field: 'address.zip', type: 'number', formatter: Formatters.complexObject },
+        { id: 'zip', field: 'address.zip', type: FieldType.number, formatter: Formatters.complexObject },
       ];
     });
 
@@ -27,9 +29,9 @@ describe('Slick-Vanilla-Grid-Bundle / Utilies', () => {
       expect(columnDefinitions).toEqual([
         { id: 'firstName', field: 'firstName', editor: { model: Editors.text }, formatter: customEditableInputFormatter },
         { id: 'lastName', field: 'lastName', editor: { model: Editors.text }, formatter: Formatters.multiple, params: { formatters: [Formatters.italic, Formatters.bold, customEditableInputFormatter] } },
-        { id: 'age', field: 'age', type: 'number', formatter: Formatters.multiple },
+        { id: 'age', field: 'age', type: FieldType.number, formatter: Formatters.multiple },
         { id: 'address', field: 'address.street', editor: { model: Editors.longText }, formatter: Formatters.multiple, params: { formatters: [Formatters.complexObject, customEditableInputFormatter] } },
-        { id: 'zip', field: 'address.zip', type: 'number', formatter: Formatters.complexObject },
+        { id: 'zip', field: 'address.zip', type: FieldType.number, formatter: Formatters.complexObject },
       ]);
     });
   });

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -769,7 +769,7 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy, OnIn
 
   private bindResizeHook(grid: any, options: GridOption) {
     if ((options.autoFitColumnsOnFirstLoad && options.autosizeColumnsByCellContentOnFirstLoad) || (options.enableAutoSizeColumns && options.enableAutoResizeColumnsByCellContent)) {
-      throw new Error(`You cannot enable both autosize/fit viewport & resize by content, you must choose which resize technique to use. You can enable these 2 options ("autoFitColumnsOnFirstLoad" and "enableAutoSizeColumns") OR these other 2 options ("autosizeColumnsByCellContentOnFirstLoad" and "enableAutoResizeColumnsByCellContent").`);
+      throw new Error(`[Angular-Slickgrid] You cannot enable both autosize/fit viewport & resize by content, you must choose which resize technique to use. You can enable these 2 options ("autoFitColumnsOnFirstLoad" and "enableAutoSizeColumns") OR these other 2 options ("autosizeColumnsByCellContentOnFirstLoad" and "enableAutoResizeColumnsByCellContent").`);
     }
 
     // expand/autofit columns on first page load

--- a/src/app/modules/angular-slickgrid/components/slick-vanilla-utilities.ts
+++ b/src/app/modules/angular-slickgrid/components/slick-vanilla-utilities.ts
@@ -1,0 +1,26 @@
+import { Formatters } from '../formatters/index';
+import { Column, Formatter } from '../models/index';
+
+/**
+ * Automatically add a Custom Formatter on all column definitions that have an Editor.
+ * Instead of manually adding a Custom Formatter on every column definitions that are editables, let's ask the system to do it in an easier automated way.
+ * It will loop through all column definitions and add an Custom Editor Formatter when necessary,
+ * also note that if there's already a Formatter on the column definition it will automatically use the Formatters.multiple and add the custom formatter into the `params: formatters: {}}`
+ */
+export function autoAddEditorFormatterToColumnsWithEditor(columnDefinitions: Column[], customEditableFormatter: Formatter) {
+  if (Array.isArray(columnDefinitions)) {
+    for (const columnDef of columnDefinitions) {
+      if (columnDef.editor) {
+        if (columnDef.formatter && columnDef.formatter !== Formatters.multiple) {
+          const prevFormatter = columnDef.formatter;
+          columnDef.formatter = Formatters.multiple;
+          columnDef.params = { ...columnDef.params, formatters: [prevFormatter, customEditableFormatter] };
+        } else if (columnDef.formatter && columnDef.formatter === Formatters.multiple && columnDef.params) {
+          columnDef.params.formatters = [...columnDef.params.formatters, customEditableFormatter];
+        } else {
+          columnDef.formatter = customEditableFormatter;
+        }
+      }
+    }
+  }
+}

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/checkboxSelectorExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/checkboxSelectorExtension.spec.ts
@@ -46,7 +46,7 @@ describe('checkboxSelectorExtension', () => {
   });
 
   it('should return null after calling "create" method when either the column definitions or the grid options is missing', () => {
-    const output = extension.create([] as Column[], null);
+    const output = extension.create([] as Column[], null as any);
     expect(output).toBeNull();
   });
 
@@ -115,7 +115,7 @@ describe('checkboxSelectorExtension', () => {
     it('should provide addon options and expect them to be called in the addon constructor', () => {
       const optionMock = { selectActiveRow: true };
       const selectionModelOptions = { ...gridOptionsMock, rowSelectionOptions: optionMock };
-      const selectionColumn = { ...columnSelectionMock, excludeFromExport: true, excludeFromColumnPicker: true, excludeFromGridMenu: true, excludeFromQuery: true, excludeFromHeaderMenu: true };
+      const selectionColumn = { ...columnSelectionMock, excludeFromExport: true, excludeFromColumnPicker: true, excludeFromGridMenu: true, excludeFromQuery: true, excludeFromHeaderMenu: true, maxWidth: 30 };
       jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(selectionModelOptions);
 
       // we can only spy after 1st "create" call, we'll only get a valid selectionColumn on 2nd "create" call
@@ -130,7 +130,7 @@ describe('checkboxSelectorExtension', () => {
       expect(mockSelectionModel).toHaveBeenCalledWith(optionMock);
       expect(columnsMock[0]).toEqual(selectionColumn);
       expect(columnsMock).toEqual([
-        { excludeFromColumnPicker: true, excludeFromExport: true, excludeFromGridMenu: true, excludeFromHeaderMenu: true, excludeFromQuery: true, field: 'sel', id: '_checkbox_selector', },
+        { excludeFromColumnPicker: true, excludeFromExport: true, excludeFromGridMenu: true, excludeFromHeaderMenu: true, excludeFromQuery: true, maxWidth: 30, field: 'sel', id: '_checkbox_selector', },
         { cssClass: 'red', field: 'field1', id: 'field1', width: 100, },
         { field: 'field2', id: 'field2', width: 50, }
       ]);
@@ -140,7 +140,7 @@ describe('checkboxSelectorExtension', () => {
       const rowSelectionOptionMock = { selectActiveRow: true };
       gridOptionsMock.checkboxSelector = { columnIndexPosition: 2, };
       const selectionModelOptions = { ...gridOptionsMock, rowSelectionOptions: rowSelectionOptionMock };
-      const selectionColumn = { ...columnSelectionMock, excludeFromExport: true, excludeFromColumnPicker: true, excludeFromGridMenu: true, excludeFromQuery: true, excludeFromHeaderMenu: true };
+      const selectionColumn = { ...columnSelectionMock, excludeFromExport: true, excludeFromColumnPicker: true, excludeFromGridMenu: true, excludeFromQuery: true, excludeFromHeaderMenu: true, maxWidth: 30 };
       jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(selectionModelOptions);
 
       // we can only spy after 1st "create" call, we'll only get a valid selectionColumn on 2nd "create" call
@@ -157,7 +157,7 @@ describe('checkboxSelectorExtension', () => {
       expect(columnsMock).toEqual([
         { cssClass: 'red', field: 'field1', id: 'field1', width: 100, },
         { field: 'field2', id: 'field2', width: 50, },
-        { excludeFromColumnPicker: true, excludeFromExport: true, excludeFromGridMenu: true, excludeFromHeaderMenu: true, excludeFromQuery: true, field: 'sel', id: '_checkbox_selector', },
+        { excludeFromColumnPicker: true, excludeFromExport: true, excludeFromGridMenu: true, excludeFromHeaderMenu: true, excludeFromQuery: true, maxWidth: 30, field: 'sel', id: '_checkbox_selector', },
       ]);
     });
 

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
@@ -303,6 +303,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should call internal event handler subscribe and expect the "onMenuClose" option to be called when addon notify is called', () => {
+        jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
         const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
         const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onAfterMenuShow');
@@ -349,6 +350,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should call "autosizeColumns" method when the "onMenuClose" event was triggered and the columns are different', () => {
+        jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
         const onColumnSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onColumnsChanged');
         const onCloseSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onMenuClose');
@@ -607,6 +609,10 @@ describe('gridMenuExtension', () => {
     });
 
     describe('executeGridMenuInternalCustomCommands method', () => {
+      beforeEach(() => {
+        jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      });
+
       afterEach(() => {
         jest.clearAllMocks();
         extension.eventHandler.unsubscribeAll();

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
@@ -154,7 +154,7 @@ describe('headerMenuExtension', () => {
 
       it('should register the addon', () => {
         const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'registerPlugin');
-        const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onExtensionRegistered');
+        const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onExtensionRegistered');
 
         const instance = extension.register();
         const addonInstance = extension.getAddonInstance();
@@ -181,9 +181,9 @@ describe('headerMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onBeforeMenuShow" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onBeforeMenuShow');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onBeforeMenuShow');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
 
         const instance = extension.register();
         instance.onBeforeMenuShow.notify({ grid: gridStub, menu: {} }, new Slick.EventData(), gridStub);
@@ -200,9 +200,9 @@ describe('headerMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onAfterMenuShow" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onBeforeMenuShow');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onBeforeMenuShow');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
 
         const instance = extension.register();
         instance.onAfterMenuShow.notify({ grid: gridStub, menu: {} }, new Slick.EventData(), gridStub);
@@ -219,9 +219,9 @@ describe('headerMenuExtension', () => {
 
       it('should call internal event handler subscribe and expect the "onCommand" option to be called when addon notify is called', () => {
         const handlerSpy = jest.spyOn(extension.eventHandler, 'subscribe');
-        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onAfterMenuShow');
-        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onBeforeMenuShow');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onAfterSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onAfterMenuShow');
+        const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onBeforeMenuShow');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ grid: gridStub, command: 'help' }, new Slick.EventData(), gridStub);
@@ -303,8 +303,8 @@ describe('headerMenuExtension', () => {
 
       it('should expect only the "hide-column" command in the menu when "enableSorting" and "hideSortCommands" are set', () => {
         const copyGridOptionsMock = { ...gridOptionsMock, enableSorting: true } as unknown as GridOption;
-        copyGridOptionsMock.headerMenu.hideColumnHideCommand = false;
-        copyGridOptionsMock.headerMenu.hideSortCommands = true;
+        copyGridOptionsMock.headerMenu!.hideColumnHideCommand = false;
+        copyGridOptionsMock.headerMenu!.hideSortCommands = true;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
 
         extension.register();
@@ -435,10 +435,14 @@ describe('headerMenuExtension', () => {
     });
 
     describe('executeHeaderMenuInternalCommands method', () => {
+      beforeEach(() => {
+        jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      });
+
       it('should trigger the command "freeze-columns" and grid "setOptions" method to be called with current column position', () => {
         const setOptionsSpy = jest.spyOn(gridStub, 'setOptions');
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ column: columnsMock[0], grid: gridStub, command: 'freeze-columns' }, new Slick.EventData(), gridStub);
@@ -451,7 +455,7 @@ describe('headerMenuExtension', () => {
       it('should trigger the command "freeze-columns" and grid "setOptions" method to be called with frozen column of -1 because the column found is not visible', () => {
         const setOptionsSpy = jest.spyOn(gridStub, 'setOptions');
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ column: columnsMock[1], grid: gridStub, command: 'freeze-columns' }, new Slick.EventData(), gridStub);
@@ -462,7 +466,7 @@ describe('headerMenuExtension', () => {
       });
 
       it('should trigger the command "hide" and expect the grid "autosizeColumns" method being called', () => {
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
         const autosizeSpy = jest.spyOn(SharedService.prototype.grid, 'autosizeColumns');
 
         const instance = extension.register();
@@ -474,7 +478,7 @@ describe('headerMenuExtension', () => {
 
       it('should trigger the command "clear-filter" and expect "clearColumnFilter" method being called with dataview refresh', () => {
         const filterSpy = jest.spyOn(filterServiceStub, 'clearFilterByColumnId');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ column: columnsMock[0], grid: gridStub, command: 'clear-filter' }, new Slick.EventData(), gridStub);
@@ -485,7 +489,7 @@ describe('headerMenuExtension', () => {
 
       it('should trigger the command "clear-sort" and expect "clearSortByColumnId" being called with event and column id', () => {
         const clearSortSpy = jest.spyOn(sortServiceStub, 'clearSortByColumnId');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
 
         const instance = extension.register();
         instance.onCommand.notify({ column: columnsMock[0], grid: gridStub, command: 'clear-sort' }, new Slick.EventData(), gridStub);
@@ -500,7 +504,7 @@ describe('headerMenuExtension', () => {
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: true, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = jest.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
         const backendSortSpy = jest.spyOn(sortServiceStub, 'onBackendSortChanged');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
         const setSortSpy = jest.spyOn(SharedService.prototype.grid, 'setSortColumns');
 
         const instance = extension.register();
@@ -518,7 +522,7 @@ describe('headerMenuExtension', () => {
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = jest.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
         const backendSortSpy = jest.spyOn(sortServiceStub, 'onBackendSortChanged');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
         const setSortSpy = jest.spyOn(SharedService.prototype.grid, 'setSortColumns');
 
         const instance = extension.register();
@@ -538,7 +542,7 @@ describe('headerMenuExtension', () => {
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = jest.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
         const localSortSpy = jest.spyOn(sortServiceStub, 'onLocalSortChanged');
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
         const setSortSpy = jest.spyOn(SharedService.prototype.grid, 'setSortColumns');
 
         const instance = extension.register();
@@ -557,7 +561,7 @@ describe('headerMenuExtension', () => {
         const mockSortedCols: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: true, sortCol: { id: 'field2', field: 'field2' } }];
         const mockSortedOuput: ColumnSort[] = [{ columnId: 'field1', sortAsc: true, sortCol: { id: 'field1', field: 'field1' } }, { columnId: 'field2', sortAsc: false, sortCol: { id: 'field2', field: 'field2' } }];
         const previousSortSpy = jest.spyOn(sortServiceStub, 'getCurrentColumnSorts').mockReturnValue([mockSortedCols[0]]);
-        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onCommand');
+        const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu!, 'onCommand');
         const setSortSpy = jest.spyOn(SharedService.prototype.grid, 'setSortColumns');
         const gridSortSpy = jest.spyOn(gridStub.onSort, 'notify');
 
@@ -574,7 +578,7 @@ describe('headerMenuExtension', () => {
 
   describe('without ngx-translate', () => {
     beforeEach(() => {
-      translate = null;
+      translate = null as any;
       extension = new HeaderMenuExtension({} as ExtensionUtility, {} as FilterService, { gridOptions: { enableTranslate: true } } as SharedService, {} as SortService, translate);
     });
 

--- a/src/app/modules/angular-slickgrid/extensions/checkboxSelectorExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/checkboxSelectorExtension.ts
@@ -34,20 +34,21 @@ export class CheckboxSelectorExtension implements Extension {
       if (!this._addon) {
         this._addon = new Slick.CheckboxSelectColumn(gridOptions.checkboxSelector || {});
       }
-      const iconColumn: Column = this._addon.getColumnDefinition();
-      if (typeof iconColumn === 'object') {
-        iconColumn.excludeFromExport = true;
-        iconColumn.excludeFromColumnPicker = true;
-        iconColumn.excludeFromGridMenu = true;
-        iconColumn.excludeFromQuery = true;
-        iconColumn.excludeFromHeaderMenu = true;
+      const selectionColumn: Column = this._addon.getColumnDefinition();
+      if (typeof selectionColumn === 'object') {
+        selectionColumn.excludeFromExport = true;
+        selectionColumn.excludeFromColumnPicker = true;
+        selectionColumn.excludeFromGridMenu = true;
+        selectionColumn.excludeFromQuery = true;
+        selectionColumn.excludeFromHeaderMenu = true;
+        selectionColumn.maxWidth = selectionColumn.width || 30;
 
         // column index position in the grid
         const columnPosition = gridOptions && gridOptions.checkboxSelector && gridOptions.checkboxSelector.columnIndexPosition || 0;
         if (columnPosition > 0) {
-          columnDefinitions.splice(columnPosition, 0, iconColumn);
+          columnDefinitions.splice(columnPosition, 0, selectionColumn);
         } else {
-          columnDefinitions.unshift(iconColumn);
+          columnDefinitions.unshift(selectionColumn);
         }
       }
       return this._addon;

--- a/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
@@ -148,7 +148,8 @@ export class GridMenuExtension implements Extension {
             // make sure that the grid still exist (by looking if the Grid UID is found in the DOM tree)
             const gridUid = this.sharedService.grid.getUID();
             if (this._areVisibleColumnDifferent && gridUid && document.querySelector(`.${gridUid}`) !== null) {
-              if (this.sharedService.gridOptions && this.sharedService.gridOptions.enableAutoSizeColumns) {
+              const gridOptions = this.sharedService.grid.getOptions();
+              if (gridOptions.enableAutoSizeColumns) {
                 this.sharedService.grid.autosizeColumns();
               }
               this._areVisibleColumnDifferent = false;
@@ -399,7 +400,8 @@ export class GridMenuExtension implements Extension {
           }
 
           // we also need to autosize columns if the option is enabled
-          if (this.sharedService.gridOptions.enableAutoSizeColumns) {
+          const gridOptions = this.sharedService.grid.getOptions();
+          if (gridOptions.enableAutoSizeColumns) {
             this.sharedService.grid.autosizeColumns();
           }
           break;

--- a/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/headerMenuExtension.ts
@@ -357,7 +357,8 @@ export class HeaderMenuExtension implements Extension {
           }
 
           // we also need to autosize columns if the option is enabled
-          if (this.sharedService.gridOptions.enableAutoSizeColumns) {
+          const gridOptions = this.sharedService.grid.getOptions();
+          if (gridOptions.enableAutoSizeColumns) {
             this.sharedService.grid.autosizeColumns();
           }
           break;

--- a/src/app/modules/angular-slickgrid/filter-conditions/filterConditionProcesses.ts
+++ b/src/app/modules/angular-slickgrid/filter-conditions/filterConditionProcesses.ts
@@ -11,7 +11,7 @@ import { isCollectionOperator } from './filterUtilities';
  * General variable types, just 5x types instead of the multiple FieldType.
  * For example all DateIso, DateUs are all "date", this makes it easier to know which filter condition to call
  */
-export type GeneralizedVariableType = 'boolean' | 'date' | 'number' | 'object' | 'text';
+export type GeneralVariableDataType = 'boolean' | 'date' | 'number' | 'object' | 'string';
 
 /** Execute mapped condition (per field type) for each cell in the grid */
 export const executeFilterConditionTest: FilterCondition = (options: FilterConditionOption, parsedSearchTerms?: SearchTerm | SearchTerm[]) => {
@@ -21,7 +21,7 @@ export const executeFilterConditionTest: FilterCondition = (options: FilterCondi
   }
 
   // From a more specific field type (dateIso, dateEuro, text, readonly, ...), get the more generalized type (boolean, date, number, object, text)
-  const generalizedType = getGeneralizedVarTypeByFieldType(options.filterSearchType || options.fieldType);
+  const generalizedType = getVarTypeOfByColumnFieldType(options.filterSearchType || options.fieldType);
 
   // execute the mapped type, or default to String condition check
   switch (generalizedType) {
@@ -35,7 +35,7 @@ export const executeFilterConditionTest: FilterCondition = (options: FilterCondi
     case 'object':
       // the parsedSearchTerms should be single value (result came from getFilterParsedObjectResult() method)
       return executeObjectFilterCondition(options, parsedSearchTerms as SearchTerm);
-    case 'text':
+    case 'string':
     default:
       // the parsedSearchTerms should be single value (result came from getFilterParsedText() method)
       return executeStringFilterCondition(options, (parsedSearchTerms || []) as string[]);
@@ -48,7 +48,7 @@ export const executeFilterConditionTest: FilterCondition = (options: FilterCondi
  * So this is called only once, for each search filter that is, prior to running the actual filter condition checks on each cell afterward.
  */
 export function getParsedSearchTermsByFieldType(inputSearchTerms: SearchTerm[] | undefined, inputFilterSearchType: typeof FieldType[keyof typeof FieldType]): SearchTerm | SearchTerm[] | undefined {
-  const generalizedType = getGeneralizedVarTypeByFieldType(inputFilterSearchType);
+  const generalizedType = getVarTypeOfByColumnFieldType(inputFilterSearchType);
   let parsedSearchValues: SearchTerm | SearchTerm[] | undefined;
 
   // parse the search value(s), the Date & Numbers could be in a range and so we will return an array for them
@@ -66,7 +66,7 @@ export function getParsedSearchTermsByFieldType(inputSearchTerms: SearchTerm[] |
     case 'object':
       parsedSearchValues = getFilterParsedObjectResult(inputSearchTerms);
       break;
-    case 'text':
+    case 'string':
       parsedSearchValues = getFilterParsedText(inputSearchTerms) as SearchTerm[];
       break;
   }
@@ -79,7 +79,7 @@ export function getParsedSearchTermsByFieldType(inputSearchTerms: SearchTerm[] |
  * @param fieldType - specific field type
  * @returns generalType - general field type
  */
-function getGeneralizedVarTypeByFieldType(fieldType: typeof FieldType[keyof typeof FieldType]): GeneralizedVariableType {
+export function getVarTypeOfByColumnFieldType(fieldType: typeof FieldType[keyof typeof FieldType]): GeneralVariableDataType {
   // return general field type
   switch (fieldType) {
     case FieldType.boolean:
@@ -122,6 +122,6 @@ function getGeneralizedVarTypeByFieldType(fieldType: typeof FieldType[keyof type
     case FieldType.password:
     case FieldType.readonly:
     default:
-      return 'text';
+      return 'string';
   }
 }

--- a/src/app/modules/angular-slickgrid/global-grid-options.ts
+++ b/src/app/modules/angular-slickgrid/global-grid-options.ts
@@ -195,6 +195,12 @@ export const GlobalGridOptions: Partial<GridOption> = {
   rowHeight: 35,
   topPanelHeight: 35,
   translationNamespaceSeparator: ':',
+  resizeAlwaysRecalculateColumnWidth: false,
+  resizeCellCharWidthInPx: 7.8,
+  resizeCellPaddingWidthInPx: 14,
+  resizeFormatterPaddingWidthInPx: 0,
+  resizeDefaultRatioForStringType: 0.88,
+  resizeMaxItemToInspectCellContentWidth: 1000,
 };
 
 /**

--- a/src/app/modules/angular-slickgrid/models/column.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/column.interface.ts
@@ -157,6 +157,14 @@ export interface Column<T = any> {
   /** Minimum Width of the column in pixels (number only). */
   minWidth?: number;
 
+  /**
+   * @reserved use internally by the lib, it will copy the `width` (when defined by the user) to this property for later reference.
+   * so that we know if it was provided by the user or by the lib.
+   * We do this because SlickGrid override the `width` with its own default width when nothing is provided.
+   * We will use this original width reference when resizing the columns widths, if it was provided by the user then we won't override it.
+   */
+  originalWidth?: number;
+
   /** Field Name to be displayed in the Grid (UI) */
   name?: string;
 
@@ -217,6 +225,30 @@ export interface Column<T = any> {
 
   /** Is the column resizable, can we make it wider/thinner? A resize cursor will show on the right side of the column when enabled. */
   resizable?: boolean;
+
+  /** defaults to false, if a column `width` is provided (or was previously calculated) should we recalculate it or not when resizing by cell content? */
+  resizeAlwaysRecalculateWidth?: boolean;
+
+  /**
+   * Defaults to 1, a column width ratio to use in the calculation when resizing columns by their cell content.
+   * We have this ratio number so that if we know that the cell content has lots of thin character (like 1, i, t, ...) we can lower the ratio to take up less space.
+   * In other words and depending on which font family you use, each character will have different width, characters like (i, t, 1) takes a lot less space compare to (W, H, Q),
+   * unless of course we use a monospace font family which will have the exact same size for each characters and in that case we leave it to 1 but that rarely happens.
+   * NOTE: the default ratio is 1, except for string where we use a ratio of around ~0.9 since we have more various thinner characters like (i, l, t, ...).
+   */
+  resizeCalcWidthRatio?: number;
+
+  /**
+   * no defaults, a character width to use when resizing columns by their cell content.
+   * If nothing is provided it will use `resizeCellCharWidthInPx` defined in the grid options.
+   */
+  resizeCharWidthInPx?: number;
+
+  /** no defaults, what is the column max width threshold to not go over when resizing columns by their cell content */
+  resizeMaxWidthThreshold?: number;
+
+  /** no defaults, what is optional extra width padding to add to the calculation when resizing columns by their cell content */
+  resizeExtraWidthPadding?: number;
 
   /** Do we want to re-render the grid on a grid resize */
   rerenderOnResize?: boolean;

--- a/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
@@ -16,6 +16,7 @@ import {
   ExcelCopyBufferOption,
   ExcelExportOption,
   ExportOption,
+  Formatter,
   FormatterOption,
   GridMenu,
   GridState,
@@ -50,14 +51,31 @@ export interface GridOption {
   /** Defaults to 40, which is the delay before the asynchronous post renderer start cleanup execution */
   asyncPostRenderCleanupDelay?: number;
 
+  /**
+   * Automatically add a Custom Formatter on all column definitions that have an Editor.
+   * Instead of manually adding a Custom Formatter on every column definitions that are editables, let's ask the system to do it in an easier automated way.
+   * It will loop through all column definitions and add an Custom Editor Formatter when necessary,
+   * also note that if there's already a Formatter on the column definition it will automatically use the Formatters.multiple and add the custom formatter into the `params: formatters: {}}`
+   */
+  autoAddCustomEditorFormatter?: Formatter;
+
   /** Defaults to false, when enabled will try to commit the current edit without focusing on the next row. If a custom editor is implemented and the grid cannot auto commit, you must use this option to implement it yourself */
   autoCommitEdit?: boolean;
 
   /** Defaults to false, when enabled will automatically open the inlined editor as soon as there is a focus on the cell (can be combined with "enableCellNavigation: true"). */
   autoEdit?: boolean;
 
-  /** Defaults to true, which leads to automatically adjust the size of each column with the available space. Similar to "Force Fit Column" but only happens on first page/component load. */
+  /**
+    * Defaults to true, which leads to automatically adjust the width of each column with the available space. Similar to "Force Fit Column" but only happens on first page/component load.
+    * If you wish this resize to also re-evaluate when resizing the browser, then you should also use `enableAutoSizeColumns` (it is also enabled by default)
+    */
   autoFitColumnsOnFirstLoad?: boolean;
+
+  /**
+   * Defaults to false, which leads to automatically adjust the width of each column by their cell value content and only on first page/component load.
+   * If you wish this resize to also re-evaluate when resizing the browser, then you should also use `enableAutoResizeColumnsByCellContent`
+   */
+  autosizeColumnsByCellContentOnFirstLoad?: boolean;
 
   /** Defaults to false, which leads to automatically adjust the size (height) of the grid to display the entire content without any scrolling in the grid. */
   autoHeight?: boolean;
@@ -196,6 +214,12 @@ export interface GridOption {
 
   /** Defaults to true, which will automatically resize the column headers whenever the grid size changes */
   enableAutoSizeColumns?: boolean;
+
+  /**
+   * Defaults to false, which will automatically resize the column headers by their cell content whenever the grid size changes.
+   * NOTE: this option is opt-in and if you decide to use it then you should disable the other grid option `enableAutoSizeColumns: false`
+   */
+  enableAutoResizeColumnsByCellContent?: boolean;
 
   /** Defaults to false, which leads to showing tooltip over cell & header values that are not shown completely (... ellipsis) */
   enableAutoTooltip?: boolean;
@@ -410,6 +434,30 @@ export interface GridOption {
 
   /** Register 1 or more Slick Plugins */
   registerPlugins?: any | any[];
+
+  /** defaults to false, if a column `width` is provided (or was previously calculated) should we recalculate it or not when resizing by cell content? */
+  resizeAlwaysRecalculateColumnWidth?: boolean;
+
+  /**
+   * Defaults to 7, width in pixels of a string character which is used by the resize columns by its content, this can vary depending on which font family/size is used & cell padding.
+   * This is only used when resizing the columns width by their content, we need to know the width of a character in pixel to do all calculations.
+   */
+  resizeCellCharWidthInPx?: number;
+
+  /** Defaults to 6, cell padding width to add to the calculation when resizing columns by their cell text content. */
+  resizeCellPaddingWidthInPx?: number;
+
+  /** Defaults to around ~0.9, what is the ratio to use (on field `type` "string" only) in the calculation when resizing columns by their cell text content. */
+  resizeDefaultRatioForStringType?: number;
+
+  /** Defaults to 6, padding width to add to the calculation when using a Formatter and resizing columns by their cell text content. */
+  resizeFormatterPaddingWidthInPx?: number;
+
+  /**
+   * Defaults to 1000, width in pixels of a string character which is used by the resize columns by its content, this can vary depending on which font family/size is used & cell padding.
+   * This is only used when resizing the columns width by their content, we need to know the width of a character in pixel to do all calculations.
+   */
+  resizeMaxItemToInspectCellContentWidth?: number;
 
   /** Row Detail View Plugin options & events (columnId, cssClass, toolTip, width) */
   rowDetailView?: RowDetailView;

--- a/src/app/modules/angular-slickgrid/models/slickGrid.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/slickGrid.interface.ts
@@ -319,6 +319,12 @@ export interface SlickGrid {
    */
   removeCellCssStyles(key: string): void;
 
+  /**
+   * Apply Columns Widths in the UI and optionally invalidate & re-render the columns when specified
+   * @param {Boolean} shouldReRender - should we invalidate and re-render the grid?
+   */
+  reRenderColumns(shouldReRender: boolean): void;
+
   /**  Resets active cell. */
   resetActiveCell(): void;
 

--- a/src/app/modules/angular-slickgrid/services/__tests__/grid.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/grid.service.spec.ts
@@ -971,7 +971,7 @@ describe('Grid Service', () => {
 
       service.setPinning(mockPinning);
 
-      expect(setOptionsSpy).toHaveBeenCalledWith(mockPinning);
+      expect(setOptionsSpy).toHaveBeenCalledWith(mockPinning, false, true);
       expect(gridOptionSetterSpy).toHaveBeenCalledWith(mockPinning);
       expect(autosizeColumnsSpy).toHaveBeenCalled();
     });
@@ -985,7 +985,7 @@ describe('Grid Service', () => {
 
       service.setPinning(mockPinning, false);
 
-      expect(setOptionsSpy).toHaveBeenCalledWith(mockPinning);
+      expect(setOptionsSpy).toHaveBeenCalledWith(mockPinning, false, true);
       expect(gridOptionSetterSpy).toHaveBeenCalledWith(mockPinning);
       expect(autosizeColumnsSpy).not.toHaveBeenCalled();
     });

--- a/src/app/modules/angular-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
@@ -46,6 +46,7 @@ const gridStub = {
   getPreHeaderPanelRight: jest.fn(),
   getSortColumns: jest.fn(),
   invalidate: jest.fn(),
+  onAutosizeColumns: new Slick.Event(),
   onColumnsResized: new Slick.Event(),
   onColumnsReordered: new Slick.Event(),
   onRendered: new Slick.Event(),
@@ -182,6 +183,18 @@ describe('GroupingAndColspanService', () => {
 
       service.init(gridStub, dataViewStub);
       gridStub.onSort.notify({ impactedColumns: mockColumns }, new Slick.EventData(), gridStub);
+      jest.runAllTimers(); // fast-forward timer
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 50);
+    });
+
+    it('should call the "renderPreHeaderRowGroupingTitles" after triggering a grid "onAutosizeColumns"', () => {
+      const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
+
+      service.init(gridStub, dataViewStub);
+      gridStub.onAutosizeColumns.notify({ columns: [], grid: gridStub }, new Slick.EventData(), gridStub);
       jest.runAllTimers(); // fast-forward timer
 
       expect(spy).toHaveBeenCalledTimes(2);

--- a/src/app/modules/angular-slickgrid/services/grid.service.ts
+++ b/src/app/modules/angular-slickgrid/services/grid.service.ts
@@ -86,11 +86,13 @@ export class GridService {
 
   /**
    * Set pinning (frozen) grid options
-   * @param pinningOptions - which pinning/frozen options to modify
-   * @param shouldAutosizeColumns - defaults to True, should we call an autosizeColumns after the pinning is done?
+   * @param  {Object} pinningOptions - which pinning/frozen options to modify
+   * @param {Boolean} shouldAutosizeColumns - defaults to True, should we call an autosizeColumns after the pinning is done?
+   * @param {Boolean} suppressRender - do we want to supress the grid re-rendering? (defaults to false)
+   * @param {Boolean} suppressColumnSet - do we want to supress the columns set, via "setColumns()" method? (defaults to false)
    */
-  setPinning(pinningOptions: CurrentPinning, shouldAutosizeColumns = true) {
-    this.sharedService.grid.setOptions(pinningOptions);
+  setPinning(pinningOptions: CurrentPinning, shouldAutosizeColumns = true, suppressRender = false, suppressColumnSet = true) {
+    this.sharedService.grid.setOptions(pinningOptions, suppressRender, suppressColumnSet);
     this.sharedService.gridOptions = { ...this.sharedService.gridOptions, ...pinningOptions };
 
     if (shouldAutosizeColumns) {

--- a/src/app/modules/angular-slickgrid/services/gridState.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridState.service.ts
@@ -169,6 +169,10 @@ export class GridStateService {
           }
         }
 
+        // keep copy the original optional `width` properties optionally provided by the user.
+        // We will use this when doing a resize by cell content, if user provided a `width` it won't override it.
+        gridColumns.forEach(col => col.originalWidth = col.width || col.originalWidth);
+
         // finally set the new presets columns (including checkbox selector if need be)
         this._grid.setColumns(gridColumns);
 
@@ -327,6 +331,7 @@ export class GridStateService {
    */
   resetToOriginalColumns(triggerAutoSizeColumns = true) {
     this._grid.setColumns(this.sharedService.allColumns);
+    this.sharedService.visibleColumns = this.sharedService.allColumns;
 
     // resize the columns to fit the grid canvas
     if (triggerAutoSizeColumns) {

--- a/src/app/modules/angular-slickgrid/services/gridState.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridState.service.ts
@@ -175,6 +175,7 @@ export class GridStateService {
 
         // finally set the new presets columns (including checkbox selector if need be)
         this._grid.setColumns(gridColumns);
+        this.sharedService.visibleColumns = gridColumns;
 
         // resize the columns to fit the grid canvas
         if (triggerAutoSizeColumns) {

--- a/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
+++ b/src/app/modules/angular-slickgrid/services/groupingAndColspan.service.ts
@@ -49,6 +49,7 @@ export class GroupingAndColspanService {
         // on all following events, call the
         this._eventHandler.subscribe(grid.onSort, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(grid.onRendered, () => this.renderPreHeaderRowGroupingTitles());
+        this._eventHandler.subscribe(grid.onAutosizeColumns, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(grid.onColumnsResized, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(grid.onColumnsReordered, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(dataView.onRowCountChanged, () => this.renderPreHeaderRowGroupingTitles());

--- a/src/app/modules/angular-slickgrid/services/resizer.service.ts
+++ b/src/app/modules/angular-slickgrid/services/resizer.service.ts
@@ -237,12 +237,10 @@ export class ResizerService {
         if (this._gridUid && $(`.${this._gridUid}`).length > 0) {
           this._grid.autosizeColumns();
         }
-      } else if (this._gridOptions.enableAutoResizeColumnsByCellContent && this._lastDimensions?.width && newWidth !== this._lastDimensions?.width) {
+      } else if (this._gridOptions.enableAutoResizeColumnsByCellContent && (!this._lastDimensions?.width || newWidth !== this._lastDimensions?.width)) {
         // we can call our resize by content here (when enabled)
         // since the core Slick.Resizer plugin only supports the "autosizeColumns"
-        if (this._gridOptions.enableAutoResizeColumnsByCellContent && this._lastDimensions?.width && newWidth !== this._lastDimensions?.width) {
-          this.resizeColumnsByCellContent();
-        }
+        this.resizeColumnsByCellContent();
       }
 
       // keep last resized dimensions & resolve them to the Promise
@@ -278,17 +276,17 @@ export class ResizerService {
     }
 
     // read a few optional resize by content grid options
-    const resizeCellCharWidthInPx = this._gridOptions.resizeCellCharWidthInPx || 7; // width in pixels of a string character, this can vary depending on which font family/size is used & cell padding
-    const resizeCellPaddingWidthInPx = this._gridOptions.resizeCellPaddingWidthInPx || 6;
-    const resizeFormatterPaddingWidthInPx = this._gridOptions.resizeFormatterPaddingWidthInPx || 6;
-    const resizeMaxItemToInspectCellContentWidth = this._gridOptions.resizeMaxItemToInspectCellContentWidth || 1000; // how many items do we want to analyze cell content with widest width
+    const resizeCellCharWidthInPx = this._gridOptions.resizeCellCharWidthInPx ?? 7; // width in pixels of a string character, this can vary depending on which font family/size is used & cell padding
+    const resizeCellPaddingWidthInPx = this._gridOptions.resizeCellPaddingWidthInPx ?? 6;
+    const resizeFormatterPaddingWidthInPx = this._gridOptions.resizeFormatterPaddingWidthInPx ?? 6;
+    const resizeMaxItemToInspectCellContentWidth = this._gridOptions.resizeMaxItemToInspectCellContentWidth ?? 1000; // how many items do we want to analyze cell content with widest width
 
     // calculate total width necessary by each cell content
     // we won't re-evaluate if we already had calculated the total
     if (this._totalColumnsWidthByContent === 0 || recalculateColumnsTotalWidth) {
       // loop through all columns to get their minWidth or width for later usage
       for (const columnDef of columnDefinitions) {
-        columnWidths[columnDef.id] = columnDef.originalWidth || columnDef.minWidth || 0;
+        columnWidths[columnDef.id] = columnDef.originalWidth ?? columnDef.minWidth ?? 0;
       }
 
       // loop through the entire dataset (limit to first 1000 rows), and evaluate the width by its content

--- a/src/app/modules/angular-slickgrid/services/resizer.service.ts
+++ b/src/app/modules/angular-slickgrid/services/resizer.service.ts
@@ -291,9 +291,9 @@ export class ResizerService {
 
       // loop through the entire dataset (limit to first 1000 rows), and evaluate the width by its content
       // if we have a Formatter, we will also potentially add padding
-      for (const [rowIdx, item] of dataset.entries()) {
+      dataset.every((item: any, rowIdx: number) => {
         if (rowIdx > resizeMaxItemToInspectCellContentWidth) {
-          break;
+          return false;
         }
         columnDefinitions.forEach((columnDef, colIdx) => {
           if (!columnDef.originalWidth) {
@@ -310,7 +310,8 @@ export class ResizerService {
             }
           }
         });
-      }
+        return true;
+      });
 
       // finally loop through all column definitions one last time to apply new calculated `width` on each elligible column
       let totalColsWidth = 0;

--- a/test/cypress/integration/example30.spec.js
+++ b/test/cypress/integration/example30.spec.js
@@ -1,0 +1,56 @@
+/// <reference types="cypress" />
+
+describe('Example 30 - Columns Resize by Content', () => {
+  const titles = ['', 'Title', 'Duration', 'Cost', '% Complete', 'Complexity', 'Start', 'Completed', 'Finish', 'Product', 'Country of Origin', 'Action'];
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/resize-by-content`);
+    cy.get('h2').should('contain', 'Example 30: Columns Resize by Content');
+  });
+
+  it('should have cell that fit the text content', () => {
+    cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('be.gt', 75);
+    cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('be.gt', 67);
+    cy.get('.slick-row').find('.slick-cell:nth(3)').invoke('width').should('be.gt', 59);
+    cy.get('.slick-row').find('.slick-cell:nth(4)').invoke('width').should('be.gt', 102);
+    cy.get('.slick-row').find('.slick-cell:nth(5)').invoke('width').should('be.gt', 89);
+    cy.get('.slick-row').find('.slick-cell:nth(6)').invoke('width').should('be.gt', 72);
+    cy.get('.slick-row').find('.slick-cell:nth(7)').invoke('width').should('be.gt', 67);
+    cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
+    cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
+    cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
+    cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+  });
+
+  it('should make the grid readonly and expect to fit the text by content and expect column width to be the same as earlier', () => {
+    cy.get('[data-test="toggle-readonly-btn"]').click();
+
+    cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('be.gt', 75);
+    cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('be.gt', 67);
+    cy.get('.slick-row').find('.slick-cell:nth(3)').invoke('width').should('be.gt', 59);
+    cy.get('.slick-row').find('.slick-cell:nth(4)').invoke('width').should('be.gt', 102);
+    cy.get('.slick-row').find('.slick-cell:nth(5)').invoke('width').should('be.gt', 89);
+    cy.get('.slick-row').find('.slick-cell:nth(6)').invoke('width').should('be.gt', 72);
+    cy.get('.slick-row').find('.slick-cell:nth(7)').invoke('width').should('be.gt', 67);
+    cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.gt', 72);
+    cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.gt', 179);
+    cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.gt', 94);
+    cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+  });
+
+  it('should click on (default resize "autosizeColumns") and expect column to be much thinner and fit all its column within the grid container', () => {
+    cy.get('[data-text="autosize-columns-btn"]').click();
+
+    cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('be.lt', 75);
+    cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('be.lt', 95);
+    cy.get('.slick-row').find('.slick-cell:nth(3)').invoke('width').should('be.lt', 70);
+    cy.get('.slick-row').find('.slick-cell:nth(4)').invoke('width').should('be.lt', 100);
+    cy.get('.slick-row').find('.slick-cell:nth(5)').invoke('width').should('be.lt', 100);
+    cy.get('.slick-row').find('.slick-cell:nth(6)').invoke('width').should('be.lt', 85);
+    cy.get('.slick-row').find('.slick-cell:nth(7)').invoke('width').should('be.lt', 70);
+    cy.get('.slick-row').find('.slick-cell:nth(8)').invoke('width').should('be.lt', 85);
+    cy.get('.slick-row').find('.slick-cell:nth(9)').invoke('width').should('be.lt', 120);
+    cy.get('.slick-row').find('.slick-cell:nth(10)').invoke('width').should('be.lt', 100);
+    cy.get('.slick-row').find('.slick-cell:nth(11)').invoke('width').should('equal', 58);
+  });
+});


### PR DESCRIPTION
- a quick description of the problem, by default the auto-resize will call the `grid.autosizeColumns()` which will try to find all columns in the grid viewport and that works ok with a small grid but as soon as we have many columns, it starts to wrap many words (with ellipsis) and some user might prefer to resize the column by the cell content (to match the content width with the cell width) and that might mean going wider than the grid viewport.
- so this will be an opt-in feature since it will loop through the entire dataset (by default it will read no more than the first 1000 rows) and find/calculate the width it needs to show the entire text value without word being wrapped, in some cases when having many columns it might make the grid wider than the viewport (in that case the horizontal scroll will appear)

#### TODOs
- [x] create POC code
- [x] add new method in Grid Service 
- [x] add grid option to choose which resize type to use (currently defaults to use only the `autosizeColumns`)
   - default should still always be to use `autosizeColumns` for performance reasons
- [x] add full unit tests coverage
- [x] add Cypress E2E tests