### PR TITLE
fix(tree): couple of issues found in Tree Data

### DIFF
--- a/src/app/examples/grid-resize-by-content.component.ts
+++ b/src/app/examples/grid-resize-by-content.component.ts
@@ -54,7 +54,7 @@ const myCustomTitleValidator = (value: any, args: any) => {
 @Injectable()
 export class GridResizeByContentComponent implements OnInit {
   title = 'Example 30: Columns Resize by Content';
-  subTitle = `The grid below uses the optional resize by cell content (with a fixed 950px for demo purposes), you can click on the 2 buttons to see the difference. The "autosizeColumns" is really the default option used by SlickGrid-Universal, the resize by cell content is optional because it requires to read the first thousand rows and do extra width calculation.`;
+  subTitle = `The grid below uses the optional resize by cell content (with a fixed 950px for demo purposes), you can click on the 2 buttons to see the difference. The "autosizeColumns" is really the default option used by Angular-SlickGrid, the resize by cell content is optional because it requires to read the first thousand rows and do extra width calculation.`;
 
   angularGrid!: AngularGridInstance;
   gridOptions!: GridOption;

--- a/src/app/examples/grid-tree-data-hierarchical.component.html
+++ b/src/app/examples/grid-tree-data-hierarchical.component.html
@@ -26,10 +26,10 @@
         <span>Expand All</span>
       </button>
       <button (click)="logFlatStructure()" class="btn btn-outline-secondary btn-sm">
-        <span>Log Flag Structure</span>
+        <span>Log Flat Structure</span>
       </button>
-      <button (click)="logExpandedStructure()" class="btn btn-outline-secondary btn-sm">
-        <span>Log Expanded Structure</span>
+      <button (click)="logHierarchicalStructure()" class="btn btn-outline-secondary btn-sm">
+        <span>Log Hierarchical Structure</span>
       </button>
     </div>
 

--- a/src/app/examples/grid-tree-data-hierarchical.component.ts
+++ b/src/app/examples/grid-tree-data-hierarchical.component.ts
@@ -218,7 +218,7 @@ export class GridTreeDataHierarchicalComponent implements OnInit {
     this.angularGrid.treeDataService.toggleTreeDataCollapse(false);
   }
 
-  logExpandedStructure() {
+  logHierarchicalStructure() {
     console.log('exploded array', this.angularGrid.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
   }
 

--- a/src/app/examples/grid-tree-data-parent-child.component.html
+++ b/src/app/examples/grid-tree-data-parent-child.component.html
@@ -26,10 +26,10 @@
         <span>Expand All</span>
       </button>
       <button (click)="logFlatStructure()" class="btn btn-outline-secondary btn-sm">
-        <span>Log Flag Structure</span>
+        <span>Log Flat Structure</span>
       </button>
-      <button (click)="logExpandedStructure()" class="btn btn-outline-secondary btn-sm">
-        <span>Log Expanded Structure</span>
+      <button (click)="logHierarchicalStructure()" class="btn btn-outline-secondary btn-sm">
+        <span>Log Hierarchical Structure</span>
       </button>
     </div>
   </div>

--- a/src/app/examples/grid-tree-data-parent-child.component.ts
+++ b/src/app/examples/grid-tree-data-parent-child.component.ts
@@ -98,9 +98,16 @@ export class GridTreeDataParentChildComponent implements OnInit {
       enableTreeData: true, // you must enable this flag for the filtering & sorting to work as expected
       treeDataOptions: {
         columnId: 'title',
-        levelPropName: 'indent',
-        parentPropName: 'parentId'
+        levelPropName: 'indent', // this is optional, except that in our case we just need to define it because we are adding new item in the demo
+        parentPropName: 'parentId',
+
+        // you can optionally sort by a different column and/or sort direction
+        initialSort: {
+          columnId: 'title',
+          direction: 'ASC'
+        }
       },
+      showCustomFooter: true,
       multiColumnSort: false, // multi-column sorting is not supported with Tree Data, so you need to disable it
       // change header/cell row height for material design theme
       headerRowHeight: 45,
@@ -166,7 +173,7 @@ export class GridTreeDataParentChildComponent implements OnInit {
       parentId: parentItemFound.id,
       title: `Task ${newId}`,
       duration: '1 day',
-      percentComplete: Math.round(Math.random() * 100),
+      percentComplete: 99,
       start: new Date(),
       finish: new Date(),
       effortDriven: false
@@ -176,11 +183,7 @@ export class GridTreeDataParentChildComponent implements OnInit {
     this.dataset = [...dataset]; // make a copy to trigger a dataset refresh
 
     // add setTimeout to wait a full cycle because datasetChanged needs a full cycle
-    // force a resort because of the tree data structure
     setTimeout(() => {
-      const titleColumn = this.columnDefinitions.find(col => col.id === 'title') as Column;
-      this.angularGrid.sortService.onLocalSortChanged(this.gridObj, [{ columnId: 'title', sortCol: titleColumn, sortAsc: true }]);
-
       // scroll into the position, after insertion cycle, where the item was added
       const rowIndex = this.dataViewObj.getRowById(newItem.id);
       this.gridObj.scrollRowIntoView(rowIndex + 3);
@@ -195,7 +198,7 @@ export class GridTreeDataParentChildComponent implements OnInit {
     this.angularGrid.treeDataService.toggleTreeDataCollapse(false);
   }
 
-  logExpandedStructure() {
+  logHierarchicalStructure() {
     console.log('exploded array', this.angularGrid.treeDataService.datasetHierarchical /* , JSON.stringify(explodedArray, null, 2) */);
   }
 
@@ -232,8 +235,8 @@ export class GridTreeDataParentChildComponent implements OnInit {
       }
 
       d['id'] = i;
-      d['indent'] = indent;
       d['parentId'] = parentId;
+      d['indent'] = indent;
       d['title'] = 'Task ' + i;
       d['duration'] = '5 days';
       d['percentComplete'] = Math.round(Math.random() * 100);

--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -43,17 +43,8 @@ import {
   RowMoveManagerExtension,
   RowSelectionExtension,
 } from '../../extensions';
-import * as utilities from '../../services/utilities';
 
 declare const Slick: any;
-
-function removeExtraSpaces(text: string) {
-  return `${text}`.replace(/\s{2,}/g, '');
-}
-
-const mockConvertParentChildArray = jest.fn();
-// @ts-ignore
-utilities.convertParentChildArrayToHierarchicalView = mockConvertParentChildArray;
 
 const excelExportServiceStub = {
   init: jest.fn(),
@@ -123,7 +114,9 @@ const sortServiceStub = {
 } as unknown as SortService;
 
 const treeDataServiceStub = {
+  convertFlatDatasetConvertToHierarhicalView: jest.fn(),
   init: jest.fn(),
+  initializeHierarchicalDataset: jest.fn(),
   dispose: jest.fn(),
   handleOnCellClick: jest.fn(),
   toggleTreeDataCollapse: jest.fn(),
@@ -237,6 +230,7 @@ describe('App Component', () => {
   it('should convert parent/child dataset to hierarchical dataset when Tree Data is enabled and "onRowsChanged" was triggered', async (done) => {
     const mockFlatDataset = [{ id: 0, file: 'documents' }, { id: 1, file: 'vacation.txt', parentId: 0 }];
     const hierarchicalSpy = jest.spyOn(SharedService.prototype, 'hierarchicalDataset', 'set');
+    jest.spyOn(treeDataServiceStub, 'initializeHierarchicalDataset').mockReturnValue({ hierarchical: [], flat: mockFlatDataset });
 
     component.gridId = 'grid1';
     component.gridOptions = { enableTreeData: true, treeDataOptions: { columnId: 'file' } } as GridOption;
@@ -250,7 +244,6 @@ describe('App Component', () => {
 
     setTimeout(() => {
       expect(hierarchicalSpy).toHaveBeenCalled();
-      expect(mockConvertParentChildArray).toHaveBeenCalled();
       done();
     }, 51)
   });

--- a/src/app/modules/angular-slickgrid/models/autocompleteOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/autocompleteOption.interface.ts
@@ -70,8 +70,8 @@ export interface AutocompleteOption {
 
   /**
    * Triggered when a value is selected from the autocomplete list.
-   * NOTE: this method should NOT be used since Slickgrid-Universal will use it exclusively
-   * and if you do try to use it, what will happen is that it will override and break Slickgrid-Universal internal code.
+   * NOTE: this method should NOT be used since Angular-Slickgrid will use it exclusively
+   * and if you do try to use it, what will happen is that it will override and break Angular-Slickgrid internal code.
    * Please use the "onSelect" which was added specifically to avoid this problem but still provide exact same result
    */
   select?: (e: Event, ui: { item: any; }) => boolean;

--- a/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/sort.service.spec.ts
@@ -990,6 +990,7 @@ describe('SortService', () => {
         { sortAsc: false, sortCol: { id: 'file', field: 'file', width: 75 } }
       ];
 
+      sharedService.hierarchicalDataset = [];
       service.bindLocalOnSort(gridStub);
       gridStub.onSort.notify({ multiColumnSort: true, sortCols: mockSortedCols, grid: gridStub }, new Slick.EventData(), gridStub);
 
@@ -1015,6 +1016,7 @@ describe('SortService', () => {
         { sortAsc: false, sortCol: { id: 'file', field: 'file', width: 75 } }
       ];
 
+      sharedService.hierarchicalDataset = [];
       service.bindLocalOnSort(gridStub);
       gridStub.onSort.notify({ multiColumnSort: true, sortCols: mockSortedCols, grid: gridStub }, new Slick.EventData(), gridStub);
 

--- a/src/app/modules/angular-slickgrid/services/__tests__/treeData.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/treeData.service.spec.ts
@@ -1,10 +1,12 @@
 import { GridOption, SlickEventHandler, Column } from '../../models/index';
 import { SharedService } from '../shared.service';
+import { SortService } from '../sort.service';
 import { TreeDataService } from '../treeData.service';
 
 declare const Slick: any;
 
 const gridOptionsMock = {
+  multiColumnSort: false,
   enableTreeData: true,
   treeDataOptions: {
     columnId: 'file'
@@ -35,13 +37,19 @@ const gridStub = {
   setSortColumns: jest.fn(),
 };
 
+const sortServiceStub = {
+  clearSorting: jest.fn(),
+  sortHierarchicalDataset: jest.fn(),
+} as unknown as SortService;
+
 describe('SortService', () => {
   let service: TreeDataService;
   let slickgridEventHandler: SlickEventHandler;
   const sharedService = new SharedService();
 
   beforeEach(() => {
-    service = new TreeDataService(sharedService);
+    gridOptionsMock.multiColumnSort = false;
+    service = new TreeDataService(sharedService, sortServiceStub);
     slickgridEventHandler = service.eventHandler;
     jest.spyOn(gridStub, 'getData').mockReturnValue(dataViewStub);
   });
@@ -53,6 +61,16 @@ describe('SortService', () => {
 
   it('should create the service', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should throw an error when used with multi-column sorting', (done) => {
+    try {
+      gridOptionsMock.multiColumnSort = true;
+      service.init(gridStub);
+    } catch (e) {
+      expect(e.toString()).toContain('[Angular-Slickgrid] Tree Data does not currently support multi-column sorting');
+      done();
+    }
   });
 
   it('should dispose of the event handler', () => {
@@ -79,9 +97,9 @@ describe('SortService', () => {
   });
 
   describe('handleOnCellClick method', () => {
-    let div;
-    let mockColumn;
-    let mockRowData;
+    let div: HTMLDivElement;
+    let mockColumn: Column;
+    let mockRowData: any;
 
     beforeEach(() => {
       div = document.createElement('div');
@@ -139,7 +157,7 @@ describe('SortService', () => {
 
     it('should toggle the collapsed custom class name to False when that custom class name was found to be True prior', () => {
       mockRowData.customCollapsed = true;
-      gridOptionsMock.treeDataOptions.collapsedPropName = 'customCollapsed';
+      gridOptionsMock.treeDataOptions!.collapsedPropName = 'customCollapsed';
       const spyGetItem = jest.spyOn(dataViewStub, 'getItem').mockReturnValue(mockRowData);
       const spyUptItem = jest.spyOn(dataViewStub, 'updateItem');
       const spyInvalidate = jest.spyOn(gridStub, 'invalidate');
@@ -156,13 +174,11 @@ describe('SortService', () => {
     });
 
     describe('toggleTreeDataCollapse method', () => {
-      let itemsMock;
+      let itemsMock: any;
 
       beforeEach(() => {
         itemsMock = [{ file: 'myFile.txt', size: 0.5 }, { file: 'myMusic.txt', size: 5.3 }];
-        gridOptionsMock.treeDataOptions = {
-          columnId: 'file'
-        };
+        gridOptionsMock.treeDataOptions = { columnId: 'file' };
         jest.clearAllMocks();
       });
 
@@ -181,7 +197,7 @@ describe('SortService', () => {
       });
 
       it('should collapse all items with a custom collapsed property when calling the method with collapsing True', () => {
-        gridOptionsMock.treeDataOptions.collapsedPropName = 'customCollapsed';
+        gridOptionsMock.treeDataOptions!.collapsedPropName = 'customCollapsed';
         const dataGetItemsSpy = jest.spyOn(dataViewStub, 'getItems').mockReturnValue(itemsMock);
         const dataSetItemsSpy = jest.spyOn(dataViewStub, 'setItems');
 
@@ -207,6 +223,64 @@ describe('SortService', () => {
           { __collapsed: false, file: 'myFile.txt', size: 0.5, },
           { __collapsed: false, file: 'myMusic.txt', size: 5.3, },
         ]);
+      });
+    });
+
+    describe('initializeHierarchicalDataset method', () => {
+      let mockColumns: Column[];
+      let mockFlatDataset: any;
+
+      beforeEach(() => {
+        mockColumns = [{ id: 'file', field: 'file', }, { id: 'size', field: 'size', }] as Column[];
+        mockFlatDataset = [{ id: 0, file: 'documents' }, { id: 1, file: 'vacation.txt', size: 1.2, parentId: 0 }, { id: 2, file: 'todo.txt', size: 2.3, parentId: 0 }];
+        gridOptionsMock.treeDataOptions = { columnId: 'file', parentPropName: 'parentId' };
+        jest.clearAllMocks();
+      });
+
+      it('should sort by the Tree column when there is no initial sort provided', () => {
+        const mockHierarchical = [{
+          id: 0,
+          file: 'documents',
+          files: [{ id: 2, file: 'todo.txt', size: 2.3, }, { id: 1, file: 'vacation.txt', size: 1.2, }]
+        }];
+        const setSortSpy = jest.spyOn(gridStub, 'setSortColumns');
+        jest.spyOn(gridStub, 'getColumnIndex').mockReturnValue(0);
+        jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+
+        service.init(gridStub);
+        const result = service.initializeHierarchicalDataset(mockFlatDataset, [mockColumn]);
+
+        expect(setSortSpy).toHaveBeenCalledWith([{
+          columnId: 'file',
+          sortAsc: true,
+          sortCol: mockColumn
+        }]);
+        expect(result).toEqual({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+      });
+
+      it('should sort by the Tree column by the "initialSort" provided', () => {
+        gridOptionsMock.treeDataOptions!.initialSort = {
+          columnId: 'size',
+          direction: 'desc'
+        };
+        const mockHierarchical = [{
+          id: 0,
+          file: 'documents',
+          files: [{ id: 1, file: 'vacation.txt', size: 1.2, }, { id: 2, file: 'todo.txt', size: 2.3, }]
+        }];
+        const setSortSpy = jest.spyOn(gridStub, 'setSortColumns');
+        jest.spyOn(gridStub, 'getColumnIndex').mockReturnValue(0);
+        jest.spyOn(sortServiceStub, 'sortHierarchicalDataset').mockReturnValue({ flat: mockFlatDataset, hierarchical: mockHierarchical });
+
+        service.init(gridStub);
+        const result = service.initializeHierarchicalDataset(mockFlatDataset, [mockColumn]);
+
+        expect(setSortSpy).toHaveBeenCalledWith([{
+          columnId: 'size',
+          sortAsc: false,
+          sortCol: mockColumn
+        }]);
+        expect(result).toEqual({ flat: mockFlatDataset, hierarchical: mockHierarchical });
       });
     });
   });


### PR DESCRIPTION
1. initial sort not always working
2. tree level property should not be required while providing a `parentId` relation
3. tree data was loading and rendering the grid more than once (at least 1x time before the sort and another time after the tree was built) while it should only be rendered once
4. 
#### TODOs
- [x] should work with all 3 things mentioned
- [x] add missing unit tests
- [x] need to investigate, it seems to remove the tree level property when original dataset doesn't have the property (e,g, `indent`)
- [x] do more tests in our SF implementation
- [x] add throw error to not use multi-column sorting with Tree Data
- [x] should also work when adding new item dynamically as shown in the demo 
  - there was an issue in the demo because the demo also has a filter preset