### PR TITLE
fix(pagination): should be able to toggle Pagination

### DIFF
--- a/src/app/modules/angular-slickgrid/components/slick-pagination.component.ts
+++ b/src/app/modules/angular-slickgrid/components/slick-pagination.component.ts
@@ -131,8 +131,6 @@ export class SlickPaginationComponent implements OnDestroy, OnInit {
   }
 
   dispose() {
-    this.paginationService?.dispose();
-
     // also unsubscribe all Angular Subscriptions
     this.subscriptions = unsubscribeAllObservables(this.subscriptions);
   }

--- a/src/app/modules/angular-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -5,6 +5,7 @@ import { SharedService } from '../shared.service';
 import { FilterService, GridService } from '../index';
 import { Column, GridOption, CurrentFilter } from '../../models';
 import * as utilities from '../backend-utilities';
+import { BackendServiceApi, Pagination } from 'dist/public_api';
 
 declare const Slick: any;
 
@@ -86,9 +87,9 @@ describe('PaginationService', () => {
   });
 
   afterEach(() => {
-    mockGridOption.pagination.pageSize = 25;
-    mockGridOption.pagination.pageNumber = 2;
-    mockGridOption.pagination.totalItems = 85;
+    mockGridOption.pagination!.pageSize = 25;
+    mockGridOption.pagination!.pageNumber = 2;
+    mockGridOption.pagination!.totalItems = 85;
     service.dispose();
     jest.clearAllMocks();
   });
