### PR TITLE
fix(addon): providing columnIndexPosition should always work

### DIFF
--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -70,6 +70,8 @@ export class GridRowMoveComponent implements OnInit {
       enableFiltering: true,
       enableCheckboxSelector: true,
       checkboxSelector: {
+        columnIndexPosition: 1,
+
         // you can toggle these 2 properties to show the "select all" checkbox in different location
         hideInFilterHeaderRow: false,
         hideInColumnTitleRow: true
@@ -95,7 +97,7 @@ export class GridRowMoveComponent implements OnInit {
         // you can change the move icon position of any extension (RowMove, RowDetail or RowSelector icon)
         // note that you might have to play with the position when using multiple extension
         // since it really depends on which extension get created first to know what their real position are
-        // columnIndexPosition: 1,
+        columnIndexPosition: 0,
 
         // you can also override the usability of the rows, for example make every 2nd row the only moveable rows,
         // usabilityOverride: (row, dataContext, grid) => dataContext.id % 2 === 1

--- a/src/app/modules/angular-slickgrid/services/extension.service.ts
+++ b/src/app/modules/angular-slickgrid/services/extension.service.ts
@@ -31,6 +31,12 @@ import {
 } from '../extensions/index';
 import { SharedService } from './shared.service';
 
+interface ExtensionWithColumnIndexPosition {
+  name: ExtensionName;
+  position: number;
+  extension: CheckboxSelectorExtension | RowDetailViewExtension | RowMoveManagerExtension;
+}
+
 @Injectable()
 export class ExtensionService {
   private _extensionCreatedList: ExtensionList = {} as ExtensionList;
@@ -277,32 +283,39 @@ export class ExtensionService {
    * Bind/Create certain plugins before the Grid creation to avoid having odd behaviors.
    * Mostly because the column definitions might change after the grid creation, so we want to make sure to add it before then
    * @param columnDefinitions
-   * @param options
+   * @param gridOptions
    */
-  createExtensionsBeforeGridCreation(columnDefinitions: Column[], options: GridOption) {
-    if (options.enableCheckboxSelector) {
+  createExtensionsBeforeGridCreation(columnDefinitions: Column[], gridOptions: GridOption) {
+    const featureWithColumnIndexPositions: { name: ExtensionName; position: number; extension: CheckboxSelectorExtension | RowDetailViewExtension | RowMoveManagerExtension; }[] = [];
+
+    // the following 3 features might have `columnIndexPosition` that we need to respect their column order, we will execute them by their sort order further down
+    // we push them into a array and we'll process them by their position (if provided, else use same order that they were inserted)
+    if (gridOptions.enableCheckboxSelector) {
       if (!this.getCreatedExtensionByName(ExtensionName.checkboxSelector)) {
-        const checkboxInstance = this.checkboxSelectorExtension.create(columnDefinitions, options);
-        this._extensionCreatedList[ExtensionName.checkboxSelector] = { name: ExtensionName.checkboxSelector, addon: checkboxInstance, instance: checkboxInstance, class: this.checkboxSelectorExtension };
+        featureWithColumnIndexPositions.push({ name: ExtensionName.checkboxSelector, extension: this.checkboxSelectorExtension, position: gridOptions?.checkboxSelector?.columnIndexPosition ?? featureWithColumnIndexPositions.length });
       }
     }
-    if (options.enableRowMoveManager) {
+    if (gridOptions.enableRowMoveManager) {
       if (!this.getCreatedExtensionByName(ExtensionName.rowMoveManager)) {
-        const rowMoveInstance = this.rowMoveManagerExtension.create(columnDefinitions, options);
-        this._extensionCreatedList[ExtensionName.rowMoveManager] = { name: ExtensionName.rowMoveManager, addon: rowMoveInstance, instance: rowMoveInstance, class: this.rowMoveManagerExtension };
+        featureWithColumnIndexPositions.push({ name: ExtensionName.rowMoveManager, extension: this.rowMoveManagerExtension, position: gridOptions?.rowMoveManager?.columnIndexPosition ?? featureWithColumnIndexPositions.length });
       }
     }
-    if (options.enableRowDetailView) {
+    if (gridOptions.enableRowDetailView) {
       if (!this.getCreatedExtensionByName(ExtensionName.rowDetailView)) {
-        const rowDetailInstance = this.rowDetailViewExtension.create(columnDefinitions, options);
-        this._extensionCreatedList[ExtensionName.rowDetailView] = { name: ExtensionName.rowDetailView, addon: rowDetailInstance, instance: rowDetailInstance, class: this.rowDetailViewExtension };
+        featureWithColumnIndexPositions.push({ name: ExtensionName.rowDetailView, extension: this.rowDetailViewExtension, position: gridOptions?.rowDetailView?.columnIndexPosition ?? featureWithColumnIndexPositions.length });
       }
     }
-    if (options.enableDraggableGrouping) {
+
+    // since some features could have a `columnIndexPosition`, we need to make sure these indexes are respected in the column definitions
+    this.createExtensionByTheirColumnIndex(featureWithColumnIndexPositions, columnDefinitions, gridOptions);
+
+    if (gridOptions.enableDraggableGrouping) {
       if (!this.getCreatedExtensionByName(ExtensionName.draggableGrouping)) {
-        const draggableInstance = this.draggableGroupingExtension.create(options);
-        options.enableColumnReorder = draggableInstance.getSetupColumnReorder;
-        this._extensionCreatedList[ExtensionName.draggableGrouping] = { name: ExtensionName.draggableGrouping, addon: draggableInstance, instance: draggableInstance, class: draggableInstance.getSetupColumnReorder };
+        const draggableInstance = this.draggableGroupingExtension.create(gridOptions);
+        if (draggableInstance) {
+          gridOptions.enableColumnReorder = draggableInstance.getSetupColumnReorder;
+          this._extensionCreatedList[ExtensionName.draggableGrouping] = { name: ExtensionName.draggableGrouping, addon: draggableInstance, instance: draggableInstance, class: this.draggableGroupingExtension };
+        }
       }
     }
   }
@@ -438,6 +451,27 @@ export class ExtensionService {
   //
   // private functions
   // -------------------
+
+  /**
+   * Some extension (feature) have specific `columnIndexPosition` that the developer want to use, we need to make sure these indexes are respected in the column definitions in the order provided.
+   * the following 3 features might have `columnIndexPosition` that we need to respect their column order, we will execute them by their sort order further down
+   * we push them into a array and we'll process them by their position (if provided, else use same order that they were inserted)
+   * @param featureWithIndexPositions
+   * @param columnDefinitions
+   * @param gridOptions
+   */
+  private createExtensionByTheirColumnIndex(featureWithIndexPositions: ExtensionWithColumnIndexPosition[], columnDefinitions: Column[], gridOptions: GridOption) {
+    // 1- first step is to sort them by their index position
+    featureWithIndexPositions.sort((feat1, feat2) => feat1.position - feat2.position);
+
+    // 2- second step, we can now proceed to create each extension/addon and that will position them accordingly in the column definitions list
+    featureWithIndexPositions.forEach(feature => {
+      const instance = feature.extension.create(columnDefinitions, gridOptions);
+      if (instance) {
+        this._extensionCreatedList[feature.name] = { name: feature.name, addon: instance, instance, class: feature.extension };
+      }
+    });
+  }
 
   /**
    * Get an Extension that was created by calling its "create" method (there are only 3 extensions which uses this method)


### PR DESCRIPTION
- providing columnIndexPosition should work regardless of when the extension (plugin) is created, basically the previous code was assuming that you will always want the checkbox before the row move plugin but that is not always true and the other way around wasn't possible while this PR fixes it