### PR TITLE
fix(demo): we should be able to move row(s) and keep selections

### DIFF
--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -110,7 +110,7 @@ export class GridRowMoveComponent implements OnInit, OnDestroy {
         // the RECOMMENDED is to use "dataContextIds" since that will always work even with Pagination, while "gridRowIndexes" is only good for 1 page
         rowSelection: {
           // gridRowIndexes: [2],       // the row position of what you see on the screen (UI)
-          dataContextIds: [2, 3, 6, 7]  // (recommended) select by your data object IDs
+          dataContextIds: [1, 2, 6, 7]  // (recommended) select by your data object IDs
         }
       },
     };

--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AngularGridInstance, Column, ExtensionName, Filters, Formatters, GridOption } from './../modules/angular-slickgrid';
-import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   templateUrl: './grid-rowmove.component.html'
@@ -27,11 +26,6 @@ export class GridRowMoveComponent implements OnInit, OnDestroy {
   columnDefinitions!: Column[];
   gridOptions!: GridOption;
   dataset!: any[];
-  selectedLanguage: string;
-
-  constructor(private translate: TranslateService) {
-    this.selectedLanguage = this.translate.getDefaultLang();
-  }
 
   angularGridReady(angularGrid: AngularGridInstance) {
     this.angularGrid = angularGrid;
@@ -93,7 +87,7 @@ export class GridRowMoveComponent implements OnInit, OnDestroy {
       },
       enableRowMoveManager: true,
       rowMoveManager: {
-        // when using Row Move + Row Selection, you want to enable the following 2 flags so it doesn't cancel row selection
+        // when using Row Move + Row Selection, you want to move only a single row and we will enable the following flags so it doesn't cancel row selection
         singleRowMove: true,
         disableRowSelection: true,
         cancelEditOnDrag: true,
@@ -109,8 +103,16 @@ export class GridRowMoveComponent implements OnInit, OnDestroy {
         // you can also override the usability of the rows, for example make every 2nd row the only moveable rows,
         // usabilityOverride: (row, dataContext, grid) => dataContext.id % 2 === 1
       },
-      enableTranslate: true,
-      i18n: this.translate
+      showCustomFooter: true,
+      presets: {
+        // you can presets row selection here as well, you can choose 1 of the following 2 ways of setting the selection
+        // by their index position in the grid (UI) or by the object IDs, the default is "dataContextIds" and if provided it will use it and disregard "gridRowIndexes"
+        // the RECOMMENDED is to use "dataContextIds" since that will always work even with Pagination, while "gridRowIndexes" is only good for 1 page
+        rowSelection: {
+          // gridRowIndexes: [2],       // the row position of what you see on the screen (UI)
+          dataContextIds: [2, 3, 6, 7]  // (recommended) select by your data object IDs
+        }
+      },
     };
 
     this.getData();
@@ -144,32 +146,52 @@ export class GridRowMoveComponent implements OnInit, OnDestroy {
     return true;
   }
 
-  onMoveRows(e: Event, args: any) {
-    const extractedRows = [];
-    const rows = args.rows;
+  onMoveRows(_e: Event, args: any) {
+    // rows and insertBefore references,
+    // note that these references are assuming that the dataset isn't filtered at all
+    // which is not always the case so we will recalcualte them and we won't use these reference afterward
+    const rows = args.rows as number[];
     const insertBefore = args.insertBefore;
-    const left = this.dataset.slice(0, insertBefore);
-    const right = this.dataset.slice(insertBefore, this.dataset.length);
+    const extractedRows = [];
+
+    // when moving rows, we need to cancel any sorting that might happen
+    // we can do this by providing an undefined sort comparer
+    // which basically destroys the current sort comparer without resorting the dataset, it basically keeps the previous sorting
+    this.angularGrid.dataView.sort(undefined, true);
+
+    // the dataset might be filtered/sorted,
+    // so we need to get the same dataset as the one that the SlickGrid DataView uses
+    const tmpDataset = this.angularGrid.dataView.getItems();
+    const filteredItems = this.angularGrid.dataView.getFilteredItems();
+
+    const itemOnRight = this.angularGrid.dataView.getItem(insertBefore);
+    const insertBeforeFilteredIdx = this.angularGrid.dataView.getIdxById(itemOnRight.id);
+
+    const filteredRowItems: any[] = [];
+    rows.forEach(row => filteredRowItems.push(filteredItems[row]));
+    const filteredRows = filteredRowItems.map(item => this.angularGrid.dataView.getIdxById(item.id));
+
+    const left = tmpDataset.slice(0, insertBeforeFilteredIdx);
+    const right = tmpDataset.slice(insertBeforeFilteredIdx, tmpDataset.length);
+
+    // convert into a final new dataset that has the new order
+    // we need to resort with
     rows.sort((a: number, b: number) => a - b);
-    for (let i = 0; i < rows.length; i++) {
-      extractedRows.push(this.dataset[rows[i]]);
+    for (const filteredRow of filteredRows) {
+      extractedRows.push(tmpDataset[filteredRow]);
     }
-    rows.reverse();
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i];
-      if (row < insertBefore) {
+    filteredRows.reverse();
+    for (const row of filteredRows) {
+      if (row < insertBeforeFilteredIdx) {
         left.splice(row, 1);
       } else {
-        right.splice(row - insertBefore, 1);
+        right.splice(row - insertBeforeFilteredIdx, 1);
       }
     }
-    const tmpDataset = left.concat(extractedRows.concat(right));
-    const selectedRows = [];
-    for (let i = 0; i < rows.length; i++) {
-      selectedRows.push(left.length + i);
-    }
-    args.grid.resetActiveCell();
-    this.dataset = tmpDataset;
+
+    // final updated dataset, we need to overwrite the DataView dataset (and our local one) with this new dataset that has a new order
+    const finalDataset = left.concat(extractedRows.concat(right));
+    this.dataset = finalDataset; // update dataset and re-render the grid
   }
 
   hideDurationColumnDynamically() {

--- a/src/app/modules/angular-slickgrid/services/gridState.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridState.service.ts
@@ -502,7 +502,7 @@ export class GridStateService {
         setTimeout(() => {
           const shouldBeSelectedRowIndexes = this._dataView.mapIdsToRows(this._selectedRowDataContextIds || []);
           const currentSelectedRowIndexes = this._grid.getSelectedRows();
-          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes) && this._gridOptions.enablePagination) {
+          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes)) {
             this._grid.setSelectedRows(shouldBeSelectedRowIndexes);
           }
         });
@@ -543,7 +543,7 @@ export class GridStateService {
           // this could happen if the previous step was a page change
           const shouldBeSelectedRowIndexes = this._dataView.mapIdsToRows(this._selectedRowDataContextIds || []);
           const currentSelectedRowIndexes = this._grid.getSelectedRows();
-          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes)) {
+          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes) && this._gridOptions.enablePagination) {
             this._grid.setSelectedRows(shouldBeSelectedRowIndexes);
           }
 

--- a/src/app/modules/angular-slickgrid/services/gridState.service.ts
+++ b/src/app/modules/angular-slickgrid/services/gridState.service.ts
@@ -112,7 +112,7 @@ export class GridStateService {
     }
 
     if (this.hasRowSelectionEnabled()) {
-      const currentRowSelection = this.getCurrentRowSelections(args && args.requestRefreshRowFilteredRow);
+      const currentRowSelection = this.getCurrentRowSelections(args?.requestRefreshRowFilteredRow);
       if (currentRowSelection) {
         gridState.rowSelection = currentRowSelection;
       }
@@ -136,8 +136,8 @@ export class GridStateService {
     const currentColumns: CurrentColumn[] = [];
 
     if (gridColumns && Array.isArray(gridColumns)) {
-      gridColumns.forEach((column: Column, index: number) => {
-        if (column && column.id) {
+      gridColumns.forEach((column: Column) => {
+        if (column?.id) {
           currentColumns.push({
             columnId: column.id as string,
             cssClass: column.cssClass || '',
@@ -204,7 +204,7 @@ export class GridStateService {
     if (currentColumns && Array.isArray(currentColumns)) {
       currentColumns.forEach((currentColumn: CurrentColumn, index: number) => {
         const gridColumn = gridColumns.find((c: Column) => c.id === currentColumn.columnId);
-        if (gridColumn && gridColumn.id) {
+        if (gridColumn?.id) {
           columns.push({
             ...gridColumn,
             cssClass: currentColumn.cssClass,
@@ -240,10 +240,10 @@ export class GridStateService {
   getCurrentFilters(): CurrentFilter[] | null {
     if (this._gridOptions && this._gridOptions.backendServiceApi) {
       const backendService = this._gridOptions.backendServiceApi.service;
-      if (backendService && backendService.getCurrentFilters) {
+      if (backendService?.getCurrentFilters) {
         return backendService.getCurrentFilters() as CurrentFilter[];
       }
-    } else if (this.filterService && this.filterService.getCurrentLocalFilters) {
+    } else if (this.filterService?.getCurrentLocalFilters) {
       return this.filterService.getCurrentLocalFilters();
     }
     return null;
@@ -254,10 +254,10 @@ export class GridStateService {
    * @return current pagination state
    */
   getCurrentPagination(): CurrentPagination | undefined {
-    if (this._gridOptions.enablePagination) {
-      if (this._gridOptions && this._gridOptions.backendServiceApi) {
+    if (this._gridOptions?.enablePagination) {
+      if (this._gridOptions.backendServiceApi) {
         const backendService = this._gridOptions.backendServiceApi.service;
-        if (backendService && backendService.getCurrentPagination) {
+        if (backendService?.getCurrentPagination) {
           return backendService.getCurrentPagination();
         }
       } else {
@@ -296,12 +296,12 @@ export class GridStateService {
    * @return current sorters
    */
   getCurrentSorters(): CurrentSorter[] | null {
-    if (this._gridOptions && this._gridOptions.backendServiceApi) {
+    if (this._gridOptions?.backendServiceApi) {
       const backendService = this._gridOptions.backendServiceApi.service;
-      if (backendService && backendService.getCurrentSorters) {
+      if (backendService?.getCurrentSorters) {
         return backendService.getCurrentSorters() as CurrentSorter[];
       }
-    } else if (this.sortService && this.sortService.getCurrentLocalSorters) {
+    } else if (this.sortService?.getCurrentLocalSorters) {
       return this.sortService.getCurrentLocalSorters();
     }
     return null;
@@ -310,7 +310,7 @@ export class GridStateService {
   /** Check whether the row selection needs to be preserved */
   needToPreserveRowSelection(): boolean {
     let preservedRowSelection = false;
-    if (this._gridOptions && this._gridOptions.dataView && this._gridOptions.dataView.hasOwnProperty('syncGridSelection')) {
+    if (this._gridOptions?.dataView && this._gridOptions.dataView.hasOwnProperty('syncGridSelection')) {
       const syncGridSelection = this._gridOptions.dataView.syncGridSelection;
       if (typeof syncGridSelection === 'boolean') {
         preservedRowSelection = this._gridOptions.dataView.syncGridSelection as boolean;
@@ -351,8 +351,8 @@ export class GridStateService {
   resetRowSelectionWhenRequired() {
     if (!this.needToPreserveRowSelection() && (this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector)) {
       // this also requires the Row Selection Model to be registered as well
-      const rowSelectionExtension = this.extensionService && this.extensionService.getExtensionByName && this.extensionService.getExtensionByName(ExtensionName.rowSelection);
-      if (rowSelectionExtension && rowSelectionExtension.instance) {
+      const rowSelectionExtension = this.extensionService?.getExtensionByName?.(ExtensionName.rowSelection);
+      if (rowSelectionExtension?.instance) {
         this._grid.setSelectedRows([]);
       }
     }
@@ -435,12 +435,12 @@ export class GridStateService {
    * @param grid
    */
   private bindExtensionAddonEventToGridStateChange(extensionName: ExtensionName, eventName: string) {
-    const extension = this.extensionService && this.extensionService.getExtensionByName && this.extensionService.getExtensionByName(extensionName);
-    const slickEvent = extension && extension.instance && extension.instance[eventName];
+    const extension = this.extensionService?.getExtensionByName?.(extensionName);
+    const slickEvent = extension?.instance?.[eventName];
 
     if (slickEvent && slickEvent.subscribe) {
-      this._eventHandler.subscribe(slickEvent, (e: Event, args: any) => {
-        const columns: Column[] = args && args.columns;
+      this._eventHandler.subscribe(slickEvent, (_e: Event, args: any) => {
+        const columns: Column[] = args?.columns;
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
         this.onGridStateChanged.next({ change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       });
@@ -502,7 +502,7 @@ export class GridStateService {
         setTimeout(() => {
           const shouldBeSelectedRowIndexes = this._dataView.mapIdsToRows(this._selectedRowDataContextIds || []);
           const currentSelectedRowIndexes = this._grid.getSelectedRows();
-          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes)) {
+          if (!dequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes) && this._gridOptions.enablePagination) {
             this._grid.setSelectedRows(shouldBeSelectedRowIndexes);
           }
         });

--- a/src/app/modules/angular-slickgrid/services/pagination.service.ts
+++ b/src/app/modules/angular-slickgrid/services/pagination.service.ts
@@ -338,13 +338,11 @@ export class PaginationService {
    *
    * IMPORTANT NOTE:
    * The Pagination must be created on initial page load, then only after can you toggle it.
-   * Basically this method WILL NOT WORK to show the Pagination if it was not there from the start.
+   * Basically this method WILL NOT WORK to show the Pagination if it was never created from the start.
    */
   togglePaginationVisibility(visible?: boolean) {
     if (this.grid && this.sharedService && this.sharedService.gridOptions) {
       const isVisible = visible !== undefined ? visible : !this.sharedService.gridOptions.enablePagination;
-      this.sharedService.gridOptions.enablePagination = isVisible;
-      this.onPaginationVisibilityChanged.next({ visible: isVisible });
 
       // make sure to reset the Pagination and go back to first page to avoid any issues with Pagination being offset
       if (isVisible) {
@@ -357,6 +355,11 @@ export class PaginationService {
         const pageSize = visible ? this._itemsPerPage : 0;
         this.dataView.setPagingOptions({ pageSize, pageNum: 0 });
       }
+
+      // finally toggle the "enablePagination" flag and make sure it happens AFTER the setPagingOptions is called (when using local grid)
+      // to avoid conflict with GridState bindSlickGridRowSelectionToGridStateChange() method
+      this.onPaginationVisibilityChanged.next({ visible: isVisible });
+      this.sharedService.gridOptions.enablePagination = isVisible
     }
   }
 

--- a/src/app/modules/angular-slickgrid/services/sort.service.ts
+++ b/src/app/modules/angular-slickgrid/services/sort.service.ts
@@ -166,8 +166,8 @@ export class SortService {
           }
         }
       } else if (this._isBackendGrid) {
-        const backendService = this._gridOptions && this._gridOptions.backendServiceApi && this._gridOptions.backendServiceApi.service;
-        if (backendService && backendService.clearSorters) {
+        const backendService = this._gridOptions?.backendServiceApi?.service;
+        if (backendService?.clearSorters) {
           backendService.clearSorters();
         }
       }

--- a/test/cypress/integration/example17.spec.js
+++ b/test/cypress/integration/example17.spec.js
@@ -16,7 +16,15 @@ describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', { retries
       .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
   });
 
-  it('should drag opened Row Detail to another position in the grid', () => {
+  it('should have 4 rows selected count shown in the grid left footer', () => {
+    cy.get('.slick-custom-footer')
+      .find('div.left-footer')
+      .should($span => {
+        expect($span.text()).to.eq(`4 items selected`);
+      });
+  });
+
+  it('should drag opened row to another position in the grid', () => {
     cy.get('[style="top:35px"] > .slick-cell.cell-reorder').as('moveIconTask1');
     cy.get('[style="top:105px"] > .slick-cell.cell-reorder').as('moveIconTask3');
 
@@ -31,7 +39,7 @@ describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', { retries
       .trigger('mouseup', 'bottomRight', { force: true });
 
     cy.get('input[type="checkbox"]:checked')
-      .should('have.length', 0);
+      .should('have.length', 4);
   });
 
   it('should expect row to be moved to another row index', () => {
@@ -45,10 +53,26 @@ describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', { retries
     cy.get('[style="top:140px"] > .slick-cell:nth(2)').should('contain', 'Task 4');
 
     cy.get('input[type="checkbox"]:checked')
-      .should('have.length', 0);
+      .should('have.length', 4);
   });
 
-  it('should select 2 rows (Task 3,4), then move row and expect the 2 rows to still be selected without any others', () => {
+  it('should uncheck all rows', () => {
+    // click twice to check then uncheck all
+    cy.get('.slick-headerrow-column input[type=checkbox]')
+      .click({ force: true });
+    cy.get('.slick-headerrow-column input[type=checkbox]')
+      .click({ force: true });
+  });
+
+  it('should have 0 row selected count shown in the grid left footer', () => {
+    cy.get('.slick-custom-footer')
+      .find('div.left-footer')
+      .should($span => {
+        expect($span.text()).to.eq(`0 items selected`);
+      });
+  });
+
+  it('should select 2 rows (Task 3,4), then move the rows and expect both rows to still be selected without any other rows', () => {
     cy.get('[style="top:70px"] > .slick-cell:nth(1)').click();
     cy.get('[style="top:140px"] > .slick-cell:nth(1)').click();
 

--- a/test/cypress/integration/example17.spec.js
+++ b/test/cypress/integration/example17.spec.js
@@ -26,6 +26,7 @@ describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', { retries
 
   it('should drag opened row to another position in the grid', () => {
     cy.get('[style="top:35px"] > .slick-cell.cell-reorder').as('moveIconTask1');
+    cy.get('[style="top:70px"] > .slick-cell.cell-reorder').as('moveIconTask2');
     cy.get('[style="top:105px"] > .slick-cell.cell-reorder').as('moveIconTask3');
 
     cy.get('@moveIconTask3').should('have.length', 1);
@@ -37,6 +38,8 @@ describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', { retries
     cy.get('@moveIconTask1')
       .trigger('mousemove', 'bottomRight')
       .trigger('mouseup', 'bottomRight', { force: true });
+
+    cy.get('@moveIconTask2').trigger('mouseover', { force: true });
 
     cy.get('input[type="checkbox"]:checked')
       .should('have.length', 4);

--- a/test/cypress/integration/example17.spec.js
+++ b/test/cypress/integration/example17.spec.js
@@ -45,7 +45,7 @@ describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', { retries
       .should('have.length', 4);
   });
 
-  it('should expect row to be moved to another row index', () => {
+  it('should expect the row to have moved to another row index', () => {
     cy.get('.slick-viewport-top.slick-viewport-left')
       .scrollTo('top');
 
@@ -62,8 +62,7 @@ describe('Example 17 - Row Move & Checkbox Selector Selector Plugins', { retries
   it('should uncheck all rows', () => {
     // click twice to check then uncheck all
     cy.get('.slick-headerrow-column input[type=checkbox]')
-      .click({ force: true });
-    cy.get('.slick-headerrow-column input[type=checkbox]')
+      .click({ force: true })
       .click({ force: true });
   });
 

--- a/test/cypress/integration/example27.spec.js
+++ b/test/cypress/integration/example27.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-xdescribe('Example 27 - GraphQL Basic API without Pagination', { retries: 1 }, () => {
+describe('Example 27 - GraphQL Basic API without Pagination', { retries: 1 }, () => {
   const GRID_ROW_HEIGHT = 35;
   const fullPreTitles = ['Country', 'Language', 'Continent'];
   const fullTitles = ['Code', 'Name', 'Native', 'Phone Area Code', 'Currency', 'Emoji', 'Names', 'Native', 'Codes', 'Name', 'Code'];


### PR DESCRIPTION
- grid state should only be allowed to change row selection only when Pagination is enabled
- refactor some part of the code to use more optional chaining (?.) syntax for cleaner and smaller code
- move around some of the Cypress tests so that it makes sure that moving rows will keep row selections