### PR TITLE
feat: improve AngularUtilService methods to create dynamic component, fixes #1273

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,7 +34,7 @@ body:
     id: system-info
     attributes:
       label: Environment Info
-      description: versions number of each systems and libs (Angular, Angular-Slickgrid, TypeScript)
+      description: output of `npx envinfo --system --npmPackages 'angular-slickgrid' --binaries --browsers`
       render: shell
       placeholder: |
         Angular (x.y)

--- a/src/app/examples/custom-angularComponentFilter.ts
+++ b/src/app/examples/custom-angularComponentFilter.ts
@@ -70,26 +70,20 @@ export class CustomAngularComponentFilter implements Filter {
     if (this.columnFilter?.params.component) {
       // use a delay to make sure Angular ran at least a full cycle and it finished rendering the Component before hooking onto it
       // else we get the infamous error "ExpressionChangedAfterItHasBeenCheckedError"
-      setTimeout(() => {
-        const headerElm = this.grid.getHeaderRowColumn(this.columnDef.id);
-        if (headerElm) {
-          headerElm.innerHTML = '';
-          const componentOuput = this.angularUtilService.createAngularComponentAppendToDom(this.columnFilter.params.component, headerElm);
-          this.componentRef = componentOuput.componentRef;
+      const headerElm = this.grid.getHeaderRowColumn(this.columnDef.id);
+      if (headerElm) {
+        headerElm.innerHTML = '';
+        const componentOuput = this.angularUtilService.createAngularComponentAppendToDom(this.columnFilter.params.component, headerElm, { collection: this.collection });
+        this.componentRef = componentOuput.componentRef;
 
-          // here we override the collection object of the Angular Component
-          // but technically you can pass any values you wish to your Component
-          Object.assign(componentOuput.componentRef.instance, { collection: this.collection });
-
-          this._subscriptions.push(
-            componentOuput.componentRef.instance.onItemChanged.subscribe((item: any) => {
-              this.callback(undefined, { columnDef: this.columnDef, operator: this.operator, searchTerms: [item.id], shouldTriggerQuery: this._shouldTriggerQuery });
-              // reset flag for next use
-              this._shouldTriggerQuery = true;
-            })
-          );
-        }
-      });
+        this._subscriptions.push(
+          componentOuput.componentRef.instance.onItemChanged.subscribe((item: any) => {
+            this.callback(undefined, { columnDef: this.columnDef, operator: this.operator, searchTerms: [item.id], shouldTriggerQuery: this._shouldTriggerQuery });
+            // reset flag for next use
+            this._shouldTriggerQuery = true;
+          })
+        );
+      }
     }
   }
 

