### PR TITLE
fix: adding dataset hierarchical item shouldn't cause scroll flickering

### DIFF
--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -220,7 +220,6 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
 
     // when a hierarchical dataset is set afterward, we can reset the flat dataset and call a tree data sort that will overwrite the flat dataset
     if (newHierarchicalDataset && this.slickGrid && this.sortService?.processTreeDataInitialSort) {
-      this.dataView.setItems([], this.gridOptions.datasetIdPropertyName ?? 'id');
       this.sortService.processTreeDataInitialSort();
 
       // we also need to reset/refresh the Tree Data filters because if we inserted new item(s) then it might not show up without doing this refresh
@@ -389,12 +388,8 @@ export class AngularSlickgridComponent implements AfterViewInit, OnDestroy {
     }
     this._eventPubSubService?.unsubscribeAll();
     if (this.dataView) {
-      if (this.dataView?.setItems) {
-        this.dataView.setItems([]);
-      }
-      if (this.dataView.destroy) {
-        this.dataView.destroy();
-      }
+      this.dataView.setItems([]);
+      this.dataView.destroy();
     }
     if (this.slickGrid?.destroy) {
       this.slickGrid.destroy(shouldEmptyDomElementContainer);


### PR DESCRIPTION
- calling `datasetHierarchical` setter shouldn't cause scroll flickering, this was caused a call to the DataView `setItems` with an empty array which in terms always scroll back to top and that was meant to clear the dataset before recreating it, however this is certainly not needed since calling the `datasetHierarchical` setter will then trigger a new sort which will indirectly call DataView setItems anyway
- it might also fix issue #1201, I'm not entirely sure since the user never mentioned which type of Tree Data (there's 2 types) was used