### PR TITLE
perf(resizer): `autosizeColumns` is called too many times on page load

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -564,6 +564,20 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         sharedService.slickGrid = mockGrid as unknown as SlickGrid;
       });
 
+      it('should expect "autosizeColumns" being called when "autoFitColumnsOnFirstLoad" is set we udpated the dataset', () => {
+        const autosizeSpy = jest.spyOn(mockGrid, 'autosizeColumns');
+        const refreshSpy = jest.spyOn(component, 'refreshGridData');
+        const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
+        jest.spyOn(mockDataView, 'getLength').mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValueOnce(mockData.length);
+
+        component.ngAfterViewInit();
+        component.gridOptions = { autoFitColumnsOnFirstLoad: true };
+        component.setData(mockData, true); // manually force an autoresize
+
+        expect(autosizeSpy).toHaveBeenCalledTimes(2); // 1x by datasetChanged and 1x by bindResizeHook
+        expect(refreshSpy).toHaveBeenCalledWith(mockData);
+      });
+
       it('should expect "autosizeColumns" being called when "autoFitColumnsOnFirstLoad" is set and we are on first page load', () => {
         const autosizeSpy = jest.spyOn(mockGrid, 'autosizeColumns');
         const refreshSpy = jest.spyOn(component, 'refreshGridData');
@@ -574,7 +588,7 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
         component.gridOptions = { autoFitColumnsOnFirstLoad: true };
         component.dataset = mockData;
 
-        expect(autosizeSpy).toHaveBeenCalledTimes(3); // 1x by datasetChanged and 2x by bindResizeHook
+        expect(autosizeSpy).toHaveBeenCalledTimes(1);
         expect(refreshSpy).toHaveBeenCalledWith(mockData);
       });
 


### PR DESCRIPTION
- when loading a new grid, we are calling `grid.autosizeColumns()` to resize the columns and while adding tests for that method I incidently discovered that it was being called multiple times on a page load (up to 6-8x times) but in reality there is no need to call it more than once or twice.
- there is also no need to call the `autosizeColumns` if the grid dimension calculated by the Resizer Service are the same as the previously calculated dimensions
- the updated code will never call `autosizeColumns` more than twice on a page load, however note that the method will always be called whenever the grid dimensions or columns get updated