### PR TITLE
fix: NG0406: This instance of the ApplicationRef has already been destroyed

### DIFF
--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -90,7 +90,6 @@ import { ContainerService } from '../services/container.service';
   providers: [
     // make everything transient (non-singleton)
     AngularUtilService,
-    ApplicationRef,
     TranslaterService,
   ]
 })


### PR DESCRIPTION
When navigating away from within a rowdetail-view component the browser logs `NG0406: This instance of the ApplicationRef has already been destroyed` in the console.

Steps to reproduce & validate the fix:

rowdetail-view.component.html
```html
<button class="btn btn-outline-secondary btn-sm" (click)="navigate()" data-test="navigate-btn">
  Navigate to Basic Grids
</button>
```

rowdetail-view.component.ts
```ts
export class RowDetailViewComponent {
  private readonly _router = inject(Router);
  ...

  navigate() {
    this._router.navigate(['/basic']);
  }
}
```

The issue is caused by the `AngularSlickgridComponent` providing the `ApplicationRef` as a transient. Reading up on the `ApplicationRef`, it looks like it should be a singleton provided by Angular itself.

I didn't include the above changes to `RowDetailViewComponent` in the commit/PR because I assume creating an automated test for it is not that easy and I don't see much value in having such a test case in the code.

Also I noticed that `SlickRowDetailView.dispose` is called 2x. 
The 1st time from:
```ts
this.serviceList.forEach((service: any) => {
      if (service && service.dispose) {
        service.dispose();
      }
    });
```

And the 2nd from
```ts
// dispose all registered external resources
this.disposeExternalResources();
```

I'm not sure if that is intended behavior?