### PR TITLE
fix(menu): toggle filter bar could be out of sync w/horizontal scroll

### DIFF
--- a/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
@@ -42,6 +42,7 @@ const gridStub = {
   getSelectedRows: jest.fn(),
   getUID: () => gridUid,
   registerPlugin: jest.fn(),
+  scrollColumnIntoView: jest.fn(),
   setColumns: jest.fn(),
   setOptions: jest.fn(),
   setHeaderRowVisibility: jest.fn(),
@@ -734,7 +735,8 @@ describe('gridMenuExtension', () => {
 
       it('should call the grid "setHeaderRowVisibility" method when the command triggered is "toggle-filter"', () => {
         gridOptionsMock.showHeaderRow = false;
-        const gridSpy = jest.spyOn(SharedService.prototype.grid, 'setHeaderRowVisibility');
+        const setHeaderSpy = jest.spyOn(gridStub, 'setHeaderRowVisibility');
+        const scrollSpy = jest.spyOn(gridStub, 'scrollColumnIntoView');
         const onCommandSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu as GridMenu, 'onCommand');
         const setColumnSpy = jest.spyOn(SharedService.prototype.grid, 'setColumns');
 
@@ -742,14 +744,15 @@ describe('gridMenuExtension', () => {
         instance.onCommand.notify({ grid: gridStub, command: 'toggle-filter' }, new Slick.EventData(), gridStub);
 
         expect(onCommandSpy).toHaveBeenCalled();
-        expect(gridSpy).toHaveBeenCalledWith(true);
+        expect(setHeaderSpy).toHaveBeenCalledWith(true);
+        expect(scrollSpy).toHaveBeenCalledWith(0);
         expect(setColumnSpy).toHaveBeenCalledTimes(1);
 
         gridOptionsMock.showHeaderRow = true;
         instance.onCommand.notify({ grid: gridStub, command: 'toggle-filter' }, new Slick.EventData(), gridStub);
 
         expect(onCommandSpy).toHaveBeenCalled();
-        expect(gridSpy).toHaveBeenCalledWith(false);
+        expect(setHeaderSpy).toHaveBeenCalledWith(false);
         expect(setColumnSpy).toHaveBeenCalledTimes(1); // same as before, so count won't increase
       });
 

--- a/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/app/modules/angular-slickgrid/extensions/gridMenuExtension.ts
@@ -449,6 +449,7 @@ export class GridMenuExtension implements Extension {
           // when displaying header row, we'll call "setColumns" which in terms will recreate the header row filters
           if (showHeaderRow === true) {
             this.sharedService.grid.setColumns(this.sharedService.columnDefinitions);
+            this.sharedService.grid.scrollColumnIntoView(0); // quick fix to avoid filter being out of sync with horizontal scroll
           }
           break;
         case 'toggle-toppanel':


### PR DESCRIPTION
- when toggling the filter bar (on and off), the horizontal scroll could become out of sync (the alignment of the filters with the column and its data), this happen because the filters are recreated every time we toggle back the filter bar, for that issue we simply need to move the horizontal scroll back to top-left and that fixes the issue
- this bug was reported over Stack Overflow with this [SO question](https://stackoverflow.com/questions/67986388/angular-slickgrid-column-filter-box-alignment-issue)

animated gif of the issue

![0sQTgafZO1](https://user-images.githubusercontent.com/643976/122275609-e4e9e880-ceb1-11eb-99d8-604d7264f3a0.gif)
