### PR TITLE
fix: remove width style on grid container for CSP safe, fixes #1368

### DIFF
--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.html
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.html
@@ -1,6 +1,6 @@
 <div id="slickGridContainer-{{gridId}}" class="gridPane">
   <ng-container *ngTemplateOutlet="slickgridHeader"></ng-container>
-  <div attr.id='{{gridId}}' class="slickgrid-container" style="width: 100%">
+  <div attr.id='{{gridId}}' class="slickgrid-container">
   </div>
   <ng-container *ngTemplateOutlet="slickgridFooter"></ng-container>
 </div>


### PR DESCRIPTION
- we shouldn't use inline `style` for CSP safe code, that code was moved in Slickgrid-Universal style instead