### PR TITLE
fix(TreeData): addItem should keep current sorted column

### DIFF
--- a/src/app/examples/grid-tree-data-parent-child.component.html
+++ b/src/app/examples/grid-tree-data-parent-child.component.html
@@ -58,7 +58,7 @@
     <div class="col-md-12">
       <button (click)="addNewRow()" data-test="add-item-btn" class="btn btn-primary btn-xs btn-icon">
         <span class="icon mdi mdi-plus color-white"></span>
-        <span>Add New Item (in 1st group)</span>
+        <span>Add New Item to "Task 1" group</span>
       </button>
       <button (click)="updateFirstRow()" data-test="update-item-btn" class="btn btn-outline-secondary btn-xs btn-icon">
         <span class="icon mdi mdi-pencil"></span>

--- a/src/app/examples/grid-tree-data-parent-child.component.ts
+++ b/src/app/examples/grid-tree-data-parent-child.component.ts
@@ -150,20 +150,15 @@ export class GridTreeDataParentChildComponent implements OnInit {
   }
 
   /**
-   * A simple method to add a new item inside the first group that we find (it's random and is only for demo purposes).
-   * After adding the item, it will sort by parent/child recursively
+   * A simple method to add a new item inside the first group that has children which is "Task 1"
+   * After adding the item, it will resort by parent/child recursively but keep current sort column
    */
   addNewRow() {
     const newId = this.dataViewObj.getItemCount();
-    const parentPropName = 'parentId';
-    const treeLevelPropName = 'treeLevel'; // if undefined in your options, the default prop name is "__treeLevel"
-    const newTreeLevel = 1;
+    // find "Task 1" which has `id = 1`
+    const parentItemFound = this.dataViewObj.getItemById(1);
 
-    // find first parent object and add the new item as a child
-    const childItemFound = this.dataViewObj.getItems().find((item: any) => item[treeLevelPropName] === newTreeLevel);
-    const parentItemFound = this.dataViewObj.getItemByIdx(childItemFound[parentPropName]);
-
-    if (childItemFound && parentItemFound) {
+    if (parentItemFound?.__hasChildren) {
       const newItem = {
         id: newId,
         parentId: parentItemFound.id,


### PR DESCRIPTION
closes issue #1423 

- prior to this PR, calling `addItem()`, or `addItems()`, was always resorting using the Tree Data initial sort because the method being called is the same for the first build of the Tree Data and/or adding an item. So when we're adding an item, we should really reuse any existing sort that may exist when resynching the flat/hierarchical and resorting them (we always need to resort whenever it changes because by SlickGrid doesn't support Tree Data, we only support it by keeping copies of both flat & hierarchical and then resort them whenever something changes)

![brave_KNDYMGY8FW](https://github.com/ghiscoding/slickgrid-universal/assets/643976/85cb8965-fd09-45e9-b5fc-1ce5d3743948)
