### PR TITLE
fix(docs): update onGridStateServiceChanged to onGridStateChanged

### DIFF
--- a/docs/grid-functionalities/Grid-Menu.md
+++ b/docs/grid-functionalities/Grid-Menu.md
@@ -142,18 +142,18 @@ export class GridDemoComponent {
 
 ### Grid State Event
 There are 2 ways of subscribing to GridState Service event changed.
-1. Through `(onGridStateServiceChanged)` Event Emitter (recommended)
+1. Through `(onGridStateChanged)` Event Emitter (recommended)
 2. Through `onGridStateChanged` Observable on the GridState Service.
 
 Examples
-#### 1. `(onGridStateServiceChanged)` Event Emitter (recommended)
+#### 1. `(onGridStateChanged)` Event Emitter (recommended)
 ##### View
 ```html
 <angular-slickgrid gridId="grid1"
          [columnDefinitions]="columnDefinitions"
          [gridOptions]="gridOptions"
          [dataset]="dataset"
-         (onGridStateServiceChanged)="gridStateChanged($event)">
+         (onGridStateChanged)="gridStateChanged($event)">
 </angular-slickgrid>
 ```
 ##### Component

--- a/docs/grid-functionalities/Grid-State-&-Preset.md
+++ b/docs/grid-functionalities/Grid-State-&-Preset.md
@@ -145,18 +145,18 @@ export class GridDemoComponent {
 
 ### Grid State Event
 There are 2 ways of subscribing to GridState Service event changed.
-1. Through `(onGridStateServiceChanged)` Event Emitter (recommended)
+1. Through `(onGridStateChanged)` Event Emitter (recommended)
 2. Through `onGridStateChanged` Observable on the GridState Service.
 
 Examples
-#### 1. `(onGridStateServiceChanged)` Event Emitter (recommended)
+#### 1. `(onGridStateChanged)` Event Emitter (recommended)
 ##### View
 ```html
 <angular-slickgrid gridId="grid1"
          [columnDefinitions]="columnDefinitions"
          [gridOptions]="gridOptions"
          [dataset]="dataset"
-         (onGridStateServiceChanged)="gridStateChanged($event)">
+         (onGridStateChanged)="gridStateChanged($event)">
 </angular-slickgrid>
 ```
 ##### Component

--- a/docs/grid-functionalities/Row-Selection.md
+++ b/docs/grid-functionalities/Row-Selection.md
@@ -174,7 +174,7 @@ handleOnSelectedRowsChanged(args) {
           [columnDefinitions]="columnDefinitions"
           [gridOptions]="gridOptions"
           [dataset]="dataset"
-          (onGridStateServiceChanged)="handleOngridStateChanged($event.detail.args)">
+          (onGridStateChanged)="handleOngridStateChanged($event.detail.args)">
 </angular-slickgrid>
 ```
 ```ts


### PR DESCRIPTION
in migration to v2 

```
- Event Emitter `(onGridStateServiceChanged)` renamed to `(onGridStateChanged)`
```

I got confused why the event did not work