### PR TITLE
fix: register RowDetail and dispose of it only once

### DIFF
--- a/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
+++ b/src/app/modules/angular-slickgrid/components/__tests__/angular-slickgrid.component.spec.ts
@@ -1001,11 +1001,14 @@ describe('Angular-Slickgrid Custom Component instantiated via Constructor', () =
       it('should create the Row Detail View plugin when "enableRowDetailView" is enabled', () => {
         const initSpy = jest.spyOn(mockSlickRowDetailView, 'init');
         const createSpy = jest.spyOn(mockSlickRowDetailView, 'create');
+        jest.spyOn(extensionServiceStub, 'extensionList', 'get').mockReturnValue({ rowDetailView: { pluginName: 'RowDetail' } } as unknown as ExtensionList<any>);
 
         component.gridOptions = { enableRowDetailView: true } as unknown as GridOption;
         component.initialization(slickEventHandler);
 
-        expect(component.registeredResources.length).toBe(4);
+        expect(extensionServiceStub.addExtensionToList).toHaveBeenCalledWith('rowDetailView', { name: 'rowDetailView', instance: mockSlickRowDetailView });
+        expect(component.registeredResources.length).toBe(3);
+        expect(component.extensionService.extensionList.rowDetailView).toBeTruthy();
         expect(createSpy).toHaveBeenCalled();
         expect(initSpy).toHaveBeenCalled();
       });

--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -1338,7 +1338,7 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
     return options;
   }
 
-  /** Add a register a new external resource, user could also optional dispose all previous resources before pushing any new resources to the resources array list. */
+  /** Add a register of a new external resource, user could also optional dispose all previous resources before pushing any new resources to the resources array list. */
   registerExternalResources(resources: ExternalResource[], disposePreviousResources = false) {
     if (disposePreviousResources) {
       this.disposeExternalResources();
@@ -1361,7 +1361,6 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
     if (this.gridOptions.enableRowDetailView) {
       this.slickRowDetailView = new SlickRowDetailView(this.angularUtilService, this.appRef, this._eventPubSubService, this.elm.nativeElement, this.rxjs);
       this.slickRowDetailView.create(this.columnDefinitions, this.gridOptions);
-      this._registeredResources.push(this.slickRowDetailView);
       this.extensionService.addExtensionToList(ExtensionName.rowDetailView, { name: ExtensionName.rowDetailView, instance: this.slickRowDetailView });
     }
   }
@@ -1407,6 +1406,12 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
     // bind & initialize all Components/Services that were tagged as enabled
     // register all services by executing their init method and providing them with the Grid object
     this.initializeExternalResources(this._registeredResources);
+
+    // initialize RowDetail separately since we already added it to the ExtensionList via `addExtensionToList()` but not in external resources,
+    // because we don't want to dispose the extension/resource more than once (because externalResources/extensionList are both looping through their list to dispose of them)
+    if (this.gridOptions.enableRowDetailView && this.slickRowDetailView) {
+      this.slickRowDetailView.init(this.slickGrid);
+    }
   }
 
   /** Register the RxJS Resource in all necessary services which uses */


### PR DESCRIPTION
fixes comment mentioned in separate PR #1457 

> Also I noticed that `SlickRowDetailView.dispose` is called 2x. The 1st time from:
> 
> ```ts
> this.serviceList.forEach((service: any) => {
>       if (service && service.dispose) {
>         service.dispose();
>       }
>     });
> ```
> 
> And the 2nd from
> 
> ```ts
> // dispose all registered external resources
> this.disposeExternalResources();
> ```
> 
> I'm not sure if that is intended behavior?

The issue was because both the `externalResources` & `extensionList` are arrays and to make it easier, they both loop through their arrays when it's time to dispose (destroy) of them. However the `RowDetailService` was added to both arrays which was disposing of it twice instead of once. This PR fixes this by keeping RowDetail in the `extensionList` but without adding it to the `externalResources` array. The other thing to note is that it's better to keep it in `extensionList` since I already had code in place to get the RowDetail instance from that list as per this Example 21 code

https://github.com/ghiscoding/Angular-Slickgrid/blob/849d30d03de16597687aa071558c70c88e0b02da/src/app/examples/grid-rowdetail.component.ts#L44-L52
