### PR TITLE
feat(filters): build multiple-select options from native dom elements

### DIFF
--- a/src/app/modules/angular-slickgrid/editors/__tests__/selectEditor.spec.ts
+++ b/src/app/modules/angular-slickgrid/editors/__tests__/selectEditor.spec.ts
@@ -119,7 +119,7 @@ describe('SelectEditor', () => {
         (mockColumn.internalColumnEditor as ColumnEditor).collection = [{ hello: 'world' }];
         editor = new SelectEditor(editorArguments, true);
       } catch (e) {
-        expect(e.toString()).toContain(`[select-editor] A collection with value/label (or value/labelKey when using Locale) is required to populate the Select list`);
+        expect(e.toString()).toContain(`[Angular-Slickgrid] Select Filter/Editor collection with value/label (or value/labelKey when using Locale) is required to populate the Select list`);
         done();
       }
     });

--- a/src/app/modules/angular-slickgrid/filters/__tests__/selectFilter.spec.ts
+++ b/src/app/modules/angular-slickgrid/filters/__tests__/selectFilter.spec.ts
@@ -8,6 +8,7 @@ import { CollectionService } from './../../services/collection.service';
 import { Filters } from '..';
 import { SelectFilter } from '../selectFilter';
 import { of, Subject } from 'rxjs';
+import { ColumnFilter } from 'dist/public_api';
 
 const containerId = 'demo-container';
 