@@ -99,7 +100,7 @@ describe('PaginationService', () => {
 
   it('should initialize the service and call "refreshPagination" and trigger "onPaginationChanged" event', () => {
     const refreshSpy = jest.spyOn(service, 'refreshPagination');
-    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+    service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
 
     expect(service.paginationOptions).toEqual(mockGridOption.pagination);
     expect(refreshSpy).toHaveBeenCalled();
@@ -107,8 +108,8 @@ describe('PaginationService', () => {
   });
 
   it('should initialize the service and be able to change the grid options by the SETTER and expect the GETTER to have updated options', () => {
-    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-    service.paginationOptions = mockGridOption.pagination;
+    service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
+    service.paginationOptions = mockGridOption.pagination as Pagination;
 
     expect(service.paginationOptions).toEqual(mockGridOption.pagination);
     expect(service.getCurrentPageNumber()).toBe(2);
@@ -117,7 +118,7 @@ describe('PaginationService', () => {
   it('should initialize the service and be able to change the totalItems by the SETTER and not expect the "refreshPagination" method to be called within the SETTER before initialization', () => {
     const spy = jest.spyOn(service, 'refreshPagination');
     service.totalItems = 125;
-    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+    service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
 
     expect(service.totalItems).toEqual(125);
     expect(service.getCurrentPageNumber()).toBe(2);
@@ -126,7 +127,7 @@ describe('PaginationService', () => {
 
   it('should be able to change the totalItems by the SETTER after the initialization and expect the "refreshPagination" method to be called', () => {
     const spy = jest.spyOn(service, 'refreshPagination');
-    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+    service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
     service.totalItems = 125;
 
     expect(service.totalItems).toEqual(125);
@@ -136,33 +137,33 @@ describe('PaginationService', () => {
 
   describe('Getters and Setters', () => {
     it('should get the availablePageSizes and equal the one defined in the grid options pagination', () => {
-      mockGridOption.pagination.pageSizes = [5, 10, 15, 20];
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
-      expect(service.availablePageSizes).toEqual(mockGridOption.pagination.pageSizes);
+      mockGridOption.pagination!.pageSizes = [5, 10, 15, 20];
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
+      expect(service.availablePageSizes).toEqual(mockGridOption.pagination!.pageSizes);
     });
 
     it('should get the itemsPerPage and equal the one defined in the grid options pagination', () => {
-      mockGridOption.pagination.pageSize = 20;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
-      expect(service.itemsPerPage).toEqual(mockGridOption.pagination.pageSize);
+      mockGridOption.pagination!.pageSize = 20;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
+      expect(service.itemsPerPage).toEqual(mockGridOption.pagination!.pageSize);
     });
 
     it('should get the pageCount and equal the one defined in the grid options pagination', () => {
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
       expect(service.pageCount).toEqual(4); // since totalItems is 85 and our pageSize is 20/page
     });
 
     it('should get the pageNumber and equal the one defined in the grid options pagination', () => {
-      mockGridOption.pagination.pageNumber = 3;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
-      expect(service.pageNumber).toEqual(mockGridOption.pagination.pageNumber);
+      mockGridOption.pagination!.pageNumber = 3;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
+      expect(service.pageNumber).toEqual(mockGridOption.pagination!.pageNumber);
     });
   });
 
   describe('changeItemPerPage method', () => {
     it('should be on page 0 when total items is 0', () => {
-      mockGridOption.pagination.totalItems = 0;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      mockGridOption.pagination!.totalItems = 0;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.changeItemPerPage(30);
 
       expect(service.getCurrentPageNumber()).toBe(0);
@@ -170,11 +171,11 @@ describe('PaginationService', () => {
     });
 
     it('should be on page 1 with 2 pages when total items is 51 and we set 50 per page', () => {
-      mockGridOption.pagination.pageSize = 25;
-      mockGridOption.pagination.pageNumber = 2;
-      mockGridOption.pagination.totalItems = 51;
+      mockGridOption.pagination!.pageSize = 25;
+      mockGridOption.pagination!.pageNumber = 2;
+      mockGridOption.pagination!.totalItems = 51;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.changeItemPerPage(50);
 
       expect(service.getCurrentPageNumber()).toBe(1);
@@ -182,11 +183,11 @@ describe('PaginationService', () => {
     });
 
     it('should be on page 1 with 2 pages when total items is 100 and we set 50 per page', () => {
-      mockGridOption.pagination.pageSize = 25;
-      mockGridOption.pagination.pageNumber = 2;
-      mockGridOption.pagination.totalItems = 100;
+      mockGridOption.pagination!.pageSize = 25;
+      mockGridOption.pagination!.pageNumber = 2;
+      mockGridOption.pagination!.totalItems = 100;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.changeItemPerPage(50);
 
       expect(service.getCurrentPageNumber()).toBe(1);
@@ -197,7 +198,7 @@ describe('PaginationService', () => {
   describe('goToFirstPage method', () => {
     it('should expect current page to be 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToFirstPage();
 
       expect(service.dataFrom).toBe(1);
@@ -211,7 +212,7 @@ describe('PaginationService', () => {
     it('should call "goToLastPage" method and expect current page to be last page and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToLastPage();
 
       expect(service.dataFrom).toBe(76);
@@ -225,7 +226,7 @@ describe('PaginationService', () => {
     it('should expect page to increment by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToNextPage();
 
       expect(service.dataFrom).toBe(51);
@@ -237,7 +238,7 @@ describe('PaginationService', () => {
     it('should expect page to increment by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToNextPage();
 
       expect(service.dataFrom).toBe(51);
@@ -248,9 +249,9 @@ describe('PaginationService', () => {
 
     it('should not expect "processOnPageChanged" method to be called when we are already on last page', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
-      mockGridOption.pagination.pageNumber = 4;
+      mockGridOption.pagination!.pageNumber = 4;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToNextPage();
 
       expect(service.dataFrom).toBe(76);
@@ -264,7 +265,7 @@ describe('PaginationService', () => {
     it('should expect page to decrement by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToPreviousPage();
 
       expect(service.dataFrom).toBe(1);
@@ -275,9 +276,9 @@ describe('PaginationService', () => {
 
     it('should not expect "processOnPageChanged" method to be called when we are already on first page', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
-      mockGridOption.pagination.pageNumber = 1;
+      mockGridOption.pagination!.pageNumber = 1;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToPreviousPage();
 
       expect(service.dataFrom).toBe(1);
@@ -292,7 +293,7 @@ describe('PaginationService', () => {
     it('should expect page to decrement by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(4);
 
       expect(service.dataFrom).toBe(76);
@@ -304,7 +305,7 @@ describe('PaginationService', () => {
     it('should expect to go to page 1 when input number is below 1', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(0);
 
       expect(service.dataFrom).toBe(1);
@@ -316,7 +317,7 @@ describe('PaginationService', () => {
     it('should expect to go to last page (4) when input number is bigger than the last page number', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(10);
 
       expect(service.dataFrom).toBe(76);
@@ -327,9 +328,9 @@ describe('PaginationService', () => {
 
     it('should not expect "processOnPageChanged" method to be called when we are already on same page', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
-      mockGridOption.pagination.pageNumber = 2;
+      mockGridOption.pagination!.pageNumber = 2;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(2);
 
       expect(service.dataFrom).toBe(26);
@@ -353,9 +354,9 @@ describe('PaginationService', () => {
 
     it('should execute "preProcess" method when defined', () => {
       const spy = jest.fn();
-      mockGridOption.backendServiceApi.preProcess = spy;
+      mockGridOption.backendServiceApi!.preProcess = spy;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.processOnPageChanged(1);
 
       expect(spy).toHaveBeenCalled();
@@ -364,13 +365,13 @@ describe('PaginationService', () => {
     it('should execute "process" method and catch error when process Promise rejects', async () => {
       const mockError = { error: '404' };
       const postSpy = jest.fn();
-      mockGridOption.backendServiceApi.process = postSpy;
+      mockGridOption.backendServiceApi!.process = postSpy;
       jest.spyOn(mockBackendService, 'processOnPaginationChanged').mockReturnValue('backend query');
       const promise = new Promise((resolve, reject) => setTimeout(() => reject(mockError), 1));
-      jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(promise);
+      jest.spyOn(mockGridOption.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(promise);
 
       try {
-        service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+        service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
         await service.processOnPageChanged(1);
       } catch (e) {
         expect(mockBackendError).toHaveBeenCalledWith(mockError, mockGridOption.backendServiceApi);
@@ -380,12 +381,12 @@ describe('PaginationService', () => {
     it('should execute "process" method and catch error when process Observable fails', async () => {
       const mockError = { error: '404' };
       const postSpy = jest.fn();
-      mockGridOption.backendServiceApi.process = postSpy;
+      mockGridOption.backendServiceApi!.process = postSpy;
       jest.spyOn(mockBackendService, 'processOnPaginationChanged').mockReturnValue('backend query');
-      jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(throwError(mockError));
+      jest.spyOn(mockGridOption.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(throwError(mockError));
 
       try {
-        service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+        service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
         await service.processOnPageChanged(1);
       } catch (e) {
         expect(mockBackendError).toHaveBeenCalledWith(mockError, mockGridOption.backendServiceApi);
@@ -394,14 +395,14 @@ describe('PaginationService', () => {
 
     it('should execute "process" method when defined', (done) => {
       const postSpy = jest.fn();
-      mockGridOption.backendServiceApi.process = postSpy;
+      mockGridOption.backendServiceApi!.process = postSpy;
       jest.spyOn(mockBackendService, 'processOnPaginationChanged').mockReturnValue('backend query');
       const now = new Date();
       const processResult = { users: [{ name: 'John' }], metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 } };
       const promise = new Promise((resolve) => setTimeout(() => resolve(processResult), 1));
-      jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(promise);
+      jest.spyOn(mockGridOption.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(promise);
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.processOnPageChanged(1);
 
       setTimeout(() => {
@@ -413,13 +414,13 @@ describe('PaginationService', () => {
 
     it('should execute "process" method when defined', (done) => {
       const postSpy = jest.fn();
-      mockGridOption.backendServiceApi.process = postSpy;
+      mockGridOption.backendServiceApi!.process = postSpy;
       jest.spyOn(mockBackendService, 'processOnPaginationChanged').mockReturnValue('backend query');
       const now = new Date();
       const processResult = { users: [{ name: 'John' }], metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 } };
-      jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(of(processResult));
+      jest.spyOn(mockGridOption.backendServiceApi as BackendServiceApi, 'process').mockReturnValue(of(processResult));
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.processOnPageChanged(1);
 
       setTimeout(() => {
@@ -433,13 +434,13 @@ describe('PaginationService', () => {
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
       const onPaginationSpy = jest.spyOn(service.onPaginationChanged, 'next');
 
-      mockGridOption.backendServiceApi = null;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      mockGridOption.backendServiceApi = null as any;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.processOnPageChanged(1);
 
       expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: 25, pageNum: 0 });
       expect(onPaginationSpy).toHaveBeenCalledWith({
-        pageSizes: mockGridOption.pagination.pageSizes,
+        pageSizes: mockGridOption.pagination!.pageSizes,
         dataFrom: 26,
         pageSize: 25,
         pageCount: 4,
@@ -453,24 +454,24 @@ describe('PaginationService', () => {
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
       const onPaginationSpy = jest.spyOn(service.onPaginationChanged, 'next');
 
-      mockGridOption.backendServiceApi = null;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      mockGridOption.backendServiceApi = null as any;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.processOnPageChanged(1);
 
       expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: 25, pageNum: 0 });
       expect(onPaginationSpy).toHaveBeenCalledWith({
-        dataFrom: 26, dataTo: 50, pageSize: 25, pageCount: 4, pageNumber: 2, totalItems: 85, pageSizes: mockGridOption.pagination.pageSizes,
+        dataFrom: 26, dataTo: 50, pageSize: 25, pageCount: 4, pageNumber: 2, totalItems: 85, pageSizes: mockGridOption.pagination!.pageSizes,
       });
     });
   });
 
   describe('recalculateFromToIndexes method', () => {
     it('should recalculate the From/To as 0 when total items is 0', () => {
-      mockGridOption.pagination.pageSize = 25;
-      mockGridOption.pagination.pageNumber = 2;
-      mockGridOption.pagination.totalItems = 0;
+      mockGridOption.pagination!.pageSize = 25;
+      mockGridOption.pagination!.pageNumber = 2;
+      mockGridOption.pagination!.totalItems = 0;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.recalculateFromToIndexes();
 
       expect(service.dataFrom).toBe(0);
@@ -478,11 +479,11 @@ describe('PaginationService', () => {
     });
 
     it('should recalculate the From/To within range', () => {
-      mockGridOption.pagination.pageSize = 25;
-      mockGridOption.pagination.pageNumber = 2;
-      mockGridOption.pagination.totalItems = 85;
+      mockGridOption.pagination!.pageSize = 25;
+      mockGridOption.pagination!.pageNumber = 2;
+      mockGridOption.pagination!.totalItems = 85;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.recalculateFromToIndexes();
 
       expect(service.dataFrom).toBe(26);
@@ -490,11 +491,11 @@ describe('PaginationService', () => {
     });
 
     it('should recalculate the From/To within range and have the To equal the total items when total items is not a modulo of 1', () => {
-      mockGridOption.pagination.pageSize = 25;
-      mockGridOption.pagination.pageNumber = 4;
-      mockGridOption.pagination.totalItems = 85;
+      mockGridOption.pagination!.pageSize = 25;
+      mockGridOption.pagination!.pageNumber = 4;
+      mockGridOption.pagination!.totalItems = 85;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.recalculateFromToIndexes();
 
       expect(service.dataFrom).toBe(76);
@@ -518,7 +519,7 @@ describe('PaginationService', () => {
       try {
         // @ts-ignore
         mockGridOption.backendServiceApi = {};
-        service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+        service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
         service.refreshPagination();
       } catch (e) {
         expect(e.toString()).toContain(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
@@ -526,22 +527,22 @@ describe('PaginationService', () => {
       }
     });
 
-    it('should call refreshPagination when "onFilterCleared" is triggered', () => {
+    it('should call refreshPagination when "onFilterCleared" is triggered and Pagination is enabled', () => {
       const resetSpy = jest.spyOn(service, 'resetPagination');
       const refreshSpy = jest.spyOn(service, 'refreshPagination');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       filterServiceStub.onFilterCleared.next(true);
 
       expect(resetSpy).toHaveBeenCalled();
       expect(refreshSpy).toHaveBeenCalledWith(true, true);
     });
 
-    it('should call refreshPagination when "onFilterChanged" is triggered', () => {
+    it('should call refreshPagination when "onFilterChanged" is triggered and Pagination is enabled', () => {
       const resetSpy = jest.spyOn(service, 'resetPagination');
       const spy = jest.spyOn(service, 'refreshPagination');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       filterServiceStub.onFilterChanged.next([{ columnId: 'field1', operator: '=', searchTerms: [] }]);
 
       expect(resetSpy).toHaveBeenCalled();
@@ -550,9 +551,13 @@ describe('PaginationService', () => {
   });
 
   describe('resetPagination method', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('should call "refreshPagination" with 2 arguments True when calling the method', () => {
       const spy = jest.spyOn(service, 'refreshPagination');
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.resetPagination();
 
       expect(spy).toHaveBeenCalledWith(true, true);
@@ -560,18 +565,20 @@ describe('PaginationService', () => {
 
     it('should call "refreshPagination" with True and False arguments when calling the method with False being passed as input argument', () => {
       const spy = jest.spyOn(service, 'refreshPagination');
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.resetPagination(false);
 
       expect(spy).toHaveBeenCalledWith(true, false);
     });
 
     it('should reset the DataView when using local grid by calling "setPagingOptions" with page 0 and also call "refreshPagination" method', () => {
+      const gridOptionsMock = { enablePagination: true };
+      jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
       const spy = jest.spyOn(service, 'refreshPagination');
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
 
-      mockGridOption.backendServiceApi = null;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, null);
+      mockGridOption.backendServiceApi = null as any;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, null as any);
       service.resetPagination();
 
       expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: 25, pageNum: 0 });
@@ -582,9 +589,9 @@ describe('PaginationService', () => {
   // processOnItemAddedOrRemoved is private but we can spy on recalculateFromToIndexes
   describe('processOnItemAddedOrRemoved private method', () => {
     afterEach(() => {
-      mockGridOption.pagination.pageSize = 25;
-      mockGridOption.pagination.pageNumber = 2;
-      mockGridOption.pagination.totalItems = 85;
+      mockGridOption.pagination!.pageSize = 25;
+      mockGridOption.pagination!.pageNumber = 2;
+      mockGridOption.pagination!.totalItems = 85;
       jest.clearAllMocks();
     });
 
@@ -593,7 +600,7 @@ describe('PaginationService', () => {
       const paginationSpy = jest.spyOn(service.onPaginationChanged, 'next');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemAdded.next(mockItems);
 
       setTimeout(() => {
@@ -610,7 +617,7 @@ describe('PaginationService', () => {
       const paginationSpy = jest.spyOn(service.onPaginationChanged, 'next');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemAdded.next(mockItems);
 
       setTimeout(() => {
@@ -626,7 +633,7 @@ describe('PaginationService', () => {
       const paginationSpy = jest.spyOn(service.onPaginationChanged, 'next');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemAdded.next(null);
 
       setTimeout(() => {
@@ -643,7 +650,7 @@ describe('PaginationService', () => {
       const paginationSpy = jest.spyOn(service.onPaginationChanged, 'next');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemDeleted.next(mockItems);
 
       setTimeout(() => {
@@ -660,7 +667,7 @@ describe('PaginationService', () => {
       const paginationSpy = jest.spyOn(service.onPaginationChanged, 'next');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemDeleted.next(mockItems);
 
       setTimeout(() => {
@@ -677,7 +684,7 @@ describe('PaginationService', () => {
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
       // service.totalItems = 85;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemDeleted.next(null);
 
       setTimeout(() => {
@@ -690,11 +697,11 @@ describe('PaginationService', () => {
     });
 
     it('should call "processOnItemAddedOrRemoved" and expect the (To) to equal the total items when it is lower than the total itemsPerPage count', (done) => {
-      mockGridOption.pagination.pageNumber = 4;
-      mockGridOption.pagination.totalItems = 100;
+      mockGridOption.pagination!.pageNumber = 4;
+      mockGridOption.pagination!.totalItems = 100;
       const mockItems = { name: 'John' };
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemAdded.next(mockItems);
       service.changeItemPerPage(200);
 
@@ -706,11 +713,11 @@ describe('PaginationService', () => {
     });
 
     it('should call "processOnItemAddedOrRemoved" and expect the (To) to equal the total items when it is higher than the total pageSize count', (done) => {
-      mockGridOption.pagination.pageNumber = 4;
-      mockGridOption.pagination.totalItems = 99;
+      mockGridOption.pagination!.pageNumber = 4;
+      mockGridOption.pagination!.totalItems = 99;
       const mockItems = { name: 'John' };
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       gridServiceStub.onItemAdded.next(mockItems);
       service.changeItemPerPage(100);
 
@@ -724,10 +731,10 @@ describe('PaginationService', () => {
 
   describe('with Local Grid', () => {
     beforeEach(() => {
-      mockGridOption.pagination.pageSize = 25;
-      mockGridOption.pagination.pageNumber = 1;
-      mockGridOption.pagination.totalItems = 85;
-      mockGridOption.backendServiceApi = null;
+      mockGridOption.pagination!.pageSize = 25;
+      mockGridOption.pagination!.pageNumber = 1;
+      mockGridOption.pagination!.totalItems = 85;
+      mockGridOption.backendServiceApi = null as any;
     });
 
     it('should initialize the service and call "refreshPagination" with some DataView calls', () => {
@@ -735,7 +742,7 @@ describe('PaginationService', () => {
       const onPagingSpy = jest.spyOn(dataviewStub.onPagingInfoChanged, 'subscribe');
       const setRefreshSpy = jest.spyOn(dataviewStub, 'setRefreshHints');
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
 
       expect(service.paginationOptions).toEqual(mockGridOption.pagination);
       expect(refreshSpy).toHaveBeenCalled();
@@ -750,8 +757,8 @@ describe('PaginationService', () => {
       const onPagingSpy = jest.spyOn(dataviewStub.onPagingInfoChanged, 'subscribe');
       const setRefreshSpy = jest.spyOn(dataviewStub, 'setRefreshHints');
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
-      mockGridOption.pagination.pageNumber = 3;
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
+      mockGridOption.pagination!.pageNumber = 3;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
 
       expect(service.paginationOptions).toEqual(mockGridOption.pagination);
       expect(refreshSpy).toHaveBeenCalled();
@@ -765,7 +772,7 @@ describe('PaginationService', () => {
       const expectedNewTotal = 22;
       const mockSlickPagingInfo = { pageSize: 5, pageNum: 2, totalRows: expectedNewTotal, totalPages: 3, dataView: dataviewStub };
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
       dataviewStub.onPagingInfoChanged.notify(mockSlickPagingInfo, new Slick.EventData(), dataviewStub);
 
       expect(service.totalItems).toBe(expectedNewTotal);
@@ -785,7 +792,7 @@ describe('PaginationService', () => {
       const onShowPaginationSpy = jest.spyOn(service.onPaginationVisibilityChanged, 'next');
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination, mockGridOption.backendServiceApi);
       service.togglePaginationVisibility(false);
 
       expect(sharedService.gridOptions.enablePagination).toBeFalse();
@@ -796,9 +803,9 @@ describe('PaginationService', () => {
     it('should reset DataView Pagination when using Local Grid and ShowPagination is set to False', () => {
       const onShowPaginationSpy = jest.spyOn(service.onPaginationVisibilityChanged, 'next');
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
-      mockGridOption.backendServiceApi = null;
+      mockGridOption.backendServiceApi = null as any;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
       service.togglePaginationVisibility(false);
 
       expect(sharedService.gridOptions.enablePagination).toBeFalse();
@@ -810,15 +817,15 @@ describe('PaginationService', () => {
       const onShowPaginationSpy = jest.spyOn(service.onPaginationVisibilityChanged, 'next');
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
       const gotoSpy = jest.spyOn(service, 'goToFirstPage');
-      mockGridOption.backendServiceApi = null;
+      mockGridOption.backendServiceApi = null as any;
 
-      service.init(gridStub, dataviewStub, mockGridOption.pagination);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination as Pagination);
       service.togglePaginationVisibility(true);
 
       expect(sharedService.gridOptions.enablePagination).toBeTrue();
       expect(gotoSpy).toHaveBeenCalled();
       expect(onShowPaginationSpy).toHaveBeenCalledWith({ visible: true });
-      expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: mockGridOption.pagination.pageSize, pageNum: 0 });
+      expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: mockGridOption.pagination!.pageSize, pageNum: 0 });
     });
   });
 });

--- a/src/app/modules/angular-slickgrid/services/pagination.service.ts
+++ b/src/app/modules/angular-slickgrid/services/pagination.service.ts
@@ -326,7 +326,7 @@ export class PaginationService {
 
   /** Reset the Pagination to first page and recalculate necessary numbers */
   resetPagination(triggerChangedEvent = true) {
-    if (this._isLocalGrid) {
+    if (this._isLocalGrid && this.dataView && this.sharedService?.gridOptions?.enablePagination) {
       // on a local grid we also need to reset the DataView paging to 1st page
       this.dataView.setPagingOptions({ pageSize: this._itemsPerPage, pageNum: 0 });
     }

--- a/test/cypress/integration/example10.spec.js
+++ b/test/cypress/integration/example10.spec.js
@@ -757,6 +757,27 @@ describe('Example 10 - Multiple Grids with Row Selection', { retries: 1 }, () =>
         expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: { gridRowIndexes: [0, 1], dataContextIds: [3, 12, 13, 522, 1], filteredDataContextIds: [3, 13] }, type: 'rowSelection' });
         expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: [{ columnId: 'title', operator: 'Contains', searchTerms: ['3'] }], type: 'filter' });
       });
+
+      cy.get('@grid2')
+        .find('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+      
+      cy.get('@grid2')
+        .find('[data-test=page-count]')
+        .contains('3');
+
+      cy.get('@grid2')
+        .find('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('@grid2')
+        .find('[data-test=item-to]')
+        .contains('5');
+
+      cy.get('@grid2')
+        .find('[data-test=total-items]')
+        .contains('179');
     });
   });
 });


### PR DESCRIPTION
- we should be able to toggle Pagination and it should still work as expected after showing it again
- the previous code was disposing of the Pagination Service when hiding (disposing) the Pagination Component but that shouldn't be the case, disposing of the Service should strictly be handled by the Angular-Slickgrid-Component