### PR TITLE
fix(build): should use `EventSubscription` to be unsubscribed

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jquery": "~3.5.1",
     "jquery-ui-dist": "^1.12.1",
     "moment-mini": "^2.24.0",
-    "rxjs": ">=7.0.0"
+    "rxjs": ">=7.5.1"
   },
   "peerDependencies": {
     "@ngx-translate/core": ">=14.0.0"

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -12,7 +12,7 @@ import 'slickgrid/slick.dataview';
 // ...then everything else...
 import { AfterViewInit, ApplicationRef, ChangeDetectorRef, Component, ElementRef, Inject, Input, OnDestroy, Optional, } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import {
   // interfaces/types
@@ -22,6 +22,7 @@ import {
   Column,
   ColumnEditor,
   DataViewOption,
+  EventSubscription,
   ExtensionName,
   ExternalResource,
   Locale,
@@ -59,6 +60,7 @@ import {
   autoAddEditorFormatterToColumnsWithEditor,
   emptyElement,
   GridStateType,
+  unsubscribeAll,
 } from '@slickgrid-universal/common';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
@@ -71,7 +73,6 @@ import { Constants } from '../constants';
 import { AngularGridInstance, ExternalTestingDependencies, GridOption, } from './../models/index';
 import { GlobalGridOptions } from './../global-grid-options';
 import { TranslaterService } from '../services/translater.service';
-import { unsubscribeAllObservables } from './../services/utilities';
 
 // Services
 import { AngularUtilService } from '../services/angularUtil.service';
@@ -120,7 +121,7 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
     gridOptions: GridOption;
     paginationService: PaginationService;
   };
-  subscriptions: Subscription[] = [];
+  subscriptions: EventSubscription[] = [];
 
   // components / plugins
   slickEmptyWarning?: SlickEmptyWarningComponent;
@@ -413,7 +414,7 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
     }
 
     // also unsubscribe all RxJS subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    this.subscriptions = unsubscribeAll(this.subscriptions);
 
     this._dataset = null;
     this.datasetHierarchical = undefined;

--- a/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
+++ b/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
@@ -5,19 +5,20 @@ import { ApplicationRef, ComponentRef, Type, ViewContainerRef } from '@angular/c
 import {
   addToArrayWhenNotExists,
   castObservableToPromise,
+  EventSubscription,
   RxJsFacade,
   SlickEventHandler,
   SlickGrid,
   SlickRowSelectionModel,
+  unsubscribeAll,
 } from '@slickgrid-universal/common';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickRowDetailView as UniversalSlickRowDetailView } from '@slickgrid-universal/row-detail-view-plugin';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import * as DOMPurify from 'dompurify';
 
 import { GridOption, RowDetailView } from '../models/index';
 import { AngularUtilService } from '../services/angularUtil.service';
-import { unsubscribeAllObservables } from '../services/utilities';
 
 const ROW_DETAIL_CONTAINER_PREFIX = 'container_';
 const PRELOAD_CONTAINER_PREFIX = 'container_loading';
@@ -34,7 +35,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
   protected _preloadComponent: Type<object> | undefined;
   protected _views: CreatedView[] = [];
   protected _viewComponent!: Type<object>;
-  protected _subscriptions: Subscription[] = [];
+  protected _subscriptions: EventSubscription[] = [];
   protected _userProcessFn!: (item: any) => Promise<any> | Observable<any> | Subject<any>;
 
   constructor(
@@ -78,7 +79,7 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
   /** Dispose of the RowDetailView Extension */
   dispose() {
     this.disposeAllViewComponents();
-    this._subscriptions = unsubscribeAllObservables(this._subscriptions); // also unsubscribe all RxJS subscriptions
+    this._subscriptions = unsubscribeAll(this._subscriptions); // also unsubscribe all RxJS subscriptions
     super.dispose();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9446,17 +9446,24 @@ rxjs@6.6.7, rxjs@^6.5.0, rxjs@^6.5.3, rxjs@^6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@>=7.0.0, rxjs@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+rxjs@>=7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.1.tgz#af73df343cbcab37628197f43ea0c8256f54b157"
+  integrity sha512-KExVEeZWxMZnZhUZtsJcFwz8IvPvgu4G2Z2QyqjZQzUGr32KDYuSxrEYO4w3tFFNbfLozcrKUTvTPi+E9ywJkQ==
   dependencies:
-    tslib "~2.1.0"
+    tslib "^2.1.0"
 
 rxjs@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.2.0.tgz#5cd12409639e9514a71c9f5f9192b2c4ae94de31"
   integrity sha512-aX8w9OpKrQmiPKfT1bqETtUr9JygIz6GZ+gql8v7CijClsP0laoFUdKzxFAoWuRdSlOdU2+crss+cMf+cqMTnw==
+  dependencies:
+    tslib "~2.1.0"
+
+rxjs@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
+  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
   dependencies:
     tslib "~2.1.0"
 
@@ -10454,7 +10461,7 @@ ts-node@^10.4.0:
     make-error "^1.1.1"
     yn "3.1.1"
 
-tslib@2.3.1, tslib@^2.3.0, tslib@^2.3.1:
+tslib@2.3.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
- the EventPubSubService is providing EventSubscription, not RxJS Subscription, so we should use unsubscribe the correct subscription type
- also bump required RxJS version since it seems to throw some type error on the RxJsFacade of Slickgrid-Universal which recently got bumped as well