### PR TITLE
fix(core): throw error when `[gridOptions]` missing, fixes #910

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -353,9 +353,9 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     sharedService = new SharedService();
     translaterService = new TranslaterServiceStub();
     await TestBed.configureTestingModule({
-    imports: [TranslateModule.forRoot()],
-    teardown: { destroyAfterEach: false }
-});
+      imports: [TranslateModule.forRoot()],
+      teardown: { destroyAfterEach: false }
+    });
     translate = TestBed.inject(TranslateService);
 
     mockChangeDetectorRef = {
@@ -418,6 +418,18 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
     component.ngAfterViewInit();
 
     expect(component.gridOptions.enableMouseWheelScrollHandler).toBeTrue();
+  });
+
+  it('should throw an error when [gridOptions] and/or [columnDefinitions] is undefined', (done) => {
+    try {
+      component.gridOptions = undefined as any;
+      component.ngAfterViewInit();
+      component.dataset = [];
+    } catch (e: any) {
+      expect(e.toString()).toContain('Using `<angular-slickgrid>` requires [gridOptions] and [columnDefinitions]');
+      component.destroy();
+      done();
+    }
   });
 
   it('should keep frozen column index reference (via frozenVisibleColumnId) when grid is a frozen grid', () => {

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -338,6 +338,9 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit() {
+    if (!this.gridOptions || !this.columnDefinitions) {
+      throw new Error('Using `<angular-slickgrid>` requires [gridOptions] and [columnDefinitions], it seems that you might have forgot to provide them since at least of them is undefined.');
+    }
     this.initialization(this._eventHandler);
     this._isGridInitialized = true;
 


### PR DESCRIPTION
- should throw if 1 of these 2 are missing `[gridOptions]` and/or `[columnDefinitions]`
- fixes #910