### PR TITLE
chore: remove deprecated `internalColumnEditor` usage

### DIFF
--- a/src/app/examples/custom-angularComponentEditor.ts
+++ b/src/app/examples/custom-angularComponentEditor.ts
@@ -47,7 +47,7 @@ export class CustomAngularComponentEditor implements Editor {
 
   /** Get the Collection */
   get collection(): any[] {
-    return this.columnDef?.internalColumnEditor!.collection ?? [];
+    return this.columnDef?.editor!.collection ?? [];
   }
 
   /** Get Column Definition object */
@@ -57,7 +57,7 @@ export class CustomAngularComponentEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor ?? {};
+    return this.columnDef?.editor ?? {};
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */

--- a/src/app/examples/custom-inputEditor.ts
+++ b/src/app/examples/custom-inputEditor.ts
@@ -26,7 +26,7 @@ export class CustomInputEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor ?? {};
+    return this.columnDef?.editor ?? {};
   }
 
   get hasAutoCommitEdit(): boolean {

--- a/src/app/examples/grid-editor.component.ts
+++ b/src/app/examples/grid-editor.component.ts
@@ -38,10 +38,7 @@ const myCustomTitleValidator: EditorValidator = (value: any, args?: EditorArgume
   const grid = args && args.grid;
   const gridOptions = (grid?.getOptions() ?? {}) as GridOption;
   const translate = gridOptions.i18n;
-
-  // to get the editor object, you'll need to use "internalColumnEditor"
-  // don't use "editor" property since that one is what SlickGrid uses internally by it's editor factory
-  const columnEditor = args && args.column && args.column.internalColumnEditor;
+  const columnEditor = args?.column?.editor;
 
   if (value === null || value === undefined || !value.length) {
     return { valid: false, msg: 'This is a required field' };
@@ -659,16 +656,7 @@ export class GridEditorComponent implements OnInit {
     this.columnDefinitions.pop();
     this.columnDefinitions = this.columnDefinitions.slice();
 
-    // NOTE if you use an Extensions (Checkbox Selector, Row Detail, ...) that modifies the column definitions in any way
-    // you MUST use the code below, first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
-    // in other words, SlickGrid is not using the same as Angular-Slickgrid uses (editor with a "model" and other properties are a facade, SlickGrid only uses what is inside the model)
     /*
-    const allColumns = this.angularGrid.gridService.getAllColumnDefinitions();
-    const allOriginalColumns = allColumns.map((column) => {
-      column.editor = column.internalColumnEditor;
-      return column;
-    });
-
     // remove your column the full set of columns
     // and use slice or spread [...] to trigger an Angular dirty change
     allOriginalColumns.pop();

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -1437,7 +1437,7 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
       column.editor.collection = newCollection;
       column.editor.disabled = false;
 
-      // find the new column reference pointer & re-assign the new editor to the internalColumnEditor
+      // @deprecated `internalColumnEditor`, if there's already an internalColumnEditor we'll use it, else it would be inside the editor
       if (Array.isArray(this.columnDefinitions)) {
         const columnRef = this.columnDefinitions.find((col: Column) => col.id === column.id);
         if (columnRef) {


### PR DESCRIPTION
- users can still call `internalColumnEditor` but since it's deprecated, then it's better to remove it from all demos