### PR TITLE
fix(footer): use `getFilteredItemCount` to show correct item count

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -209,6 +209,7 @@ const mockDataView = {
   destroy: jest.fn(),
   beginUpdate: jest.fn(),
   endUpdate: jest.fn(),
+  getFilteredItemCount: jest.fn(),
   getItem: jest.fn(),
   getItems: jest.fn(),
   getItemCount: jest.fn(),
@@ -1839,6 +1840,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           totalItemCount: 2
         };
         jest.spyOn(mockDataView, 'getItemCount').mockReturnValue(mockData.length);
+        jest.spyOn(mockDataView, 'getFilteredItemCount').mockReturnValue(mockData.length);
 
         component.gridOptions = { enablePagination: false, showCustomFooter: true };
         component.initialization(slickEventHandler);
@@ -1854,10 +1856,10 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         const expectation = {
           startTime: expect.toBeDate(),
           endTime: expect.toBeDate(),
-          itemCount: 2,
+          itemCount: 0,
           totalItemCount: 0
         };
-        jest.spyOn(mockDataView, 'getLength').mockReturnValue(2);
+        jest.spyOn(mockDataView, 'getFilteredItemCount').mockReturnValue(0);
 
         component.gridOptions = { enablePagination: false, showCustomFooter: true };
         component.initialization(slickEventHandler);
@@ -1885,6 +1887,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
 
         component.gridOptions.enableCheckboxSelector = true;
         component.gridOptions.presets = { rowSelection: { dataContextIds: selectedRowIds } };
+        component.isDatasetInitialized = false;
         component.initialization(slickEventHandler);
         component.dataset = mockData;
 

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -923,11 +923,11 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
         const onRowCountChangedHandler = dataView.onRowCountChanged;
         (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onRowCountChangedHandler>>).subscribe(onRowCountChangedHandler, (_e, args) => {
           grid.invalidate();
-          this.handleOnItemCountChanged(args.current || 0, dataView.getItemCount());
+          this.handleOnItemCountChanged(this.dataView.getFilteredItemCount() || 0, dataView.getItemCount());
         });
         const onSetItemsCalledHandler = dataView.onSetItemsCalled;
         (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onSetItemsCalledHandler>>).subscribe(onSetItemsCalledHandler, (_e, args) => {
-          this.handleOnItemCountChanged(dataView.getLength(), args.itemCount);
+          this.handleOnItemCountChanged(this.dataView.getFilteredItemCount() || 0, args.itemCount);
 
           // when user has resize by content enabled, we'll force a full width calculation since we change our entire dataset
           if (args.itemCount > 0 && (this.gridOptions.autosizeColumnsByCellContentOnFirstLoad || this.gridOptions.enableAutoResizeColumnsByCellContent)) {


### PR DESCRIPTION
- fixes Slickgrid-Universal issue [#469](https://github.com/ghiscoding/slickgrid-universal/issues/469)
- we should always use DataView `getFilteredItemCount()` since that is really the item count that we want to show in the footer `getFilteredItemCount` to show correct count, fix #469
- fixes #469
- we should always use DataView `getFilteredItemCount()` since that is really the item count that we want to show in the footer