### PR TITLE
fix(plugin): row move shouldn't go further when onBefore returns false

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@typescript-eslint/eslint-plugin": "4.23.0",
     "@typescript-eslint/parser": "4.23.0",
     "autoprefixer": "^10.2.6",
+    "babel-jest": "^24.9.0",
     "bootstrap": "^5.0.1",
     "codecov": "^3.8.2",
     "codelyzer": "^6.0.2",

--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -132,10 +132,10 @@ export class GridRowMoveComponent implements OnInit {
     this.dataset = mockDataset;
   }
 
-  onBeforeMoveRow(e: Event, data: any) {
-    for (let i = 0; i < data.rows.length; i++) {
+  onBeforeMoveRow(e: Event, data: { rows: number[]; insertBefore: number; }) {
+    for (const rowIdx of data.rows) {
       // no point in moving before or after itself
-      if (data.rows[i] === data.insertBefore || data.rows[i] === data.insertBefore - 1) {
+      if (rowIdx === data.insertBefore || rowIdx === data.insertBefore - 1) {
         e.stopPropagation();
         return false;
       }

--- a/src/app/modules/angular-slickgrid/extensions/rowMoveManagerExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/rowMoveManagerExtension.ts
@@ -101,7 +101,7 @@ export class RowMoveManagerExtension implements Extension {
         }
         this._eventHandler.subscribe(this._addon.onBeforeMoveRows, (e: any, args: CellArgs) => {
           if (this.sharedService.gridOptions.rowMoveManager && typeof this.sharedService.gridOptions.rowMoveManager.onBeforeMoveRows === 'function') {
-            this.sharedService.gridOptions.rowMoveManager.onBeforeMoveRows(e, args);
+            return this.sharedService.gridOptions.rowMoveManager.onBeforeMoveRows(e, args);
           }
         });
         this._eventHandler.subscribe(this._addon.onMoveRows, (e: any, args: CellArgs) => {

--- a/src/app/modules/angular-slickgrid/models/rowMoveManager.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/rowMoveManager.interface.ts
@@ -34,7 +34,7 @@ export interface RowMoveManager {
   onExtensionRegistered?: (plugin: any) => void;
 
   /** SlickGrid Event fired before the row is moved. */
-  onBeforeMoveRows?: (e: Event, args: any) => void;
+  onBeforeMoveRows?: (e: Event, args: any) => boolean | void;
 
   /** SlickGrid Event fired while the row is moved. */
   onMoveRows?: (e: Event, args: any) => void;


### PR DESCRIPTION
this fixes a problem caught with our current project, we shouldn't call a Save if we're dropping the row at the exact same place it originated from, see animated gif for explanation

#### BEFORE fix 
(we can see blue line appears even when we didn't really move the row)
![rCXUu8Z9le](https://user-images.githubusercontent.com/643976/120833660-0bae3380-c530-11eb-8a44-258576789f35.gif)

#### AFTER fix 
(blue line doesn't appear if we don't end up moving the row since the position is the same)
![GjGbNPatCK](https://user-images.githubusercontent.com/643976/120833837-41531c80-c530-11eb-889b-3c84e48ce266.gif)
