### PR TITLE
feat: expose displayEmptyDataWarning

### DIFF
--- a/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
+++ b/src/app/modules/angular-slickgrid/components/angular-slickgrid.component.ts
@@ -925,6 +925,13 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
     return showing;
   }
 
+  /**
+   * Toggle the empty data warning message visibility.
+   * @param showWarning
+   */
+  displayEmptyDataWarning(showWarning = true) {
+    this.slickEmptyWarning?.showEmptyDataMessage(showWarning);
+  }
   //
   // protected functions
   // ------------------
@@ -935,10 +942,6 @@ export class AngularSlickgridComponent<TData = any> implements AfterViewInit, On
    */
   protected copyColumnWidthsReference(columnDefinitions: Column[]) {
     columnDefinitions.forEach((col) => (col.originalWidth = col.width));
-  }
-
-  protected displayEmptyDataWarning(showWarning = true) {
-    this.slickEmptyWarning?.showEmptyDataMessage(showWarning);
   }
 
   protected bindDifferentHooks(grid: SlickGrid, gridOptions: GridOption, dataView: SlickDataView) {


### PR DESCRIPTION
hey there, I'd like to expose this method publically as there are scenarios with the OData Backend where data loads aren't properly detected and I'd like to handle the message display by myself. So far this needs an ugly any cast in order to access.