### PR TITLE
fix(composite): calling Edit change shouldn't affect Mass-Update

### DIFF
--- a/test/cypress/integration/example30.spec.js
+++ b/test/cypress/integration/example30.spec.js
@@ -262,6 +262,10 @@ describe('Example 30  Composite Editor Modal', { retries: 1 }, () => {
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(7)`).find('.fa.fa-check.checkmark-icon').should('have.length', 1);
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(8)`).should('not.be.empty');
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(9)`).should('contain', 'Tasty Granite Table');
+
+    // next few rows Title should be unchanged
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(1)`).should('contain', 'TASK 0');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(1)`).should('contain', 'TASK 1111');
   });
 
   it('should open the Composite Editor (Edit Item) and expect all form inputs to be filled with TASK 8888 data of previous create item', () => {
@@ -292,6 +296,10 @@ describe('Example 30  Composite Editor Modal', { retries: 1 }, () => {
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(7)`).find('.fa.fa-check.checkmark-icon').should('not.exist');
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(8)`).should('be.empty');
     cy.get(`[style="top:${GRID_ROW_HEIGHT * 0}px"] > .slick-cell:nth(9)`).should('contain', 'Tasty Granite Table');
+
+    // next few rows Title should be unchanged
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 1}px"] > .slick-cell:nth(1)`).should('contain', 'TASK 0');
+    cy.get(`[style="top:${GRID_ROW_HEIGHT * 2}px"] > .slick-cell:nth(1)`).should('contain', 'TASK 1111');
   });
 
   it('should open the Composite Editor (Mass Update) and be able to change some of the inputs in the form', () => {


### PR DESCRIPTION
- fix an issue in Slickgrid-Universal which we found that if we Edit a value (let say Title to "Task 1234") and then do a Mass Update on different field (say "% Complete" to 90%), the mass update was actually picking up the "Task 1234" from the previous edit even though it wasn't part of the Mass Update. So we can simply clear the `formValues` object when opening the modal window and before populating the form

#### TODOs
- [x] requires newer version of Slickgrid-Universal