### PR TITLE
fix(editors): longText Editor (textarea) was scrolling to page bottom

### DIFF
--- a/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
+++ b/src/app/modules/angular-slickgrid/editors/longTextEditor.ts
@@ -157,9 +157,9 @@ export class LongTextEditor implements Editor {
     editorFooterElm.appendChild(saveBtnElm);
     this._bindEventService.bind(cancelBtnElm, 'click', this.cancel.bind(this) as EventListener);
     this._bindEventService.bind(saveBtnElm, 'click', this.save.bind(this) as EventListener);
+    this.position(this.args?.position);
     this._textareaElm.focus();
     this._textareaElm.select();
-    this.position(this.args?.position);
     this._wrapperElm.appendChild(editorFooterElm);
 
     this._bindEventService.bind(this._textareaElm, 'keydown', this.handleKeyDown.bind(this) as EventListener);


### PR DESCRIPTION
- the previous commit to convert jQuery to vanilla JS brought a small issue that was only noticeable when defining a fixed grid height, when that was set and user clicked on the textarea editor it will scrolling to the bottom of the page. This happened because the textarea must be created on the body instead of within the grid and we do a re-positioning of the DOM element to the position of the cell, and the issue was because we focus/select the text content right after it was created (before re-positioning it) and so it was going to the bottom for that reason, we simply need to re-position it BEFORE focusing/selecting the text content