### PR TITLE
chore(styling): add polyfill to latest dart-sass warnings with division

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "require-dir": "^1.2.0",
     "rimraf": "^3.0.2",
     "run-sequence": "^2.2.1",
-    "sass": "~1.32.13",
+    "sass": "^1.34.1",
     "standard-version": "^9.3.0",
     "stream-browserify": "^3.0.0",
     "ts-node": "^10.0.0",

--- a/src/app/modules/angular-slickgrid/styles/_private.scss
+++ b/src/app/modules/angular-slickgrid/styles/_private.scss
@@ -1,0 +1,27 @@
+@use 'sass:math';
+@use 'sass:meta';
+@use 'sass:list';
+
+// Private polyfill for the `math.div` function from Sass to be used until we can update the
+// minimum required Sass version to 1.34.0 or above.
+// TODO: replace with `math.div` eventually, maybe in 6 months or a year from now.
+@function private-div($a, $b) {
+  @if (meta.function-exists('div', 'math')) {
+    @return math.div($a, $b);
+  }
+  @else {
+    @return $a / $b;
+  }
+}
+
+// Private polyfill for the `list.slash` function from Sass to be used until we can update the
+// minimum required Sass version to 1.34.0 or above.
+// TODO: replace with `list.slash` eventually, maybe in 6 months or a year from now.
+@function private-slash($a, $b) {
+  @if (meta.function-exists('slash', 'list')) {
+    @return list.slash($a, $b);
+  }
+  @else {
+    @return #{$a}#{' / '}#{$b};
+  }
+}

--- a/src/app/modules/angular-slickgrid/styles/sass-utilities.scss
+++ b/src/app/modules/angular-slickgrid/styles/sass-utilities.scss
@@ -1,3 +1,5 @@
+@use './private';
+
 @function encodecolor($string) {
 	@if type-of($string) == 'color' {
         $hex: str-slice(ie-hex-str($string), 4);
@@ -8,9 +10,9 @@
 }
 
 @mixin recolor($color: #000, $opacity: 1) {
-  $r: red($color) / 255;
-  $g: green($color) / 255;
-  $b: blue($color) / 255;
+  $r: private.private-div(red($color), 255);
+  $g: private.private-div(green($color), 255);
+  $b: private.private-div(blue($color), 255);
   $a: $opacity;
 
   // grayscale fallback if SVG from data url is not supported
@@ -40,8 +42,6 @@
     display: $display;
     vertical-align: bottom;
     margin-top: -1px; // small patch to remove padding all around the SVG
-    content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="#{$fill}" viewBox="0 0 24 24">\
-        <path d="#{$path-drawing}"></path>\
-      </svg>');
+    content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="#{$fill}" viewBox="0 0 24 24"><path d="#{$path-drawing}"></path></svg>');
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10025,10 +10025,10 @@ sass@^1.32.8:
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
-sass@~1.32.13:
-  version "1.32.13"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
-  integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==
+sass@^1.34.1:
+  version "1.34.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.34.1.tgz#30f45c606c483d47b634f1e7371e13ff773c96ef"
+  integrity sha512-scLA7EIZM+MmYlej6sdVr0HRbZX5caX5ofDT9asWnUJj21oqgsC+1LuNfm0eg+vM0fCTZHhwImTiCU0sx9h9CQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
- The latest version of Dart-Sass prints a bunch warnings when the division operator is used. These changes migrate us to the recommended `math.div` function and won't break users that aren't using latest Dart-Sass yet
- use the same technique as Angular UI from shown in this [PR](https://github.com/angular/components/commit/a4043f41f539ed910c80c780e1815f5625282b94) from them