### PR TITLE
fix(resizer): remove redundant bindAutoResizeDataGrid call

### DIFF
--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -1046,7 +1046,6 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
       this.resizerService.resizeGrid();
     }
     if (options.enableAutoResize) {
-      this.resizerService.bindAutoResizeDataGrid();
       if (grid && options.autoFitColumnsOnFirstLoad && options.enableAutoSizeColumns) {
         grid.autosizeColumns();
       }


### PR DESCRIPTION
This is "PR 2" as mentioned here https://github.com/ghiscoding/Angular-Slickgrid/issues/836

This removes the  `bindAutoResizeDataGrid()` call from `bindResizeHook` as its already called from `resizerService.init`. 
In Slickgrid vanilla & Aurelia it's also not done from `bindResizeHook`.

I have run all unit & cypress tested and tested some resizes manually and all look good.



