### PR TITLE
fix(collectionAsync): hidden column does not load edit field selection

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -687,13 +687,11 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
       it('should be able to load async editors with an Observable', (done) => {
         const mockCollection = ['male', 'female'];
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: of(mockCollection) } }] as Column[];
-        const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
 
         component.ngAfterViewInit();
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor).toBeTruthy();
           expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);
@@ -711,7 +709,6 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
           renderDomElement: jest.fn(),
         } as unknown as Editor;
         const mockColDefs = [{ id: 'gender', field: 'gender', editor: { model: Editors.text, collectionAsync: promise } }] as Column[];
-        const getColSpy = jest.spyOn(mockGrid, 'getColumns').mockReturnValue(mockColDefs);
         jest.spyOn(mockGrid, 'getCellEditor').mockReturnValue(mockEditor);
         const disableSpy = jest.spyOn(mockEditor, 'disable');
         const destroySpy = jest.spyOn(mockEditor, 'destroy');
@@ -721,7 +718,6 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         component.columnDefinitions = mockColDefs;
 
         setTimeout(() => {
-          expect(getColSpy).toHaveBeenCalled();
           expect(component.columnDefinitions[0].editor).toBeTruthy();
           expect(component.columnDefinitions[0].editor!.collection).toEqual(mockCollection);
           expect(component.columnDefinitions[0].internalColumnEditor!.collection).toEqual(mockCollection);

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -1375,9 +1375,8 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
     (column.editor as ColumnEditor).disabled = false;
 
     // find the new column reference pointer & re-assign the new editor to the internalColumnEditor
-    const columns = this.slickGrid.getColumns();
-    if (Array.isArray(columns)) {
-      const columnRef = columns.find((col: Column) => col.id === column.id);
+    if (Array.isArray(this.columnDefinitions)) {
+      const columnRef = this.columnDefinitions.find((col: Column) => col.id === column.id);
       if (columnRef) {
         columnRef.internalColumnEditor = column.editor as ColumnEditor;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8088,11 +8088,6 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment-mini@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment-mini/-/moment-mini-2.24.0.tgz#fa68d98f7fe93ae65bf1262f6abb5fb6983d8d18"
-  integrity sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ==
-
 moment-mini@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment-mini/-/moment-mini-2.29.4.tgz#cbbcdc58ce1b267506f28ea6668dbe060a32758f"


### PR DESCRIPTION
- replicate issue found and fixed in Slickgrid-Universal [PR 742](https://github.com/ghiscoding/slickgrid-universal/pull/742)