### PR TITLE
fix: using esbuild requires to specify type imports

### DIFF
--- a/src/app/examples/grid-rowmove.component.ts
+++ b/src/app/examples/grid-rowmove.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { AngularGridInstance, Column, ExtensionName, Filters, Formatters, GridOption, OnEventArgs, SlickRowMoveManager } from './../modules/angular-slickgrid';
+import { AngularGridInstance, Column, ExtensionName, Filters, Formatters, GridOption, OnEventArgs } from './../modules/angular-slickgrid';
 
 @Component({
   templateUrl: './grid-rowmove.component.html'

--- a/src/app/examples/swt-common-grid.component.ts
+++ b/src/app/examples/swt-common-grid.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit, AfterViewInit, Input, EventEmitter, Output, ViewChild, ElementRef, Renderer2 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import {
+import { FieldType } from '../modules/angular-slickgrid';
+import type {
   AngularGridInstance,
-  AngularSlickgridComponent, Column, FieldType,
+  AngularSlickgridComponent, Column,
   GridOption, BackendService,
-  BackendServiceOption, FilterChangedArgs, PaginationChangedArgs, Pagination, SlickGrid, SlickDataView
+  BackendServiceOption, FilterChangedArgs, PaginationChangedArgs, Pagination, SlickDataView
 } from '../modules/angular-slickgrid';
 import { TranslateService } from '@ngx-translate/core';
 import { Logger } from './swt-logger.service';

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -9,8 +9,7 @@ import { AfterViewInit, ApplicationRef, ChangeDetectorRef, Component, ElementRef
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 
-import {
-  // interfaces/types
+import type {
   AutocompleterEditor,
   BackendServiceApi,
   BackendServiceOption,
@@ -18,24 +17,29 @@ import {
   ColumnEditor,
   DataViewOption,
   EventSubscription,
-  ExtensionName,
   ExternalResource,
   Locale,
   Metrics,
   Pagination,
+  RxJsFacade,
   SelectEditor,
   ServicePagination,
   SlickDataView,
   SlickEventHandler,
   SlickGrid,
   SlickNamespace,
+} from '@slickgrid-universal/common';
+
+import {
+  ExtensionName,
+  ExtensionUtility,
+  SlickGroupItemMetadataProvider,
 
   // services
   BackendUtilityService,
   CollectionService,
   EventNamingStyle,
   ExtensionService,
-  ExtensionUtility,
   FilterFactory,
   FilterService,
   GridEventService,
@@ -44,10 +48,8 @@ import {
   GroupingAndColspanService,
   PaginationService,
   ResizerService,
-  RxJsFacade,
   SharedService,
   SlickgridConfig,
-  SlickGroupItemMetadataProvider,
   SortService,
   TreeDataService,
 
@@ -65,7 +67,7 @@ import { RxJsResource } from '@slickgrid-universal/rxjs-observable';
 import { dequal } from 'dequal/lite';
 
 import { Constants } from '../constants';
-import { AngularGridInstance, ExternalTestingDependencies, GridOption, } from './../models/index';
+import type { AngularGridInstance, ExternalTestingDependencies, GridOption } from './../models/index';
 import { GlobalGridOptions } from './../global-grid-options';
 import { TranslaterService } from '../services/translater.service';
 

--- a/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
+++ b/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
@@ -1,14 +1,6 @@
 import { ApplicationRef, ComponentRef, Type, ViewContainerRef } from '@angular/core';
-import {
-  addToArrayWhenNotExists,
-  castObservableToPromise,
-  EventSubscription,
-  RxJsFacade,
-  SlickEventHandler,
-  SlickGrid,
-  SlickRowSelectionModel,
-  unsubscribeAll,
-} from '@slickgrid-universal/common';
+import type { EventSubscription, RxJsFacade, SlickEventHandler, SlickGrid } from '@slickgrid-universal/common';
+import { addToArrayWhenNotExists, castObservableToPromise, SlickRowSelectionModel, unsubscribeAll } from '@slickgrid-universal/common';
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickRowDetailView as UniversalSlickRowDetailView } from '@slickgrid-universal/row-detail-view-plugin';
 import { Observable, Subject } from 'rxjs';

--- a/src/app/modules/angular-slickgrid/global-grid-options.ts
+++ b/src/app/modules/angular-slickgrid/global-grid-options.ts
@@ -1,5 +1,5 @@
 import { Column, DelimiterType, EventNamingStyle, FileType, Filters, OperatorType, TreeDataOption } from '@slickgrid-universal/common';
-import { GridOption, RowDetailView } from './models/index';
+import type { GridOption, RowDetailView } from './models/index';
 
 /** Global Grid Options Defaults */
 export const GlobalGridOptions: Partial<GridOption> = {

--- a/src/app/modules/angular-slickgrid/models/angularGridInstance.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/angularGridInstance.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BackendService,
   ExtensionList,
   ExtensionService,
@@ -14,7 +14,7 @@ import {
   SortService,
   TreeDataService
 } from '@slickgrid-universal/common';
-import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 
 export interface AngularGridInstance {
   /** Slick DataView object */

--- a/src/app/modules/angular-slickgrid/models/externalTestingDependencies.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/externalTestingDependencies.interface.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BackendUtilityService,
   CollectionService,
   ExtensionService,
@@ -15,7 +15,7 @@ import {
   SortService,
   TreeDataService
 } from '@slickgrid-universal/common';
-import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
+import type { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 
 export interface ExternalTestingDependencies {
   backendUtilityService?: BackendUtilityService;

--- a/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/gridOption.interface.ts
@@ -1,7 +1,7 @@
-import { TranslateService } from '@ngx-translate/core';
-import { GridOption as UniversalGridOption } from '@slickgrid-universal/common';
+import type { TranslateService } from '@ngx-translate/core';
+import type { GridOption as UniversalGridOption } from '@slickgrid-universal/common';
 
-import { RowDetailView } from './index';
+import type { RowDetailView } from './index';
 
 export interface GridOption extends UniversalGridOption {
   /** ngx-translate i18n translation service instance */

--- a/src/app/modules/angular-slickgrid/models/rowDetailView.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/rowDetailView.interface.ts
@@ -1,5 +1,5 @@
 import { Type } from '@angular/core';
-import { RowDetailView as UniversalRowDetailView } from '@slickgrid-universal/common';
+import type { RowDetailView as UniversalRowDetailView } from '@slickgrid-universal/common';
 
 export interface RowDetailView extends UniversalRowDetailView {
   /**

--- a/src/app/modules/angular-slickgrid/models/slickGrid.interface.ts
+++ b/src/app/modules/angular-slickgrid/models/slickGrid.interface.ts
@@ -1,5 +1,5 @@
-import { SlickGrid as UniversalSlickGrid } from '@slickgrid-universal/common';
-import { GridOption } from './gridOption.interface';
+import type { SlickGrid as UniversalSlickGrid } from '@slickgrid-universal/common';
+import type { GridOption } from './gridOption.interface';
 
 export interface SlickGrid extends UniversalSlickGrid {
   /** Returns an object containing all of the Grid options set on the grid. See a list of Grid Options here.  */

--- a/src/app/modules/angular-slickgrid/modules/angular-slickgrid.module.ts
+++ b/src/app/modules/angular-slickgrid/modules/angular-slickgrid.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { type ModuleWithProviders, NgModule } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { AngularSlickgridComponent } from './../components/angular-slickgrid.component';

--- a/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
+++ b/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
@@ -1,6 +1,6 @@
 import { EmbeddedViewRef, Injectable, ViewContainerRef } from '@angular/core';
 
-import { AngularComponentOutput } from '../models/angularComponentOutput.interface';
+import type { AngularComponentOutput } from '../models/angularComponentOutput.interface';
 
 @Injectable()
 export class AngularUtilService {

--- a/src/app/modules/angular-slickgrid/services/container.service.ts
+++ b/src/app/modules/angular-slickgrid/services/container.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ContainerInstance, ContainerService as UniversalContainerService } from '@slickgrid-universal/common';
+import { type ContainerInstance, ContainerService as UniversalContainerService } from '@slickgrid-universal/common';
 
 @Injectable()
 export class ContainerService implements UniversalContainerService {

--- a/src/app/modules/angular-slickgrid/services/translater.service.ts
+++ b/src/app/modules/angular-slickgrid/services/translater.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Optional } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
-import { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
+import type { TranslateService } from '@ngx-translate/core';
+import type { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
 
 /**
  * This is a Translate Service Wrapper for Slickgrid-Universal monorepo lib to work properly,

--- a/src/app/modules/angular-slickgrid/services/translater.service.ts
+++ b/src/app/modules/angular-slickgrid/services/translater.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Optional } from '@angular/core';
-import type { TranslateService } from '@ngx-translate/core';
-import type { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
+import { TranslateService } from '@ngx-translate/core';
+import { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
 
 /**
  * This is a Translate Service Wrapper for Slickgrid-Universal monorepo lib to work properly,

--- a/src/app/modules/angular-slickgrid/slickgrid-config.ts
+++ b/src/app/modules/angular-slickgrid/slickgrid-config.ts
@@ -1,4 +1,4 @@
-import { GridOption } from './models/gridOption.interface';
+import type { GridOption } from './models/gridOption.interface';
 import { GlobalGridOptions } from './global-grid-options';
 
 export class SlickgridConfig {


### PR DESCRIPTION
- fixes issues found while developing with the new Angular 16 esbuild experimental, esbuild was throwing the following error

> No matching export for types exported via ...

and the answer is simply to add the `import type` on interfaces as mentioned in this esbuild issue
https://github.com/evanw/esbuild/issues/1941#issuecomment-1028157800