### PR TITLE
fix(formatters): shouldn't auto-add editor formatter multiple times

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/slick-vanilla-utilities.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/slick-vanilla-utilities.spec.ts
@@ -34,5 +34,18 @@ describe('Slick-Vanilla-Grid-Bundle / Utilies', () => {
         { id: 'zip', field: 'address.zip', type: FieldType.number, formatter: Formatters.complexObject },
       ]);
     });
+
+    it('should have custom editor formatter with correct structure even if we call it twice', () => {
+      autoAddEditorFormatterToColumnsWithEditor(columnDefinitions, customEditableInputFormatter);
+      autoAddEditorFormatterToColumnsWithEditor(columnDefinitions, customEditableInputFormatter);
+
+      expect(columnDefinitions).toEqual([
+        { id: 'firstName', field: 'firstName', editor: { model: Editors.text }, formatter: customEditableInputFormatter },
+        { id: 'lastName', field: 'lastName', editor: { model: Editors.text }, formatter: Formatters.multiple, params: { formatters: [Formatters.italic, Formatters.bold, customEditableInputFormatter] } },
+        { id: 'age', field: 'age', type: 'number', formatter: Formatters.multiple },
+        { id: 'address', field: 'address.street', editor: { model: Editors.longText }, formatter: Formatters.multiple, params: { formatters: [Formatters.complexObject, customEditableInputFormatter] } },
+        { id: 'zip', field: 'address.zip', type: 'number', formatter: Formatters.complexObject },
+      ]);
+    });
   });
 });

--- a/src/app/modules/angular-slickgrid/components/slick-vanilla-utilities.ts
+++ b/src/app/modules/angular-slickgrid/components/slick-vanilla-utilities.ts
@@ -11,12 +11,15 @@ export function autoAddEditorFormatterToColumnsWithEditor(columnDefinitions: Col
   if (Array.isArray(columnDefinitions)) {
     for (const columnDef of columnDefinitions) {
       if (columnDef.editor) {
-        if (columnDef.formatter && columnDef.formatter !== Formatters.multiple) {
+        if (columnDef.formatter && columnDef.formatter !== Formatters.multiple && columnDef.formatter !== customEditableFormatter) {
           const prevFormatter = columnDef.formatter;
           columnDef.formatter = Formatters.multiple;
           columnDef.params = { ...columnDef.params, formatters: [prevFormatter, customEditableFormatter] };
         } else if (columnDef.formatter && columnDef.formatter === Formatters.multiple && columnDef.params) {
-          columnDef.params.formatters = [...columnDef.params.formatters, customEditableFormatter];
+          // before adding the formatter, make sure it's not yet in the params.formatters list, we wouldn't want to add it multiple times
+          if (columnDef.params.formatters.findIndex((formatter: Formatter) => formatter === customEditableFormatter) === -1) {
+            columnDef.params.formatters = [...columnDef.params.formatters, customEditableFormatter];
+          }
         } else {
           columnDef.formatter = customEditableFormatter;
         }


### PR DESCRIPTION
- basically if our Custom Editor Formatter is already in the column definitions and we re-ran `autoAddEditorFormatterToColumnsWithEditor` method for any reasons (this happen when changing column definitions via its setter) then we want to make sure that we don't add the same formatter over and over

below is an example of the bug when it happens, we can see the editor formatter (the cell with outlines) are added multiple times and show multiple outlines
![image](https://user-images.githubusercontent.com/643976/122475586-dfb09a80-cf92-11eb-9373-dd36875b3aac.png)

and after the fix, we now see the outline only once because the editor formatter will never be added more than once 
![image](https://user-images.githubusercontent.com/643976/122475651-fb1ba580-cf92-11eb-8e09-4fac5a2c158e.png)
