### PR TITLE
feat(addon): provide grid menu labels for all built-in commands

### DIFF
--- a/src/app/modules/angular-slickgrid/extensions/__tests__/extensionUtility.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/extensionUtility.spec.ts
@@ -198,7 +198,7 @@ describe('ExtensionUtility', () => {
 
       it('should not change "frozenColumn" when showing a column that was not found in the visibleColumns columns array', () => {
         const allColumns = [{ id: 'field1' }, { id: 'field2' }, { id: 'field3' }] as Column[];
-        const visibleColumns = [{ id: 'field1' }, { field: 'field2' }] as Column[];
+        const visibleColumns = [{ id: 'field1' }, { field: 'field2' }] as unknown as Column[];
         const setOptionSpy = jest.spyOn(SharedService.prototype.grid, 'setOptions');
 
         utility.readjustFrozenColumnIndexWhenNeeded(0, allColumns, visibleColumns);
@@ -239,6 +239,13 @@ describe('ExtensionUtility', () => {
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         const output = utility.translateWhenEnabledAndServiceExist('COMMANDS', 'NOT_EXIST');
         expect(output).toBe('NOT_EXIST');
+      });
+
+      it('should return the same text when provided as the 3rd argument', () => {
+        const gridOptionsMock = { enableTranslate: false, enableGridMenu: true, gridMenu: { hideForceFitButton: false, hideSyncResizeButton: true, columnTitle: 'Columns' } } as GridOption;
+        jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
+        const output = utility.translateWhenEnabledAndServiceExist('COMMANDS', 'NOT_EXIST', 'last argument wins');
+        expect(output).toBe('last argument wins');
       });
     });
   });

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
@@ -95,6 +95,17 @@ describe('gridMenuExtension', () => {
       postProcess: jest.fn(),
     },
     gridMenu: {
+      commandLabels: {
+        clearAllFiltersCommandKey: 'CLEAR_ALL_FILTERS',
+        clearAllSortingCommandKey: 'CLEAR_ALL_SORTING',
+        clearFrozenColumnsCommandKey: 'CLEAR_PINNING',
+        exportCsvCommandKey: 'EXPORT_TO_CSV',
+        exportExcelCommandKey: 'EXPORT_TO_EXCEL',
+        exportTextDelimitedCommandKey: 'EXPORT_TO_TAB_DELIMITED',
+        refreshDatasetCommandKey: 'REFRESH_DATASET',
+        toggleFilterCommandKey: 'TOGGLE_FILTER_ROW',
+        togglePreHeaderCommandKey: 'TOGGLE_PRE_HEADER_ROW',
+      },
       customItems: [],
       hideClearAllFiltersCommand: false,
       hideClearFrozenColumnsCommand: true,
@@ -408,7 +419,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should expect menu related to "Unfreeze Columns/Rows"', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, gridMenu: { hideClearFrozenColumnsCommand: false, } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: false, } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -430,7 +441,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have only 1 menu "clear-filter" when all other menus are defined as hidden & when "enableFilering" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideToggleFilterCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideToggleFilterCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -440,7 +451,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have only 1 menu "toggle-filter" when all other menus are defined as hidden & when "enableFilering" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideRefreshDatasetCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -450,7 +461,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have only 1 menu "refresh-dataset" when all other menus are defined as hidden & when "enableFilering" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideToggleFilterCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableFiltering: true, showHeaderRow: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideClearAllFiltersCommand: true, hideToggleFilterCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -470,7 +481,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "toggle-preheader" menu command when "showPreHeaderPanel" and "hideTogglePreHeaderCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, showPreHeaderPanel: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideTogglePreHeaderCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, showPreHeaderPanel: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideTogglePreHeaderCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
@@ -487,14 +498,14 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "clear-sorting" menu command when "enableSorting" and "hideClearAllSortingCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableSorting: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideClearAllSortingCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableSorting: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideClearAllSortingCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
       });
 
       it('should have the "export-csv" menu command when "enableExport" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -504,14 +515,14 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "export-csv" menu command when "enableExport" and "hideExportCsvCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
       });
 
       it('should have the "export-excel" menu command when "enableExport" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableExcelExport: true, enableExport: false, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: false } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableExcelExport: true, enableExport: false, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: false } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -521,7 +532,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should have the "export-text-delimited" menu command when "enableExport" is set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideExportCsvCommand: true, hideExportExcelCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         extension.register(); // calling 2x register to make sure it doesn't duplicate commands
@@ -531,7 +542,7 @@ describe('gridMenuExtension', () => {
       });
 
       it('should not have the "export-text-delimited" menu command when "enableExport" and "hideExportCsvCommand" are set', () => {
-        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
+        const copyGridOptionsMock = { ...gridOptionsMock, enableExport: true, gridMenu: { commandLabels: gridOptionsMock.gridMenu!.commandLabels, hideClearFrozenColumnsCommand: true, hideExportExcelCommand: true, hideExportCsvCommand: true, hideExportTextDelimitedCommand: true } } as unknown as GridOption;
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(copyGridOptionsMock);
         extension.register();
         expect((SharedService.prototype.gridOptions.gridMenu as GridMenu).customItems).toEqual([]);
@@ -552,6 +563,7 @@ describe('gridMenuExtension', () => {
           ...gridOptionsMock,
           enableExport: true,
           gridMenu: {
+            commandLabels: gridOptionsMock.gridMenu!.commandLabels,
             customItems: customItemsMock,
             hideClearFrozenColumnsCommand: true,
             hideExportCsvCommand: false,

--- a/src/app/modules/angular-slickgrid/extensions/extensionUtility.ts
+++ b/src/app/modules/angular-slickgrid/extensions/extensionUtility.ts
@@ -2,7 +2,7 @@ import { Injectable, Optional } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { Constants } from '../constants';
-import { Column } from '../models/index';
+import { Column, Locale } from '../models/index';
 import { SharedService } from '../services/shared.service';
 import { getTranslationPrefix } from '../services/utilities';
 
@@ -125,20 +125,23 @@ export class ExtensionUtility {
 
   /**
    * When "enabledTranslate" is set to True, we will try to translate if the Translate Service exist or use the Locales when not
-   * @param translationKey
-   * @param localeKey
+   * @param {String} translationKey
+   * @param {String} localeKey
+   * @param {String} textToUse - optionally provide a static text to use (that will completely override the other arguments of the method)
    */
-  translateWhenEnabledAndServiceExist(translationKey: string, localeKey: string): string {
+  translateWhenEnabledAndServiceExist(translationKey: string, localeKey: string, textToUse?: string): string {
     let text = '';
-    const gridOptions = this.sharedService && this.sharedService.gridOptions;
+    const gridOptions = this.sharedService?.gridOptions;
 
     // get locales provided by user in main file or else use default English locales via the Constants
-    const locales = gridOptions && gridOptions.locales || Constants.locales;
+    const locales = gridOptions?.locales ?? Constants.locales;
 
-    if (gridOptions.enableTranslate && this.translate && this.translate.currentLang && this.translate.instant) {
+    if (textToUse) {
+      text = textToUse;
+    } else if (gridOptions.enableTranslate && this.translate?.instant) {
       text = this.translate.instant(translationKey || ' ');
-    } else if (locales && locales.hasOwnProperty(localeKey)) {
-      text = (locales as any)[localeKey];
+    } else if (localeKey in locales) {
+      text = locales[localeKey as keyof Locale] as string;
     } else {
       text = localeKey;
     }

--- a/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
@@ -56,10 +56,10 @@ export class GridMenuExtension implements Extension {
   dispose() {
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
-    if (this._addon && this._addon.destroy) {
+    if (this._addon?.destroy) {
       this._addon.destroy();
     }
-    if (this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu && this.sharedService.gridOptions.gridMenu.customItems) {
+    if (this.sharedService.gridOptions?.gridMenu?.customItems) {
       this.sharedService.gridOptions.gridMenu = this._userOriginalGridMenu;
     }
     this.extensionUtility.nullifyFunctionNameStartingWithOn(this._gridMenuOptions);
@@ -74,16 +74,16 @@ export class GridMenuExtension implements Extension {
 
   /** Create the Header Menu and expose all the available hooks that user can subscribe (onCommand, onBeforeMenuShow, ...) */
   register(): any {
-    if (this.sharedService.gridOptions && this.sharedService.gridOptions.enableTranslate && (!this.translate || !this.translate.instant)) {
+    if (this.sharedService.gridOptions?.enableTranslate && (!this.translate || !this.translate.instant)) {
       throw new Error('[Angular-Slickgrid] requires "ngx-translate" to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
 
-    if (this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu) {
+    if (this.sharedService?.gridOptions?.gridMenu) {
       // keep original user grid menu, useful when switching locale to translate
       this._userOriginalGridMenu = { ...this.sharedService.gridOptions.gridMenu };
 
       // get locales provided by user in forRoot or else use default English locales via the Constants
-      this._locales = this.sharedService.gridOptions && this.sharedService.gridOptions.locales || Constants.locales;
+      this._locales = this.sharedService.gridOptions?.locales ?? Constants.locales;
 
       this._gridMenuOptions = { ...this.getDefaultGridMenuOptions(), ...this.sharedService.gridOptions.gridMenu };
       this.sharedService.gridOptions.gridMenu = this._gridMenuOptions;
@@ -191,7 +191,7 @@ export class GridMenuExtension implements Extension {
   translateGridMenu() {
     // update the properties by pointers, that is the only way to get Grid Menu Control to see the new values
     // we also need to call the control init so that it takes the new Grid object with latest values
-    if (this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu) {
+    if (this.sharedService?.gridOptions?.gridMenu) {
       this.sharedService.gridOptions.gridMenu.customItems = [];
       this.emptyGridMenuTitles();
 
@@ -228,6 +228,7 @@ export class GridMenuExtension implements Extension {
     const gridMenuCustomItems: Array<GridMenuItem | 'divider'> = [];
     const gridOptions = this.sharedService.gridOptions;
     const translationPrefix = getTranslationPrefix(gridOptions);
+    const commandLabels = this._gridMenuOptions?.commandLabels;
 
     // show grid menu: Unfreeze Columns/Rows
     if (this.sharedService.gridOptions && this._gridMenuOptions && !this._gridMenuOptions.hideClearFrozenColumnsCommand) {
@@ -236,7 +237,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconClearFrozenColumnsCommand || 'fa fa-times',
-            title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}CLEAR_PINNING`) : this._locales && this._locales.TEXT_CLEAR_PINNING,
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.clearFrozenColumnsCommandKey}`, 'TEXT_CLEAR_PINNING', commandLabels?.clearFrozenColumnsCommand),
             disabled: false,
             command: commandName,
             positionOrder: 52
@@ -253,7 +254,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconClearAllFiltersCommand || 'fa fa-filter text-danger',
-              title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}CLEAR_ALL_FILTERS`) : this._locales && this._locales.TEXT_CLEAR_ALL_FILTERS,
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.clearAllFiltersCommandKey}`, 'TEXT_CLEAR_ALL_FILTERS', commandLabels?.clearAllFiltersCommand),
               disabled: false,
               command: commandName,
               positionOrder: 50
@@ -269,7 +270,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconToggleFilterCommand || 'fa fa-random',
-              title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}TOGGLE_FILTER_ROW`) : this._locales && this._locales.TEXT_TOGGLE_FILTER_ROW,
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.toggleFilterCommandKey}`, 'TEXT_TOGGLE_FILTER_ROW', commandLabels?.toggleFilterCommand),
               disabled: false,
               command: commandName,
               positionOrder: 53
@@ -285,7 +286,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconRefreshDatasetCommand || 'fa fa-refresh',
-              title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}REFRESH_DATASET`) : this._locales && this._locales.TEXT_REFRESH_DATASET,
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.refreshDatasetCommandKey}`, 'TEXT_REFRESH_DATASET', commandLabels?.refreshDatasetCommand),
               disabled: false,
               command: commandName,
               positionOrder: 57
@@ -303,7 +304,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconTogglePreHeaderCommand || 'fa fa-random',
-              title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}TOGGLE_PRE_HEADER_ROW`) : this._locales && this._locales.TEXT_TOGGLE_PRE_HEADER_ROW,
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.togglePreHeaderCommandKey}`, 'TEXT_TOGGLE_PRE_HEADER_ROW', commandLabels?.togglePreHeaderCommand),
               disabled: false,
               command: commandName,
               positionOrder: 53
@@ -321,7 +322,7 @@ export class GridMenuExtension implements Extension {
           gridMenuCustomItems.push(
             {
               iconCssClass: this._gridMenuOptions.iconClearAllSortingCommand || 'fa fa-unsorted text-danger',
-              title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}CLEAR_ALL_SORTING`) : this._locales && this._locales.TEXT_CLEAR_ALL_SORTING,
+              title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.clearAllSortingCommandKey}`, 'TEXT_CLEAR_ALL_SORTING', commandLabels?.clearAllSortingCommand),
               disabled: false,
               command: commandName,
               positionOrder: 51
@@ -338,7 +339,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconExportCsvCommand || 'fa fa-download',
-            title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}EXPORT_TO_CSV`) : this._locales && this._locales.TEXT_EXPORT_TO_CSV,
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.exportCsvCommandKey}`, 'TEXT_EXPORT_TO_CSV', commandLabels?.exportCsvCommand),
             disabled: false,
             command: commandName,
             positionOrder: 54
@@ -354,7 +355,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconExportExcelCommand || 'fa fa-file-excel-o text-success',
-            title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}EXPORT_TO_EXCEL`) : this._locales && this._locales.TEXT_EXPORT_TO_EXCEL,
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.exportExcelCommandKey}`, 'TEXT_EXPORT_TO_EXCEL', commandLabels?.exportExcelCommand),
             disabled: false,
             command: commandName,
             positionOrder: 55
@@ -370,7 +371,7 @@ export class GridMenuExtension implements Extension {
         gridMenuCustomItems.push(
           {
             iconCssClass: this._gridMenuOptions.iconExportTextDelimitedCommand || 'fa fa-download',
-            title: this.sharedService.gridOptions.enableTranslate ? this.translate.instant(`${translationPrefix}EXPORT_TO_TAB_DELIMITED`) : this._locales && this._locales.TEXT_EXPORT_TO_TAB_DELIMITED,
+            title: this.extensionUtility.translateWhenEnabledAndServiceExist(`${translationPrefix}${commandLabels?.exportTextDelimitedCommandKey}`, 'TEXT_EXPORT_TO_TAB_DELIMITED', commandLabels?.exportTextDelimitedCommand),
             disabled: false,
             command: commandName,
             positionOrder: 56

--- a/src/app/modules/angular-slickgrid/global-grid-options.ts
+++ b/src/app/modules/angular-slickgrid/global-grid-options.ts
@@ -132,6 +132,17 @@ export const GlobalGridOptions: Partial<GridOption> = {
   forceFitColumns: false,
   frozenHeaderWidthCalcDifferential: 0,
   gridMenu: {
+    commandLabels: {
+      clearAllFiltersCommandKey: 'CLEAR_ALL_FILTERS',
+      clearAllSortingCommandKey: 'CLEAR_ALL_SORTING',
+      clearFrozenColumnsCommandKey: 'CLEAR_PINNING',
+      exportCsvCommandKey: 'EXPORT_TO_CSV',
+      exportExcelCommandKey: 'EXPORT_TO_EXCEL',
+      exportTextDelimitedCommandKey: 'EXPORT_TO_TAB_DELIMITED',
+      refreshDatasetCommandKey: 'REFRESH_DATASET',
+      toggleFilterCommandKey: 'TOGGLE_FILTER_ROW',
+      togglePreHeaderCommandKey: 'TOGGLE_PRE_HEADER_ROW',
+    },
     hideClearAllFiltersCommand: false,
     hideClearAllSortingCommand: false,
     hideClearFrozenColumnsCommand: true, // opt-in command

--- a/src/app/modules/angular-slickgrid/models/gridMenu.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridMenu.interface.ts
@@ -1,9 +1,11 @@
-import { Column } from './column.interface';
-import { GridMenuItem } from './gridMenuItem.interface';
-import { MenuCallbackArgs } from './menuCallbackArgs.interface';
-import { MenuCommandItemCallbackArgs } from './menuCommandItemCallbackArgs.interface';
-
+import { Column, GridMenuItem, GridMenuLabel, GridOption, MenuCallbackArgs, MenuCommandItemCallbackArgs } from './index';
 export interface GridMenu {
+  /**
+ * All the commands text labels
+ * NOTE: some of the text have other properties outside of this option (like 'customTitle', 'forceFitTitle', ...) and that is because they were created prior to this refactoring of labels
+ */
+  commandLabels?: GridMenuLabel;
+
   /** Defaults to 0 (auto), minimum width of grid menu content (command, column list) */
   contentMinWidth?: number;
 
@@ -122,7 +124,7 @@ export interface GridMenu {
   // action/override callbacks
 
   /** Callback method to override the column name output used by the ColumnPicker/GridMenu. */
-  headerColumnValueExtractor?: (column: Column) => string;
+  headerColumnValueExtractor?: (column: Column, gridOptions?: GridOption) => string;
 
   /** Callback method that user can override the default behavior of enabling/disabling an item from the list. */
   menuUsabilityOverride?: (args: MenuCallbackArgs) => boolean;

--- a/src/app/modules/angular-slickgrid/models/gridMenuLabel.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridMenuLabel.interface.ts
@@ -1,0 +1,55 @@
+export interface GridMenuLabel {
+  /** Defaults to "Clear all Filters" */
+  clearAllFiltersCommand?: string;
+
+  /** Defaults to "CLEAR_ALL_FILTERS" translation key */
+  clearAllFiltersCommandKey?: string;
+
+  /** Defaults to "Clear all Sorting" */
+  clearAllSortingCommand?: string;
+
+  /** Defaults to "CLEAR_ALL_SORTING" translation key */
+  clearAllSortingCommandKey?: string;
+
+  /** Defaults to "Unfreeze Columns/Rows" */
+  clearFrozenColumnsCommand?: string;
+
+  /** Defaults to "CLEAR_PINNING" translation key */
+  clearFrozenColumnsCommandKey?: string;
+
+  /** Defaults to "Export to CSV" */
+  exportCsvCommand?: string;
+
+  /** Defaults to "EXPORT_TO_CSV" translation key */
+  exportCsvCommandKey?: string;
+
+  /** Defaults to "Export to Excel" */
+  exportExcelCommand?: string;
+
+  /** Defaults to "EXPORT_TO_EXCEL" translation key */
+  exportExcelCommandKey?: string;
+
+  /** Defaults to "Export to Text Delimited" */
+  exportTextDelimitedCommand?: string;
+
+  /** Defaults to "EXPORT_TO_TAB_DELIMITED" translation key */
+  exportTextDelimitedCommandKey?: string;
+
+  /** Defaults to "Refresh Dataset" */
+  refreshDatasetCommand?: string;
+
+  /** Defaults to "REFRESH_DATASET" translation key */
+  refreshDatasetCommandKey?: string;
+
+  /** Defaults to "Toggle Filter Row" */
+  toggleFilterCommand?: string;
+
+  /** Defaults to "TOGGLE_FILTER_ROW" translation key */
+  toggleFilterCommandKey?: string;
+
+  /** Defaults to "Toggle Pre-Header Row" */
+  togglePreHeaderCommand?: string;
+
+  /** Defaults to "TOGGLE_PRE_HEADER_ROW" translation key */
+  togglePreHeaderCommandKey?: string;
+}

--- a/src/app/modules/angular-slickgrid/models/index.ts
+++ b/src/app/modules/angular-slickgrid/models/index.ts
@@ -84,6 +84,7 @@ export * from './graphqlServiceOption.interface';
 export * from './graphqlSortingOption.interface';
 export * from './gridMenu.interface';
 export * from './gridMenuItem.interface';
+export * from './gridMenuLabel.interface';
 export * from './gridOption.interface';
 export * from './gridServiceDeleteOption.interface';
 export * from './gridServiceInsertOption.interface';


### PR DESCRIPTION
- prior to the change, we couldn't change the label, we would only be able to change the translation key but we couldn't change the text when we're not using translations. This PR provides both way of customizing these labels, via its label and/or with a label translation key