### PR TITLE
chore(deps): move SortableJS as dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "@slickgrid-universal/row-detail-view-plugin": "~5.0.1",
     "@slickgrid-universal/rxjs-observable": "~5.0.1",
     "dequal": "^2.0.3",
-    "rxjs": "^7.8.1",
-    "sortablejs": "^1.15.2"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^2.2.5",
@@ -119,6 +118,7 @@
     "rxjs": "^7.8.1",
     "sass": "^1.77.1",
     "servor": "^4.0.2",
+    "sortablejs": "^1.15.2",
     "stream-browserify": "^3.0.0",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",


### PR DESCRIPTION
- SortableJS is already required by Slickgrid-Universal and is only used by Jest in Angular-Slickgrid, so it should be moved to dev deps for that reason.