### PR TITLE
fix(demo): row disappears from grid when reordering the first row 

### DIFF
--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -178,7 +178,7 @@ export class GridRowMoveComponent implements OnInit {
     // we need to resort with
     rows.sort((a: number, b: number) => a - b);
     for (const filteredRow of filteredRows) {
-      if (filteredRow !== null) {
+      if (filteredRow !== undefined) {
         extractedRows.push(tmpDataset[filteredRow]);
       }
     }


### PR DESCRIPTION
If the first row is moved down the grid, the row disappears from the grid.  This is because the `if (filteredRow)` condition on line 181 returns false, because `filteredRow` is 0.  The change I've made fixes the bug.