### PR TITLE
fix(composite): selected row count always 0 on mass-selected, fix #951

### DIFF
--- a/src/app/modules/angular-slickgrid/services/container.service.ts
+++ b/src/app/modules/angular-slickgrid/services/container.service.ts
@@ -15,6 +15,10 @@ export class ContainerService implements UniversalContainerService {
     return null;
   }
 
+  dispose() {
+    this.dependencies = [];
+  }
+
   registerInstance(key: string, instance: any) {
     const dependency = this.dependencies.some(dep => dep.key === key);
     if (!dependency) {


### PR DESCRIPTION
- fixes #951
- add dispose method to container service to start with a blank array whenever we route to another page, this is to avoid reusing already disposed services that might still be in the container service