### PR TITLE
fix(styling): header title should show ellipsis if too long

### DIFF
--- a/src/app/modules/angular-slickgrid/styles/slick-grid.scss
+++ b/src/app/modules/angular-slickgrid/styles/slick-grid.scss
@@ -206,6 +206,9 @@
 
   .slick-column-name {
     text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: #{$header-row-count};
   }
 
   .slick-resizable-handle {


### PR DESCRIPTION
- column header titles that are too long should show the "..." ellipsis and that was not working because it's a bit different with text over multiple lines

![image](https://user-images.githubusercontent.com/643976/123172878-c359a580-d44b-11eb-82a0-c2f6827b33ae.png)