--- a/src/app/examples/grid-angular.component.ts
+++ b/src/app/examples/grid-angular.component.ts
@@ -354,14 +354,11 @@ export class GridAngularComponent implements OnInit {
 
   renderAngularComponent(cellNode: HTMLElement, row: number, dataContext: any, colDef: Column) {
     if (colDef.params.component) {
-      const componentOutput = this.angularUtilService.createAngularComponent(colDef.params.component);
-      Object.assign(componentOutput.componentRef.instance, { item: dataContext });
-
-      // use a delay to make sure Angular ran at least a full cycle and make sure it finished rendering the Component
-      setTimeout(() => {
-        cellNode.innerHTML = componentOutput.domElement.innerHTML;
-        componentOutput.componentRef.destroy();
-      });
+      // the last 2 arguments of createAngularComponent() are optional
+      // but when they are provided, that is the DOM target (cellNode) and the dataContext,
+      // the util will render everything for you without too much delay
+      const componentOutput = this.angularUtilService.createAngularComponent(colDef.params.component, cellNode, { item: dataContext });
+      componentOutput.componentRef.destroy(); // cleanup no longer needed temp component
     }
   }
 

--- a/src/app/examples/grid-remote.component.ts
+++ b/src/app/examples/grid-remote.component.ts
@@ -59,15 +59,15 @@ export class GridRemoteComponent implements OnDestroy, OnInit {
   search = '';
 
   constructor() {
-    this.loaderDataView = new Slick.Data.RemoteModel();
-    this.customDataView = this.loaderDataView && this.loaderDataView.data;
+    // this.loaderDataView = new Slick.Data.RemoteModel();
+    // this.customDataView = this.loaderDataView && this.loaderDataView.data;
   }
 
   angularGridReady(angularGrid: AngularGridInstance) {
     this.angularGrid = angularGrid;
     this.gridObj = angularGrid.slickGrid; // grid object
-    this.loaderDataView.setSort('score', -1);
-    this.gridObj.setSortColumn('score', false);
+    this.loaderDataView?.setSort('score', -1);
+    this.gridObj?.setSortColumn('score', false);
 
     // notify of a change to preload the first page
     this.gridObj.onViewportChanged.notify();

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/slickRowDetailView.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/slickRowDetailView.spec.ts
@@ -45,7 +45,19 @@ const gridOptionsMock = {
   }
 } as unknown as GridOption;
 
+const dataViewStub = {
+  constructor: jest.fn(),
+  init: jest.fn(),
+  destroy: jest.fn(),
+  beginUpdate: jest.fn(),
+  endUpdate: jest.fn(),
+  getItem: jest.fn(),
+  getItems: jest.fn(),
+  getItemCount: jest.fn(),
+};
+
 const gridStub = {
+  getData: () => dataViewStub,
   getUID: jest.fn(),
   getOptions: () => gridOptionsMock,
   getSelectionModel: jest.fn(),
@@ -71,10 +83,11 @@ jest.mock('@slickgrid-universal/common/dist/commonjs/extensions/slickRowSelectio
   SlickRowSelectionModel: jest.fn().mockImplementation(() => mockRowSelectionModel),
 }));
 
-@Component({
-  template: `<h4>Loading...</h4>`
-})
+@Component({ template: `<h4>Loading...</h4>` })
 export class TestPreloadComponent { }
+
+@Component({ template: `<h1>Some Title</h1>` })
+export class TestComponent { }
 
 describe('SlickRowDetailView', () => {
   let eventHandler: SlickEventHandler;
@@ -147,7 +160,7 @@ describe('SlickRowDetailView', () => {
     });
 
     it('should provide a sanitized "postTemplate" when only a "viewComponent" is provided (meaning no "postTemplate" is originally provided)', async () => {
-      (gridOptionsMock.rowDetailView as RowDetailView).viewComponent = TestPreloadComponent;
+      (gridOptionsMock.rowDetailView as RowDetailView).viewComponent = TestComponent;
       jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
 
       const output = await gridOptionsMock.rowDetailView!.postTemplate!({ id: 'field1', field: 'field1' });
@@ -155,7 +168,7 @@ describe('SlickRowDetailView', () => {
     });
 
     it('should define "datasetIdPropertyName" with different "id" and provide a sanitized "postTemplate" when only a "viewComponent" is provided (meaning no "postTemplate" is originally provided)', async () => {
-      (gridOptionsMock.rowDetailView as RowDetailView).viewComponent = TestPreloadComponent;
+      (gridOptionsMock.rowDetailView as RowDetailView).viewComponent = TestComponent;
       gridOptionsMock.datasetIdPropertyName = 'rowId';
       const output = await gridOptionsMock.rowDetailView!.postTemplate!({ rowId: 'field1', field: 'field1' });
       expect(output).toEqual(`<div class="${ROW_DETAIL_CONTAINER_PREFIX}field1"></div>`);
@@ -166,8 +179,10 @@ describe('SlickRowDetailView', () => {
 
       beforeEach(() => {
         gridOptionsMock.datasetIdPropertyName = 'id';
+        gridOptionsMock.rowDetailView!.preTemplate = null as any;
+        gridOptionsMock.rowDetailView!.postTemplate = null as any;
         gridOptionsMock.rowDetailView!.preloadComponent = TestPreloadComponent;
-        gridOptionsMock.rowDetailView!.viewComponent = TestPreloadComponent;
+        gridOptionsMock.rowDetailView!.viewComponent = TestComponent;
         columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }];
         jest.spyOn(SharedService.prototype, 'slickGrid', 'get').mockReturnValue(gridStub);
         jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
@@ -388,7 +403,13 @@ describe('SlickRowDetailView', () => {
         plugin.register();
         plugin.eventHandler.subscribe(plugin.onBeforeRowDetailToggle, () => {
           gridStub.onColumnsReordered.notify({ impactedColumns: [mockColumn] } as any, new Slick.EventData(), gridStub);
-          expect(appendSpy).toHaveBeenCalledWith(undefined, expect.objectContaining({ className: 'container_field1' }), true);
+          expect(appendSpy).toHaveBeenCalledWith(TestComponent, expect.objectContaining({ className: 'container_field1' }), {
+            model: mockColumn,
+            addon: expect.anything(),
+            grid: gridStub,
+            dataView: undefined,
+            parent: undefined,
+          });
           done();
         });
         plugin.onBeforeRowDetailToggle.notify({ item: mockColumn, grid: gridStub }, new Slick.EventData(), gridStub);
@@ -408,7 +429,13 @@ describe('SlickRowDetailView', () => {
         plugin.register();
         plugin.eventHandler.subscribe(plugin.onBeforeRowDetailToggle, () => {
           gridStub.onSelectedRowsChanged.notify({ rows: [0], previousSelectedRows: [], grid: gridStub } as unknown as OnSelectedRowsChangedEventArgs, new Slick.EventData(), gridStub);
-          expect(appendSpy).toHaveBeenCalledWith(undefined, expect.objectContaining({ className: 'container_field1' }), true);
+          expect(appendSpy).toHaveBeenCalledWith(TestComponent, expect.objectContaining({ className: 'container_field1' }), {
+            model: mockColumn,
+            addon: expect.anything(),
+            grid: gridStub,
+            dataView: undefined,
+            parent: undefined,
+          });
         });
         plugin.onBeforeRowDetailToggle.notify({ item: mockColumn, grid: gridStub }, new Slick.EventData(), gridStub);
         plugin.onBeforeRowDetailToggle.notify({ item: { ...mockColumn, __collapsed: false }, grid: gridStub }, new Slick.EventData(), gridStub);
@@ -429,7 +456,13 @@ describe('SlickRowDetailView', () => {
 
         plugin.eventHandler.subscribe(plugin.onBeforeRowDetailToggle, () => {
           eventPubSubService.publish('onFilterChanged', { columnId: 'field1', operator: '=', searchTerms: [] });
-          expect(appendSpy).toHaveBeenCalledWith(undefined, expect.objectContaining({ className: 'container_field1' }), true);
+          expect(appendSpy).toHaveBeenCalledWith(TestComponent, expect.objectContaining({ className: 'container_field1' }), {
+            model: mockColumn,
+            addon: expect.anything(),
+            grid: gridStub,
+            dataView: undefined,
+            parent: undefined,
+          });
         });
         plugin.onBeforeRowDetailToggle.notify({ item: mockColumn, grid: gridStub }, new Slick.EventData(), gridStub);
         plugin.onBeforeRowDetailToggle.notify({ item: { ...mockColumn, __collapsed: false }, grid: gridStub }, new Slick.EventData(), gridStub);
@@ -494,7 +527,13 @@ describe('SlickRowDetailView', () => {
         plugin.register();
         plugin.onAfterRowDetailToggle.subscribe(() => {
           expect(getElementSpy).toHaveBeenCalledWith('container_field1');
-          expect(appendSpy).toHaveBeenCalledWith(undefined, expect.objectContaining({ className: 'container_field1' }), true);
+          expect(appendSpy).toHaveBeenCalledWith(TestComponent, expect.objectContaining({ className: 'container_field1' }), {
+            model: mockColumn,
+            addon: expect.anything(),
+            grid: gridStub,
+            dataView: undefined,
+            parent: undefined,
+          });
         });
         plugin.onBeforeRowDetailToggle.notify({ item: mockColumn, grid: gridStub } as any, new Slick.EventData(), gridStub);
         plugin.onAfterRowDetailToggle.notify({ item: mockColumn, grid: gridStub } as any, new Slick.EventData(), gridStub);
@@ -515,7 +554,13 @@ describe('SlickRowDetailView', () => {
         plugin.register();
         plugin.onRowBackToViewportRange.subscribe(() => {
           expect(getElementSpy).toHaveBeenCalledWith('container_field1');
-          expect(appendSpy).toHaveBeenCalledWith(undefined, expect.objectContaining({ className: 'container_field1' }), true);
+          expect(appendSpy).toHaveBeenCalledWith(TestComponent, expect.objectContaining({ className: 'container_field1' }), {
+            model: mockColumn,
+            addon: expect.anything(),
+            grid: gridStub,
+            dataView: undefined,
+            parent: undefined,
+          });
           expect(redrawSpy).toHaveBeenCalled();
         });
         plugin.onBeforeRowDetailToggle.notify({ item: mockColumn, grid: gridStub } as any, new Slick.EventData(), gridStub);

--- a/src/app/modules/angular-slickgrid/extensions/__tests__/slickRowDetailView.spec.ts
+++ b/src/app/modules/angular-slickgrid/extensions/__tests__/slickRowDetailView.spec.ts
@@ -84,10 +84,10 @@ jest.mock('@slickgrid-universal/common/dist/commonjs/extensions/slickRowSelectio
 }));
 
 @Component({ template: `<h4>Loading...</h4>` })
-export class TestPreloadComponent { }
+class TestPreloadComponent { }
 
 @Component({ template: `<h1>Some Title</h1>` })
-export class TestComponent { }
+class TestComponent { }
 
 describe('SlickRowDetailView', () => {
   let eventHandler: SlickEventHandler;

--- a/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
+++ b/src/app/modules/angular-slickgrid/extensions/slickRowDetailView.ts
@@ -239,27 +239,24 @@ export class SlickRowDetailView extends UniversalSlickRowDetailView {
 
   /** Render (or re-render) the View Component (Row Detail) */
   renderPreloadView() {
-    const containerElements = this.gridContainerElement.getElementsByClassName(`${PRELOAD_CONTAINER_PREFIX}`);
-    if (containerElements?.length >= 0) {
-      this.angularUtilService.createAngularComponentAppendToDom(this._preloadComponent, containerElements[containerElements.length - 1], true);
+    const containerElements = this.gridContainerElement.getElementsByClassName(`${PRELOAD_CONTAINER_PREFIX}`) as HTMLCollectionOf<HTMLElement>;
+    if (this._preloadComponent && containerElements?.length >= 0) {
+      this.angularUtilService.createAngularComponentAppendToDom(this._preloadComponent, containerElements[containerElements.length - 1]);
     }
   }
 
   /** Render (or re-render) the View Component (Row Detail) */
   renderViewModel(item: any): CreatedView | undefined {
-    const containerElements = this.gridContainerElement.getElementsByClassName(`${ROW_DETAIL_CONTAINER_PREFIX}${item[this.datasetIdPropName]}`);
-    if (containerElements?.length > 0) {
-      const componentOutput = this.angularUtilService.createAngularComponentAppendToDom(this._viewComponent, containerElements[containerElements.length - 1], true);
-      if (componentOutput && componentOutput.componentRef && componentOutput.componentRef.instance) {
-        // pass a few properties to the Row Detail template component
-        Object.assign(componentOutput.componentRef.instance, {
-          model: item,
-          addon: this,
-          grid: this._grid,
-          dataView: this.dataView,
-          parent: this.rowDetailViewOptions?.parent,
-        });
-
+    const containerElements = this.gridContainerElement.getElementsByClassName(`${ROW_DETAIL_CONTAINER_PREFIX}${item[this.datasetIdPropName]}`) as HTMLCollectionOf<HTMLElement>;
+    if (this._viewComponent && containerElements?.length > 0) {
+      const componentOutput = this.angularUtilService.createAngularComponentAppendToDom(this._viewComponent, containerElements[containerElements.length - 1], {
+        model: item,
+        addon: this,
+        grid: this._grid,
+        dataView: this.dataView,
+        parent: this.rowDetailViewOptions?.parent,
+      });
+      if (componentOutput?.componentRef) {
         const viewObj = this._views.find(obj => obj.id === item[this.datasetIdPropName]);
         if (viewObj) {
           viewObj.componentRef = componentOutput.componentRef;

--- a/src/app/modules/angular-slickgrid/modules/angular-slickgrid.module.spec.ts
+++ b/src/app/modules/angular-slickgrid/modules/angular-slickgrid.module.spec.ts
@@ -12,6 +12,11 @@ describe('AppComponent', () => {
   });
 
   it('should create an instance with providers via forRoot()', () => {
+    const angularSlickgridModuleWithProviders = AngularSlickgridModule.forRoot();
+    expect(angularSlickgridModuleWithProviders.providers![0]).toEqual({ provide: 'config', useValue: {} });
+  });
+
+  it('should create an instance with providers via forRoot() with extra config options', () => {
     const angularSlickgridModuleWithProviders = AngularSlickgridModule.forRoot({ enableAutoResize: true });
     expect(angularSlickgridModuleWithProviders.providers![0]).toEqual({ provide: 'config', useValue: { enableAutoResize: true } });
   });

--- a/src/app/modules/angular-slickgrid/services/__tests__/angularUtilService.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/angularUtilService.spec.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Component, Injector, ViewContainerRef } from '@angular/core';
+import { Component, ViewContainerRef } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { AngularUtilService } from '..';
 
@@ -82,7 +82,7 @@ describe('AngularUtilService', () => {
     it('should an angular component and append it to the DOM tree in the document body', () => {
       // @ts-ignore
       const createCompSpy = jest.spyOn(viewContainerRefStub, 'createComponent').mockReturnValue(mockComponentFactory);
-      const spyBody = jest.spyOn(document.body, 'appendChild');
+      const spyBody = jest.spyOn(document.body, 'replaceChildren');
 
       const output = service.createAngularComponentAppendToDom(TestPreloadComponent);
 
@@ -91,25 +91,12 @@ describe('AngularUtilService', () => {
       expect(output).toEqual({ componentRef: mockComponentFactory, domElement: domElm });
     });
 
-    it('should an angular component and append it to the current component DOM tree, which also contains the parent node text', () => {
+    it('should an angular component and append it to the current component DOM tree, which will have its parent node replaced by the new html', () => {
       // @ts-ignore
       const createCompSpy = jest.spyOn(viewContainerRefStub, 'createComponent').mockReturnValue(mockComponentFactory);
-      const spyElement = jest.spyOn(domParentElm, 'appendChild');
+      const spyElement = jest.spyOn(domParentElm, 'replaceChildren');
 
       const output = service.createAngularComponentAppendToDom(TestPreloadComponent, domParentElm);
-
-      expect(createCompSpy).toHaveBeenCalled();
-      expect(spyElement).toHaveBeenCalled();
-      expect(domParentElm.innerHTML).toBe('parent text<div id="row-detail123">some text</div>');
-      expect(output).toEqual({ componentRef: mockComponentFactory, domElement: domElm });
-    });
-
-    it('should an angular component and append it to the current component DOM tree, which will have its parent node text emptied (because of 3rd flag)', () => {
-      // @ts-ignore
-      const createCompSpy = jest.spyOn(viewContainerRefStub, 'createComponent').mockReturnValue(mockComponentFactory);
-      const spyElement = jest.spyOn(domParentElm, 'appendChild');
-
-      const output = service.createAngularComponentAppendToDom(TestPreloadComponent, domParentElm, true);
 
       expect(createCompSpy).toHaveBeenCalled();
       expect(spyElement).toHaveBeenCalled();

--- a/src/app/modules/angular-slickgrid/services/__tests__/angularUtilService.spec.ts
+++ b/src/app/modules/angular-slickgrid/services/__tests__/angularUtilService.spec.ts
@@ -100,7 +100,7 @@ describe('AngularUtilService', () => {
     it('should an angular component and append it to the DOM tree in the document body', () => {
       // @ts-ignore
       const createCompSpy = jest.spyOn(viewContainerRefStub, 'createComponent').mockReturnValue(mockComponentFactory);
-      const spyBody = jest.spyOn(document.body, 'replaceChildren');
+      const spyBody = jest.spyOn(document.body, 'appendChild');
 
       const output = service.createAngularComponentAppendToDom(TestPreloadComponent);
 

--- a/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
+++ b/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
@@ -30,7 +30,6 @@ export class AngularUtilService {
     const componentRef = this.vcr.createComponent(component, createCompOptions);
 
     // user could provide data to assign to the component instance
-
     if (componentRef?.instance && data) {
       Object.assign(componentRef.instance as any, data);
 

--- a/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
+++ b/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
@@ -1,4 +1,4 @@
-import { EmbeddedViewRef, Injectable, ViewContainerRef } from '@angular/core';
+import { EmbeddedViewRef, Injectable, Type, ViewContainerRef } from '@angular/core';
 
 import type { AngularComponentOutput } from '../models/angularComponentOutput.interface';
 
@@ -7,15 +7,33 @@ export class AngularUtilService {
 
   constructor(private vcr: ViewContainerRef) { }
 
-  createAngularComponent(component: any): AngularComponentOutput {
+  createAngularComponent<C>(component: Type<C>, target?: HTMLElement, data?: any): AngularComponentOutput {
     // Create a component reference from the component
     const componentRef = this.vcr.createComponent(component);
 
+    // user could provide data to assign to the component instance
+
+    if (data) {
+      Object.assign(componentRef.instance as any, data);
+
+      // NOTE: detectChanges() MUST be doene BEFORE returning the DOM element in the next step,
+      // because if we do it only after returning the rootNodes (domElement) then it won't have the instance data yet
+      // and we would have to wait an extra cycle to see the result, this basically helps with Example22
+      componentRef.changeDetectorRef.detectChanges();
+    }
+
     // Get DOM element from component
-    let domElem;
+    let domElem: HTMLElement | null = null;
     const viewRef = (componentRef.hostView as EmbeddedViewRef<any>);
+
+    // get DOM element from the new dynamic Component, make sure this is read after any data and detectChanges()
     if (viewRef && Array.isArray(viewRef.rootNodes) && viewRef.rootNodes[0]) {
       domElem = viewRef.rootNodes[0] as HTMLElement;
+
+      // when user provides the DOM element target, we will read the new Component html and use it to replace the target html
+      if (target && domElem) {
+        target.innerHTML = domElem.innerHTML;
+      }
     }
 
     return { componentRef, domElement: domElem as HTMLElement };

--- a/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
+++ b/src/app/modules/angular-slickgrid/services/angularUtil.service.ts
@@ -72,7 +72,7 @@ export class AngularUtilService {
     if (targetElement?.replaceChildren) {
       targetElement.replaceChildren(componentOutput.domElement);
     } else {
-      document.body.replaceChildren(componentOutput.domElement); // when no target provided, we'll simply add it to the HTML Body
+      document.body.appendChild(componentOutput.domElement); // when no target provided, we'll simply add it to the HTML Body
     }
 
     return componentOutput;

--- a/test/jest.config.ts
+++ b/test/jest.config.ts
@@ -7,7 +7,8 @@ const config: Config.InitialOptions = {
     'src/app/modules/**/*.{js,ts}',
     '!**/node_modules/**',
     '!src/**/models/**',
-    '!src/app/modules/angular-slickgrid/models/**',
+    '!src/**/constants.ts',
+    '!src/**/index.ts',
   ],
   coverageDirectory: './test/jest-coverage/',
   coveragePathIgnorePatterns: [


### PR DESCRIPTION
- because we used `setTimeout` in Example 22, it was creating the dynamic Component and rendering it at the bottom of the DOM, in our case just after the grid at the bottom of it before then transition it (or moving the DOM element) to the cell target. However we shouldn't need a `setTimeout` at all if we use `cd.detectChanges()` BUT we need to move this code into the util method that creates the component because we need to detect changes right after changing the instance data BUT before getting or reading the new Component HTML... so this way we can drop the `setTimeout` and we just use  `cd.detectChanges()` inside the util (which is even better since it simplifies the user code a lot) and this should improve performance by 2x every cell rendering because we no longer need to wait a full cycle for every single cell which is a huge perf when you think about it :rocket:
- also note that the 2 new arguments of `util.createAngularComponent` are optional, this is to avoid breaking any user who still use the previous code and also to avoid breaking Row Detail as well

#### TODOs
- [ ] requires unit test coverage
- [x] all Cypress E2E tests should pass
- [ ] wait for possible review by @zewa666

![msedge_zPbHOdwRSz](https://github.com/ghiscoding/Angular-Slickgrid/assets/643976/31a3bf10-230a-40b1-ad8c-4a53995e25dd)