@@ -30,7 +31,7 @@ describe('SelectFilter', () => {
   let divContainer: HTMLDivElement;
   let filter: SelectFilter;
   let filterArguments: FilterArguments;
-  let spyGetHeaderRow;
+  let spyGetHeaderRow: jest.SpyInstance<any, any>;
   let mockColumn: Column;
   let collectionService: CollectionService;
   let translate: TranslateService;
@@ -89,12 +90,12 @@ describe('SelectFilter', () => {
   });
 
   it('should throw an error when trying to call init without any arguments', () => {
-    expect(() => filter.init(null)).toThrowError('[Angular-SlickGrid] A filter must always have an "init()" with valid arguments.');
+    expect(() => filter.init(null as any)).toThrowError('[Angular-SlickGrid] A filter must always have an "init()" with valid arguments.');
   });
 
   it('should throw an error when there is no collection provided in the filter property', (done) => {
     try {
-      mockColumn.filter.collection = undefined;
+      (mockColumn.filter as ColumnFilter).collection = undefined;
       filter.init(filterArguments);
     } catch (e) {
       expect(e.toString()).toContain(`[Angular-SlickGrid] You need to pass a "collection" (or "collectionAsync") for the MultipleSelect/SingleSelect Filter to work correctly.`);
@@ -105,7 +106,7 @@ describe('SelectFilter', () => {
   it('should throw an error when collection is not a valid array', (done) => {
     try {
       // @ts-ignore
-      mockColumn.filter.collection = { hello: 'world' };
+      (mockColumn.filter as ColumnFilter).collection = { hello: 'world' };
       filter.init(filterArguments);
     } catch (e) {
       expect(e.toString()).toContain(`The "collection" passed to the Select Filter is not a valid array.`);
@@ -115,19 +116,19 @@ describe('SelectFilter', () => {
 
   it('should throw an error when collection is not a valid value/label pair array', (done) => {
     try {
-      mockColumn.filter.collection = [{ hello: 'world' }];
+      (mockColumn.filter as ColumnFilter).collection = [{ hello: 'world' }];
       filter.init(filterArguments);
     } catch (e) {
-      expect(e.toString()).toContain(`[select-filter] A collection with value/label (or value/labelKey when using Locale) is required to populate the Select list`);
+      expect(e.message).toContain(`[Angular-Slickgrid] Select Filter/Editor collection with value/label (or value/labelKey when using Locale) is required to populate the Select list`);
       done();
     }
   });
 
   it('should throw an error when "enableTranslateLabel" is set without a valid TranslateService', (done) => {
     try {
-      translate = undefined;
-      mockColumn.filter.enableTranslateLabel = true;
-      mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      translate = undefined as any;
+      (mockColumn.filter as ColumnFilter).enableTranslateLabel = true;
+      (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
       filter = new SelectFilter(translate, collectionService);
 
       filter.init(filterArguments);
@@ -138,7 +139,7 @@ describe('SelectFilter', () => {
   });
 
   it('should initialize the filter', () => {
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     filter.init(filterArguments);
     const filterCount = divContainer.querySelectorAll('select.ms-filter.search-filter.filter-gender').length;
 
@@ -147,7 +148,7 @@ describe('SelectFilter', () => {
   });
 
   it('should be a multiple-select filter by default when it is not specified in the constructor', () => {
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     filter = new SelectFilter(translate, collectionService);
     filter.init(filterArguments);
     const filterCount = divContainer.querySelectorAll('select.ms-filter.search-filter.filter-gender').length;
@@ -159,23 +160,23 @@ describe('SelectFilter', () => {
 
   it('should have a placeholder when defined in its column definition', () => {
     const testValue = 'test placeholder';
-    mockColumn.filter.placeholder = testValue;
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).placeholder = testValue;
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
     filter.init(filterArguments);
-    const filterElm = divContainer.querySelector<HTMLSpanElement>('.ms-filter.search-filter.filter-gender .placeholder');
+    const filterElm = divContainer.querySelector('.ms-filter.search-filter.filter-gender .placeholder') as HTMLSpanElement;
 
     expect(filterElm.innerHTML).toBe(testValue);
   });
 
   it('should trigger multiple select change event and expect the callback to be called with the search terms we select from dropdown list', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
 
     // we can use property "checked" or dispatch an event
@@ -190,12 +191,12 @@ describe('SelectFilter', () => {
 
   it('should trigger multiple select change event without choosing an option and expect the callback to be called without search terms and also expect the dropdown list to not have "filled" css class', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -208,11 +209,11 @@ describe('SelectFilter', () => {
   it('should trigger multiple select change event and expect this to work with a regular array of strings', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    mockColumn.filter.collection = ['male', 'female'];
+    (mockColumn.filter as ColumnFilter).collection = ['male', 'female'];
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
 
     // here we use "checked" property instead of dispatching an event
@@ -226,14 +227,14 @@ describe('SelectFilter', () => {
   });
 
   it('should pass a different operator then trigger an input change event and expect the callback to be called with the search terms we select from dropdown list', () => {
-    mockColumn.filter.operator = 'NIN';
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).operator = 'NIN';
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
 
     filterListElm[0].checked = true;
@@ -246,7 +247,7 @@ describe('SelectFilter', () => {
   });
 
   it('should have same value in "getValues" after being set in "setValues"', () => {
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     filter.init(filterArguments);
     filter.setValues('female');
     const values = filter.getValues();
@@ -256,7 +257,7 @@ describe('SelectFilter', () => {
   });
 
   it('should have empty array returned from "getValues" when nothing is set', () => {
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     filter.init(filterArguments);
     const values = filter.getValues();
 
@@ -272,15 +273,15 @@ describe('SelectFilter', () => {
   });
 
   it('should create the multi-select filter with a default search term when passed as a filter argument', () => {
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filterArguments.searchTerms = ['female'];
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -291,15 +292,15 @@ describe('SelectFilter', () => {
   });
 
   it('should create the multi-select filter with default boolean search term converted as strings when passed as a filter argument', () => {
-    mockColumn.filter.collection = [{ value: true, label: 'True' }, { value: false, label: 'False' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: true, label: 'True' }, { value: false, label: 'False' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filterArguments.searchTerms = [false];
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -310,15 +311,15 @@ describe('SelectFilter', () => {
   });
 
   it('should create the multi-select filter with default number search term converted as strings when passed as a filter argument', () => {
-    mockColumn.filter.collection = [{ value: 1, label: 'male' }, { value: 2, label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 1, label: 'male' }, { value: 2, label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filterArguments.searchTerms = [2];
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -330,14 +331,14 @@ describe('SelectFilter', () => {
 
   it('should create the multi-select filter with a default search term when passed as a filter argument even with collection an array of strings', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
-    mockColumn.filter.collection = ['male', 'female'];
+    (mockColumn.filter as ColumnFilter).collection = ['male', 'female'];
 
     filterArguments.searchTerms = ['female'];
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -357,7 +358,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -382,7 +383,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -402,7 +403,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -424,7 +425,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -449,7 +450,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -472,7 +473,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -497,7 +498,7 @@ describe('SelectFilter', () => {
     filter.init(filterArguments);
 
     setTimeout(() => {
-      const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+      const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
       const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
       filterBtnElm.click();
 
@@ -511,16 +512,16 @@ describe('SelectFilter', () => {
 
   it('should create the multi-select filter with a default search term when using "collectionAsync" as an Observable', (done) => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
-    mockColumn.filter.collectionAsync = of(['male', 'female']);
+    (mockColumn.filter as ColumnFilter).collectionAsync = of(['male', 'female']);
 
     filterArguments.searchTerms = ['female'];
     filter.init(filterArguments);
 
     setTimeout(() => {
-      const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+      const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
       const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
       const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-      const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+      const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
       filterBtnElm.click();
       filterOkElm.click();
 
@@ -534,13 +535,13 @@ describe('SelectFilter', () => {
 
   it('should create the multi-select filter with a "collectionAsync" as an Observable and be able to call next on it', (done) => {
     const mockCollection = ['male', 'female'];
-    mockColumn.filter.collectionAsync = of(mockCollection);
+    (mockColumn.filter as ColumnFilter).collectionAsync = of(mockCollection);
 
     filterArguments.searchTerms = ['female'];
     filter.init(filterArguments);
 
     setTimeout(() => {
-      const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+      const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
       const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
       filterBtnElm.click();
 
@@ -549,7 +550,7 @@ describe('SelectFilter', () => {
 
       // after await (or timeout delay) we'll get the Subject Observable
       mockCollection.push('other');
-      (mockColumn.filter.collectionAsync as Subject<any[]>).next(mockCollection);
+      ((mockColumn.filter as ColumnFilter).collectionAsync as Subject<any[]>).next(mockCollection);
 
       const filterUpdatedListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
       expect(filterUpdatedListElm.length).toBe(3);
@@ -558,7 +559,7 @@ describe('SelectFilter', () => {
   });
 
   it('should throw an error when "collectionAsync" Observable does not return a valid array', (done) => {
-    mockColumn.filter.collectionAsync = of({ hello: 'world' });
+    (mockColumn.filter as ColumnFilter).collectionAsync = of({ hello: 'world' });
     filter.init(filterArguments).catch((e) => {
       expect(e.toString()).toContain(`Something went wrong while trying to pull the collection from the "collectionAsync" call in the Select Filter, the collection is not a valid array.`);
       done();
@@ -577,7 +578,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -597,7 +598,7 @@ describe('SelectFilter', () => {
     };
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
 
@@ -607,15 +608,15 @@ describe('SelectFilter', () => {
 
   it('should create the multi-select filter with a blank entry at the beginning of the collection when "addBlankEntry" is set in the "collectionOptions" property', () => {
     filterArguments.searchTerms = ['female'];
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-    mockColumn.filter.collectionOptions = { addBlankEntry: true };
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collectionOptions = { addBlankEntry: true };
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -628,15 +629,15 @@ describe('SelectFilter', () => {
 
   it('should create the multi-select filter with a custom entry at the beginning of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
     filterArguments.searchTerms = ['female'];
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-    mockColumn.filter.collectionOptions = { addCustomFirstEntry: { value: null, label: '' } };
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collectionOptions = { addCustomFirstEntry: { value: null, label: '' } };
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -649,15 +650,15 @@ describe('SelectFilter', () => {
 
   it('should create the multi-select filter with a custom entry at the end of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
     filterArguments.searchTerms = ['female'];
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-    mockColumn.filter.collectionOptions = { addCustomLastEntry: { value: null, label: '' } };
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collectionOptions = { addCustomLastEntry: { value: null, label: '' } };
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filter.init(filterArguments);
-    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
-    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
     filterBtnElm.click();
     filterOkElm.click();
 
@@ -670,20 +671,20 @@ describe('SelectFilter', () => {
 
   it('should trigger a callback with the clear filter set when calling the "clear" method', () => {
     filterArguments.searchTerms = ['female'];
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filter.init(filterArguments);
     filter.clear();
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
 
-    expect(filter.searchTerms.length).toBe(0);
+    expect(filter.searchTerms!.length).toBe(0);
     expect(filterFilledElms.length).toBe(0);
     expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, clearFilterTriggered: true, shouldTriggerQuery: true });
   });
 
   it('should trigger a callback with the clear filter but without querying when when calling the "clear" method with False as argument', () => {
-    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    (mockColumn.filter as ColumnFilter).collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filterArguments.searchTerms = ['female'];
@@ -691,7 +692,7 @@ describe('SelectFilter', () => {
     filter.clear(false);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
 
-    expect(filter.searchTerms.length).toBe(0);
+    expect(filter.searchTerms!.length).toBe(0);
     expect(filterFilledElms.length).toBe(0);
     expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, clearFilterTriggered: true, shouldTriggerQuery: false });
   });
@@ -713,11 +714,11 @@ describe('SelectFilter', () => {
     filter.init(filterArguments);
 
     setTimeout(() => {
-      const filterSelectAllElm = divContainer.querySelector<HTMLSpanElement>('.filter-gender .ms-select-all label span');
-      const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+      const filterSelectAllElm = divContainer.querySelector('.filter-gender .ms-select-all label span') as HTMLSpanElement;
+      const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
       const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
-      const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
-      const filterParentElm = divContainer.querySelector<HTMLButtonElement>(`.ms-parent.ms-filter.search-filter.filter-gender button`);
+      const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
+      const filterParentElm = divContainer.querySelector(`.ms-parent.ms-filter.search-filter.filter-gender button`) as HTMLButtonElement;
       filterBtnElm.click();
 
       expect(filterListElm.length).toBe(3);
@@ -747,11 +748,11 @@ describe('SelectFilter', () => {
     filterArguments.searchTerms = ['male', 'female'];
     filter.init(filterArguments);
     setTimeout(() => {
-      const filterSelectAllElm = divContainer.querySelector<HTMLSpanElement>('.filter-gender .ms-select-all label span');
-      const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+      const filterSelectAllElm = divContainer.querySelector('.filter-gender .ms-select-all label span') as HTMLSpanElement;
+      const filterBtnElm = divContainer.querySelector('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice') as HTMLButtonElement;
       const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
-      const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
-      const filterParentElm = divContainer.querySelector<HTMLButtonElement>(`.ms-parent.ms-filter.search-filter.filter-gender button`);
+      const filterOkElm = divContainer.querySelector(`[name=filter-gender].ms-drop .ms-ok-button`) as HTMLButtonElement;
+      const filterParentElm = divContainer.querySelector(`.ms-parent.ms-filter.search-filter.filter-gender button`) as HTMLButtonElement;
       filterBtnElm.click();
 
       expect(filterListElm.length).toBe(3);

--- a/src/app/modules/angular-slickgrid/filters/selectFilter.ts
+++ b/src/app/modules/angular-slickgrid/filters/selectFilter.ts
@@ -23,6 +23,7 @@ import { Constants } from './../constants';
 import { Locale } from './../models/locale.interface';
 import { CollectionService } from './../services/collection.service';
 import { castToPromise, getDescendantProperty, getTranslationPrefix, htmlEncode, unsubscribeAllObservables } from '../services/utilities';
+import { buildSelectEditorOrFilterDomElement } from '../services/domUtilities';
 
 // using external non-typed js libraries
 declare const $: any;
@@ -351,88 +352,22 @@ export class SelectFilter implements Filter {
     newCollection = this.filterCollection(newCollection);
     newCollection = this.sortCollection(newCollection);
 
-    // step 1, create HTML string template
-    const filterTemplate = this.buildTemplateHtmlString(newCollection, this.searchTerms || []);
+    // step 1, create HTML DOM element
+    const selectBuildResult = buildSelectEditorOrFilterDomElement(
+      'filter',
+      newCollection,
+      this.columnDef,
+      this.grid,
+      this.isMultipleSelect,
+      this.translate,
+      this.searchTerms || []
+    );
+    this.isFilled = selectBuildResult.hasFoundSearchTerm;
 
     // step 2, create the DOM Element of the filter & pre-load search terms
-    // also subscribe to the onClose event
-    this.createDomElement(filterTemplate);
+    // we will later also subscribe to the onClose event to filter the data whenever that event is triggered
+    this.createDomElement(selectBuildResult.selectElement);
     this._collectionLength = newCollection.length;
-  }
-
-  /** Create the HTML template as a string */
-  protected buildTemplateHtmlString(optionCollection: any[], searchTerms: SearchTerm[]) {
-    let options = '';
-    const columnId = this.columnDef && this.columnDef.id;
-    const separatorBetweenLabels = this.collectionOptions && this.collectionOptions.separatorBetweenTextLabels || '';
-    const isEnableTranslate = this.gridOptions && this.gridOptions.enableTranslate;
-    const isRenderHtmlEnabled = this.columnFilter && this.columnFilter.enableRenderHtml || false;
-    const sanitizedOptions = this.gridOptions && this.gridOptions.sanitizeHtmlOptions || {};
-
-    // collection could be an Array of Strings OR Objects
-    if (Array.isArray(optionCollection)) {
-      if (optionCollection.every(x => typeof x === 'string')) {
-        optionCollection.forEach((option: string) => {
-          const selected = (searchTerms.findIndex((term) => term === option) >= 0) ? 'selected' : '';
-          options += `<option value="${option}" label="${option}" ${selected}>${option}</option>`;
-
-          // if there's at least 1 search term found, we will add the "filled" class for styling purposes
-          // on a single select, we'll also make sure the single value is not an empty string to consider this being filled
-          if ((selected && this.isMultipleSelect) || (selected && !this.isMultipleSelect && option !== '')) {
-            this.isFilled = true;
-          }
-        });
-      } else {
-        // array of objects will require a label/value pair unless a customStructure is passed
-        optionCollection.forEach((option: SelectOption) => {
-          if (!option || (option[this.labelName] === undefined && option.labelKey === undefined)) {
-            throw new Error(`[select-filter] A collection with value/label (or value/labelKey when using Locale) is required to populate the Select list, for example:: { filter: model: Filters.multipleSelect, collection: [ { value: '1', label: 'One' } ]')`);
-          }
-          const labelKey = (option.labelKey || option[this.labelName]) as string;
-          const selected = (searchTerms.findIndex((term) => `${term}` === `${option[this.valueName]}`) >= 0) ? 'selected' : '';
-          const labelText = ((option.labelKey || this.enableTranslateLabel) && labelKey && isEnableTranslate) ? this.translate && this.translate.currentLang && this.translate.instant(labelKey || ' ') : labelKey;
-          let prefixText = option[this.labelPrefixName] || '';
-          let suffixText = option[this.labelSuffixName] || '';
-          let optionLabel = option.hasOwnProperty(this.optionLabel) ? option[this.optionLabel] : '';
-          if (optionLabel && optionLabel.toString) {
-            optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
-          }
-
-          // also translate prefix/suffix if enableTranslateLabel is true and text is a string
-          prefixText = (this.enableTranslateLabel && isEnableTranslate && prefixText && typeof prefixText === 'string') ? this.translate && this.translate.currentLang && this.translate.instant(prefixText || ' ') : prefixText;
-          suffixText = (this.enableTranslateLabel && isEnableTranslate && suffixText && typeof suffixText === 'string') ? this.translate && this.translate.currentLang && this.translate.instant(suffixText || ' ') : suffixText;
-          optionLabel = (this.enableTranslateLabel && isEnableTranslate && optionLabel && typeof optionLabel === 'string') ? this.translate && this.translate.currentLang && this.translate.instant(optionLabel || ' ') : optionLabel;
-
-          // add to a temp array for joining purpose and filter out empty text
-          const tmpOptionArray = [prefixText, (typeof labelText === 'string' || typeof labelText === 'number') ? labelText.toString() : labelText, suffixText].filter((text) => text);
-          let optionText = tmpOptionArray.join(separatorBetweenLabels);
-
-          // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
-          // also, the 3rd party lib will saninitze any html code unless it's encoded, so we'll do that
-          if (isRenderHtmlEnabled) {
-            // sanitize any unauthorized html tags like script and others
-            // for the remaining allowed tags we'll permit all attributes
-            const sanitizedText = (DOMPurify.sanitize(optionText, sanitizedOptions) || '').toString();
-            optionText = htmlEncode(sanitizedText);
-          }
-
-          // html text of each select option
-          let optionValue = option[this.valueName];
-          if (optionValue === undefined || optionValue === null) {
-            optionValue = '';
-          }
-          options += `<option value="${optionValue}" label="${optionLabel}" ${selected}>${optionText}</option>`;
-
-          // if there's at least 1 search term found, we will add the "filled" class for styling purposes
-          // on a single select, we'll also make sure the single value is not an empty string to consider this being filled
-          if ((selected && this.isMultipleSelect) || (selected && !this.isMultipleSelect && option[this.valueName] !== '')) {
-            this.isFilled = true;
-          }
-        });
-      }
-    }
-
-    return `<select class="ms-filter search-filter filter-${columnId}" ${this.isMultipleSelect ? 'multiple="multiple"' : ''}>${options}</select>`;
   }
 
   /** Create a blank entry that can be added to the collection. It will also reuse the same customStructure if need be */
@@ -451,11 +386,10 @@ export class SelectFilter implements Filter {
   }
 
   /**
-   * From the html template string, create a DOM element
-   * Subscribe to the onClose event and run the callback when that happens
-   * @param filterTemplate
+   * From the Select DOM Element created earlier, create a Multiple/Single Select Filter using the jQuery multiple-select.js lib
+   * @param {Object} selectElement
    */
-  protected createDomElement(filterTemplate: string) {
+  protected createDomElement(selectElement: HTMLSelectElement) {
     const fieldId = this.columnDef && this.columnDef.id;
 
     // provide the name attribute to the DOM element which will be needed to auto-adjust drop position (dropup / dropdown)
@@ -466,7 +400,7 @@ export class SelectFilter implements Filter {
     $($headerElm).empty();
 
     // create the DOM element & add an ID and filter class
-    this.$filterElm = $(filterTemplate);
+    this.$filterElm = $(selectElement);
     if (typeof this.$filterElm.multipleSelect !== 'function') {
       throw new Error(`multiple-select.js was not found, make sure to modify your "angular-cli.json" file and include "../node_modules/angular-slickgrid/lib/multiple-select/multiple-select.js" and it's css or SASS file`);
     }

--- a/src/app/modules/angular-slickgrid/services/domUtilities.ts
+++ b/src/app/modules/angular-slickgrid/services/domUtilities.ts
@@ -1,0 +1,130 @@
+import { TranslateService } from '@ngx-translate/core';
+import * as DOMPurify_ from 'dompurify';
+const DOMPurify = DOMPurify_; // patch to fix rollup to work
+
+import { Column, SearchTerm, SelectOption, SlickGrid } from '../models/index';
+import { htmlEncode } from './utilities';
+
+/**
+ * Create the HTML DOM Element for a Select Editor or Filter, this is specific to these 2 types only and the unit tests are directly under them
+ * @param {String} type - type of select DOM element to build, can be either 'editor' or 'filter'
+ * @param {Array<Object>} collection - array of items to build the select html options
+ * @param {Array<Object>} columnDef - column definition object
+ * @param {Object} grid - Slick Grid object
+ * @param {Boolean} isMultiSelect - are we building a multiple select element (false means it's a single select)
+ * @param {Object} translaterService - optional Translater Service
+ * @param {Array<*>} searchTerms - optional array of search term (used by the "filter" type only)
+ * @returns object with 2 properties for the select element & a boolean value telling us if any of the search terms were found and selected in the dropdown
+ */
+export function buildSelectEditorOrFilterDomElement(type: 'editor' | 'filter', collection: any[], columnDef: Column, grid: SlickGrid, isMultiSelect = false, translateService?: TranslateService, searchTerms?: SearchTerm[]): { selectElement: HTMLSelectElement; hasFoundSearchTerm: boolean; } {
+  const columnId = columnDef?.id ?? '';
+  const gridOptions = grid.getOptions();
+  const columnFilterOrEditor = (type === 'editor' ? columnDef?.internalColumnEditor : columnDef?.filter) ?? {};
+  const collectionOptions = columnFilterOrEditor?.collectionOptions ?? {};
+  const separatorBetweenLabels = collectionOptions?.separatorBetweenTextLabels ?? '';
+  const enableTranslateLabel = columnFilterOrEditor?.enableTranslateLabel ?? false;
+  const isTranslateEnabled = gridOptions?.enableTranslate ?? false;
+  const isRenderHtmlEnabled = columnFilterOrEditor?.enableRenderHtml ?? false;
+  const sanitizedOptions = gridOptions?.sanitizeHtmlOptions ?? {};
+  const labelName = columnFilterOrEditor?.customStructure?.label ?? 'label';
+  const labelPrefixName = columnFilterOrEditor?.customStructure?.labelPrefix ?? 'labelPrefix';
+  const labelSuffixName = columnFilterOrEditor?.customStructure?.labelSuffix ?? 'labelSuffix';
+  const optionLabel = columnFilterOrEditor?.customStructure?.optionLabel ?? 'value';
+  const valueName = columnFilterOrEditor?.customStructure?.value ?? 'value';
+
+  const selectElement = document.createElement('select');
+  selectElement.className = 'ms-filter search-filter';
+  const extraCssClasses = type === 'filter' ? ['search-filter', `filter-${columnId}`] : ['select-editor', `editor-${columnId}`];
+  selectElement.classList.add(...extraCssClasses);
+
+  selectElement.multiple = isMultiSelect;
+
+  // use an HTML Fragment for performance reason, MDN explains it well as shown below::
+  // The key difference is that because the document fragment isn't part of the actual DOM's structure, changes made to the fragment don't affect the document, cause reflow, or incur any performance impact that can occur when changes are made.
+  const selectOptionsFragment = document.createDocumentFragment();
+
+  let hasFoundSearchTerm = false;
+
+  // collection could be an Array of Strings OR Objects
+  if (Array.isArray(collection)) {
+    if (collection.every((x: any) => typeof x === 'string')) {
+      for (const option of collection) {
+        const selectOptionElm = document.createElement('option');
+        if (type === 'filter' && Array.isArray(searchTerms)) {
+          selectOptionElm.selected = (searchTerms.findIndex(term => term === option) >= 0); // when filter search term is found then select it in dropdown
+        }
+        selectOptionElm.value = option;
+        selectOptionElm.label = option;
+        selectOptionElm.textContent = option;
+        selectOptionsFragment.appendChild(selectOptionElm);
+
+        // if there's at least 1 Filter search term found, we will add the "filled" class for styling purposes
+        // on a single select, we'll also make sure the single value is not an empty string to consider this being filled
+        if ((selectOptionElm.selected && isMultiSelect) || (selectOptionElm.selected && !isMultiSelect && option !== '')) {
+          hasFoundSearchTerm = true;
+        }
+      }
+    } else {
+      // array of objects will require a label/value pair unless a customStructure is passed
+      collection.forEach((option: SelectOption) => {
+        if (!option || (option[labelName] === undefined && option.labelKey === undefined)) {
+          throw new Error(`[Angular-Slickgrid] Select Filter/Editor collection with value/label (or value/labelKey when using Locale) is required to populate the Select list, for example:: { filter: model: Filters.multipleSelect, collection: [ { value: '1', label: 'One' } ]')`);
+        }
+        const selectOptionElm = document.createElement('option');
+        const labelKey = (option.labelKey || option[labelName]) as string;
+        const labelText = ((option.labelKey || (enableTranslateLabel && translateService)) && labelKey && isTranslateEnabled) ? translateService?.instant(labelKey || ' ') : labelKey;
+        let prefixText = option[labelPrefixName] || '';
+        let suffixText = option[labelSuffixName] || '';
+        let selectOptionLabel = option.hasOwnProperty(optionLabel) ? option[optionLabel] : '';
+        if (selectOptionLabel?.toString) {
+          selectOptionLabel = selectOptionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+        }
+
+        // also translate prefix/suffix if enableTranslateLabel is true and text is a string
+        prefixText = (enableTranslateLabel && translateService && prefixText && typeof prefixText === 'string') ? translateService.instant(prefixText || ' ') : prefixText;
+        suffixText = (enableTranslateLabel && translateService && suffixText && typeof suffixText === 'string') ? translateService.instant(suffixText || ' ') : suffixText;
+        selectOptionLabel = (enableTranslateLabel && translateService && selectOptionLabel && typeof selectOptionLabel === 'string') ? translateService.instant(selectOptionLabel || ' ') : selectOptionLabel;
+
+        // add to a temp array for joining purpose and filter out empty text
+        const tmpOptionArray = [prefixText, (typeof labelText === 'string' || typeof labelText === 'number') ? labelText.toString() : labelText, suffixText].filter((text) => text);
+        let optionText = tmpOptionArray.join(separatorBetweenLabels);
+
+        // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
+        // also, the 3rd party lib will saninitze any html code unless it's encoded, so we'll do that
+        if (isRenderHtmlEnabled) {
+          // sanitize any unauthorized html tags like script and others
+          // for the remaining allowed tags we'll permit all attributes
+          const sanitizedText = (DOMPurify.sanitize(optionText, sanitizedOptions) || '').toString();
+          optionText = htmlEncode(sanitizedText);
+          selectOptionElm.innerHTML = optionText;
+        } else {
+          selectOptionElm.textContent = optionText;
+        }
+
+        // html text of each select option
+        let selectOptionValue = option[valueName];
+        if (selectOptionValue === undefined || selectOptionValue === null) {
+          selectOptionValue = '';
+        }
+
+        if (type === 'filter' && Array.isArray(searchTerms)) {
+          selectOptionElm.selected = (searchTerms.findIndex(term => `${term}` === `${option[valueName]}`) >= 0); // when filter search term is found then select it in dropdown
+        }
+        selectOptionElm.value = `${selectOptionValue}`;
+        selectOptionElm.label = `${selectOptionLabel ?? ''}`;
+        selectOptionsFragment.appendChild(selectOptionElm);
+
+        // if there's a search term, we will add the "filled" class for styling purposes
+        // on a single select, we'll also make sure the single value is not an empty string to consider this being filled
+        if ((selectOptionElm.selected && isMultiSelect) || (selectOptionElm.selected && !isMultiSelect && option[valueName] !== '')) {
+          hasFoundSearchTerm = true;
+        }
+      });
+    }
+  }
+
+  // last step append the HTML fragment to the final select DOM element
+  selectElement.appendChild(selectOptionsFragment);
+
+  return { selectElement, hasFoundSearchTerm };
+}

--- a/src/app/modules/angular-slickgrid/services/index.ts
+++ b/src/app/modules/angular-slickgrid/services/index.ts
@@ -3,6 +3,7 @@ export * from './backend-utilities';
 export * from './bindingEvent.service';
 export * from './bsDropdown.service';
 export * from './collection.service';
+export * from './domUtilities';
 export * from './excelExport.service';
 export * from './export.service';
 export * from './extension.service';


### PR DESCRIPTION
- instead of building the select dom element via a string and jQuery. We could instead create these select options as native DOM elements and from there create the jQuery element which the multiple-select.js lib requires. This rewrite should provide a decent performance improvement (especially if we have a huge set of options and will avoid allocating memory for a string that could be come extremly long to hold all the select options for example "<select><option value="true" label="True">True</option>...</select>")