### PR TITLE
fix(rxjs): make unsubscribe more generic to avoid RxJS update issue

### DIFF
--- a/src/app/examples/custom-angularComponentEditor.ts
+++ b/src/app/examples/custom-angularComponentEditor.ts
@@ -136,7 +136,7 @@ export class CustomAngularComponentEditor implements Editor {
     }
 
     // also unsubscribe all Angular Subscriptions
-    this._subscriptions = unsubscribeAllObservables(this._subscriptions);
+    unsubscribeAllObservables(this._subscriptions);
   }
 
   /** optional, implement a focus method on your Angular Component */

--- a/src/app/examples/custom-angularComponentFilter.ts
+++ b/src/app/examples/custom-angularComponentFilter.ts
@@ -114,7 +114,7 @@ export class CustomAngularComponentFilter implements Filter {
     }
 
     // also unsubscribe all Angular Subscriptions
-    this._subscriptions = unsubscribeAllObservables(this._subscriptions);
+    unsubscribeAllObservables(this._subscriptions);
   }
 
   /** Set value(s) on the DOM element */

--- a/src/app/examples/grid-contextmenu.component.ts
+++ b/src/app/examples/grid-contextmenu.component.ts
@@ -123,7 +123,7 @@ export class GridContextMenuComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     // also unsubscribe all Angular Subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    unsubscribeAllObservables(this.subscriptions);
   }
 
   prepareGrid() {

--- a/src/app/examples/grid-graphql.component.ts
+++ b/src/app/examples/grid-graphql.component.ts
@@ -63,7 +63,7 @@ export class GridGraphqlComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     // also unsubscribe all Angular Subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    unsubscribeAllObservables(this.subscriptions);
   }
 
   ngOnInit(): void {

--- a/src/app/examples/grid-headermenu.component.ts
+++ b/src/app/examples/grid-headermenu.component.ts
@@ -43,7 +43,7 @@ export class GridHeaderMenuComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     // also unsubscribe all Angular Subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    unsubscribeAllObservables(this.subscriptions);
   }
 
   ngOnInit(): void {

--- a/src/app/examples/grid-localization.component.ts
+++ b/src/app/examples/grid-localization.component.ts
@@ -79,7 +79,7 @@ export class GridLocalizationComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     // also unsubscribe all Angular Subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    unsubscribeAllObservables(this.subscriptions);
   }
 
   ngOnInit(): void {

--- a/src/app/examples/grid-menu.component.ts
+++ b/src/app/examples/grid-menu.component.ts
@@ -40,7 +40,7 @@ export class GridMenuComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     // also unsubscribe all Angular Subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    unsubscribeAllObservables(this.subscriptions);
   }
 
   ngOnInit(): void {

--- a/src/app/examples/grid-range.component.ts
+++ b/src/app/examples/grid-range.component.ts
@@ -81,7 +81,7 @@ export class GridRangeComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     // also unsubscribe all Angular Subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    unsubscribeAllObservables(this.subscriptions);
   }
 
   ngOnInit(): void {

--- a/src/app/examples/grid-state.component.ts
+++ b/src/app/examples/grid-state.component.ts
@@ -54,7 +54,7 @@ export class GridStateComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     // also unsubscribe all Angular Subscriptions
-    this.subscriptions = unsubscribeAllObservables(this.subscriptions);
+    unsubscribeAllObservables(this.subscriptions);
   }
 
   ngOnInit(): void {

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -1,18 +1,17 @@
-import { Subscription } from 'rxjs';
-
 /**
  * Unsubscribe all Observables Subscriptions
  * It will return an empty array if it all went well
  * @param subscriptions
  */
-export function unsubscribeAllObservables(subscriptions: Subscription[]): Subscription[] {
+export function unsubscribeAllObservables(subscriptions: Array<{ unsubscribe: ()=> void; }>): Array<{ unsubscribe: ()=> void; }> {
   if (Array.isArray(subscriptions)) {
-    subscriptions.forEach((subscription: Subscription) => {
-      if (subscription && subscription.unsubscribe) {
+    let subscription = subscriptions.pop();
+    while (subscription) {
+      if (typeof subscription.unsubscribe === 'function') {
         subscription.unsubscribe();
       }
-    });
-    subscriptions = [];
+      subscription = subscriptions.pop();
+    }
   }
 
   return subscriptions;

--- a/src/app/modules/angular-slickgrid/services/utilities.ts
+++ b/src/app/modules/angular-slickgrid/services/utilities.ts
@@ -3,7 +3,7 @@
  * It will return an empty array if it all went well
  * @param subscriptions
  */
-export function unsubscribeAllObservables(subscriptions: Array<{ unsubscribe: ()=> void; }>): Array<{ unsubscribe: ()=> void; }> {
+export function unsubscribeAllObservables(subscriptions: Array<{ unsubscribe: ()=> void; }>): any[] {
   if (Array.isArray(subscriptions)) {
     let subscription = subscriptions.pop();
     while (subscription) {
@@ -14,5 +14,6 @@ export function unsubscribeAllObservables(subscriptions: Array<{ unsubscribe: ()
     }
   }
 
+  // TODO: deprecated, remove the return type in next major version
   return subscriptions;
 }


### PR DESCRIPTION
- let's not use RxJS Subscription directly to avoid errors when upgrading RxJS, for example this error is caused by a version mismatch between Angular-Slickgrid and the demos: "Type 'import("...dist/types/internal/Subscription").Subscription[]' is not assignable to type 'import(".../dist/types/internal/Subscription").Subscription[]'."