### PR TITLE
fix: DOMPurify should be using default import

### DIFF
--- a/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
+++ b/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
@@ -4,7 +4,7 @@ import { addToArrayWhenNotExists, castObservableToPromise, SlickRowSelectionMode
 import { EventPubSubService } from '@slickgrid-universal/event-pub-sub';
 import { SlickRowDetailView as UniversalSlickRowDetailView } from '@slickgrid-universal/row-detail-view-plugin';
 import { Observable, Subject } from 'rxjs';
-import * as DOMPurify from 'dompurify';
+import DOMPurify from 'dompurify';
 
 import { GridOption, RowDetailView } from '../models/index';
 import { AngularUtilService } from '../services/angularUtil.service';


### PR DESCRIPTION
- previous `import * as` was causing issues locally though it works well with default import