### PR TITLE
refactor: use bootstrap radio button group

### DIFF
--- a/src/app/examples/grid-resize-by-content.component.html
+++ b/src/app/examples/grid-resize-by-content.component.html
@@ -12,18 +12,24 @@
   <div class="subtitle" [innerHTML]="subTitle"></div>
 
   <h4 class="ml-3">Container Width (950px)</h4>
-  <div class="row">
 
+  <div class="row">
     <div class="ml-2 mb-2 mr-2">
-      <div class="btn-group btn-group-sm" role="group" aria-label="Basic Editing Commands">
-        <button class="btn btn-outline-secondary btn-sm" data-text="autosize-columns-btn"
-                (click)="handleDefaultResizeColumns()">
+      <div class="btn-group btn-group-toggle" data-toggle="buttons">
+        <label class="btn btn-sm btn-outline-secondary {{isUsingDefaultResize ? 'active' : ''}}"
+               data-test="autosize-columns-btn">
+          <input type="radio" name="options"
+                 [checked]="isUsingDefaultResize"
+                 (click)="handleDefaultResizeColumns()">
           <i class="fa fa-expand"></i> (default resize) by "autosizeColumns"
-        </button>
-        <button class="btn btn-outline-secondary btn-sm" data-text="resize-by-content-btn"
-                (click)="handleNewResizeColumns()">
+        </label>
+        <label class="btn btn-sm btn-outline-secondary {{isUsingDefaultResize ? '' : 'active'}}"
+               data-test="resize-by-content-btn">
+          <input type="radio" name="options"
+                 [checked]="!isUsingDefaultResize"
+                 (click)="handleNewResizeColumns()">
           <i class="fa fa-expand"></i> Resize by Cell Content
-        </button>
+        </label>
       </div>
     </div>
 

--- a/src/app/examples/grid-resize-by-content.component.ts
+++ b/src/app/examples/grid-resize-by-content.component.ts
@@ -62,6 +62,7 @@ export class GridResizeByContentComponent implements OnInit {
   dataset: any[] = [];
   editQueue: any[] = [];
   editedItems: any = {};
+  isUsingDefaultResize = false;
   isGridEditable = true;
   isCompositeDisabled = false;
   isMassSelectionDisabled = true;
@@ -463,10 +464,12 @@ export class GridResizeByContentComponent implements OnInit {
     columns.forEach(col => col.width = col.originalWidth);
     this.angularGrid.slickGrid.setColumns(columns);
     this.angularGrid.slickGrid.autosizeColumns();
+    this.isUsingDefaultResize = true;
   }
 
   handleNewResizeColumns() {
     this.angularGrid.resizerService.resizeColumnsByCellContent(true);
+    this.isUsingDefaultResize = false;
   }
 
   toggleGridEditReadonly() {

--- a/test/cypress/integration/example30.spec.js
+++ b/test/cypress/integration/example30.spec.js
@@ -39,7 +39,7 @@ describe('Example 30 - Columns Resize by Content', () => {
   });
 
   it('should click on (default resize "autosizeColumns") and expect column to be much thinner and fit all its column within the grid container', () => {
-    cy.get('[data-text="autosize-columns-btn"]').click();
+    cy.get('[data-test="autosize-columns-btn"]').click();
 
     cy.get('.slick-row').find('.slick-cell:nth(1)').invoke('width').should('be.lt', 75);
     cy.get('.slick-row').find('.slick-cell:nth(2)').invoke('width').should('be.lt', 95);


### PR DESCRIPTION
- a quick description of the problem, by default the auto-resize will call the `grid.autosizeColumns()` which will try to find all columns in the grid viewport and that works ok with a small grid but as soon as we have many columns, it starts to wrap many words (with ellipsis) and some user might prefer to resize the column by the cell content (to match the content width with the cell width) and that might mean going wider than the grid viewport.
- so this will be an opt-in feature since it will loop through the entire dataset (by default it will read no more than the first 1000 rows) and find/calculate the width it needs to show the entire text value without word being wrapped, in some cases when having many columns it might make the grid wider than the viewport (in that case the horizontal scroll will appear)

#### TODOs
- [x] create POC code
- [x] add new method in Grid Service 
- [x] add grid option to choose which resize type to use (currently defaults to use only the `autosizeColumns`)
   - default should still always be to use `autosizeColumns` for performance reasons
- [x] add full unit tests coverage
- [x] add Cypress E2E tests